### PR TITLE
feat: iOS install guide + completed exercises visual

### DIFF
--- a/src/components/IOSInstallModal.tsx
+++ b/src/components/IOSInstallModal.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from "react-i18next"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Share, Plus, CheckCircle2 } from "lucide-react"
+
+interface IOSInstallModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function IOSInstallModal({ open, onOpenChange }: IOSInstallModalProps) {
+  const { t } = useTranslation("common")
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{t("iosInstallTitle")}</DialogTitle>
+          <DialogDescription>{t("iosInstallSubtitle")}</DialogDescription>
+        </DialogHeader>
+
+        <ol className="mt-4 space-y-4">
+          <li className="flex items-start gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <Share className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="font-medium">{t("iosInstallStep1Title")}</p>
+              <p className="text-sm text-muted-foreground">
+                {t("iosInstallStep1Desc")}
+              </p>
+            </div>
+          </li>
+
+          <li className="flex items-start gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <Plus className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="font-medium">{t("iosInstallStep2Title")}</p>
+              <p className="text-sm text-muted-foreground">
+                {t("iosInstallStep2Desc")}
+              </p>
+            </div>
+          </li>
+
+          <li className="flex items-start gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <CheckCircle2 className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="font-medium">{t("iosInstallStep3Title")}</p>
+              <p className="text-sm text-muted-foreground">
+                {t("iosInstallStep3Desc")}
+              </p>
+            </div>
+          </li>
+        </ol>
+
+        <Button className="mt-4 w-full" onClick={() => onOpenChange(false)}>
+          {t("close")}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/SideDrawer.tsx
+++ b/src/components/SideDrawer.tsx
@@ -33,6 +33,8 @@ import {
 import { supabase } from "@/lib/supabase"
 import { useInstallPrompt } from "@/hooks/useInstallPrompt"
 import { AdminOnly } from "@/components/admin/AdminOnly"
+import { IOSInstallModal } from "@/components/IOSInstallModal"
+import { isIOS, isStandalone } from "@/lib/platform"
 
 function SegmentedButton<T extends string>({
   value,
@@ -73,7 +75,10 @@ export function SideDrawer() {
   const queueMeta = useAtomValue(queueSyncMetaAtom)
   const { setTheme } = useTheme()
   const [signOutConfirmOpen, setSignOutConfirmOpen] = useState(false)
+  const [iosModalOpen, setIosModalOpen] = useState(false)
   const { canInstall, promptInstall } = useInstallPrompt()
+
+  const showInstallButton = (canInstall || isIOS()) && !isStandalone()
 
   useEffect(() => {
     if (i18n.language !== locale) {
@@ -230,12 +235,12 @@ export function SideDrawer() {
               </Link>
             </Button>
 
-            {canInstall && (
+            {showInstallButton && (
               <Button
                 variant="ghost"
                 size="sm"
                 className="justify-start text-muted-foreground"
-                onClick={promptInstall}
+                onClick={isIOS() ? () => setIosModalOpen(true) : promptInstall}
               >
                 <Download className="h-4 w-4" />
                 {t("common:installApp")}
@@ -275,6 +280,8 @@ export function SideDrawer() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <IOSInstallModal open={iosModalOpen} onOpenChange={setIosModalOpen} />
     </Sheet>
   )
 }

--- a/src/components/workout/ExerciseStrip.test.tsx
+++ b/src/components/workout/ExerciseStrip.test.tsx
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest"
+import { act, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { renderWithProviders } from "@/test/utils"
+import { sessionAtom, prFlagsAtom } from "@/store/atoms"
+import type { WorkoutExercise } from "@/types/database"
+import { ExerciseStrip } from "./ExerciseStrip"
+
+vi.mock("@/hooks/useExerciseFromLibrary", () => ({
+  useExerciseFromLibrary: () => ({ data: null }),
+}))
+
+const EXERCISES: WorkoutExercise[] = [
+  {
+    id: "ex-1",
+    workout_day_id: "day-1",
+    exercise_id: "lib-1",
+    name_snapshot: "Bench Press",
+    muscle_snapshot: "chest",
+    emoji_snapshot: "🏋️",
+    sets: 3,
+    reps: "10",
+    weight: "60",
+    rest_seconds: 90,
+    sort_order: 0,
+  },
+  {
+    id: "ex-2",
+    workout_day_id: "day-1",
+    exercise_id: "lib-2",
+    name_snapshot: "Squat",
+    muscle_snapshot: "legs",
+    emoji_snapshot: "🦵",
+    sets: 3,
+    reps: "8",
+    weight: "80",
+    rest_seconds: 120,
+    sort_order: 1,
+  },
+  {
+    id: "ex-3",
+    workout_day_id: "day-1",
+    exercise_id: "lib-3",
+    name_snapshot: "Deadlift",
+    muscle_snapshot: "back",
+    emoji_snapshot: "💪",
+    sets: 3,
+    reps: "5",
+    weight: "100",
+    rest_seconds: 180,
+    sort_order: 2,
+  },
+]
+
+describe("ExerciseStrip", () => {
+  it("renders all exercise names", () => {
+    renderWithProviders(
+      <ExerciseStrip
+        exercises={EXERCISES}
+        activeIndex={0}
+        onSelectIndex={() => {}}
+      />,
+    )
+
+    expect(screen.getByText("Bench Press")).toBeInTheDocument()
+    expect(screen.getByText("Squat")).toBeInTheDocument()
+    expect(screen.getByText("Deadlift")).toBeInTheDocument()
+  })
+
+  it("shows PR badge when exercise has PR flag", () => {
+    const { store } = renderWithProviders(
+      <ExerciseStrip
+        exercises={EXERCISES}
+        activeIndex={0}
+        onSelectIndex={() => {}}
+      />,
+    )
+
+    act(() => {
+      store.set(prFlagsAtom, { "lib-1": true })
+    })
+
+    expect(screen.getByText("🏆")).toBeInTheDocument()
+  })
+
+  it("shows checkmark overlay when exercise is completed", () => {
+    const { store } = renderWithProviders(
+      <ExerciseStrip
+        exercises={EXERCISES}
+        activeIndex={1}
+        onSelectIndex={() => {}}
+      />,
+    )
+
+    act(() => {
+      store.set(sessionAtom, {
+        currentDayId: "day-1",
+        activeDayId: "day-1",
+        exerciseIndex: 1,
+        setsData: {
+          "ex-1": [
+            { reps: "10", weight: "60", done: true },
+            { reps: "10", weight: "60", done: true },
+            { reps: "10", weight: "60", done: true },
+          ],
+        },
+        startedAt: Date.now(),
+        isActive: true,
+        totalSetsDone: 3,
+        pausedAt: null,
+        accumulatedPause: 0,
+      })
+    })
+
+    const checkIcon = document.querySelector('[class*="lucide-check"]')
+    expect(checkIcon).toBeInTheDocument()
+  })
+
+  it("does not show checkmark when exercise has incomplete sets", () => {
+    const { store } = renderWithProviders(
+      <ExerciseStrip
+        exercises={EXERCISES}
+        activeIndex={0}
+        onSelectIndex={() => {}}
+      />,
+    )
+
+    act(() => {
+      store.set(sessionAtom, {
+        currentDayId: "day-1",
+        activeDayId: "day-1",
+        exerciseIndex: 0,
+        setsData: {
+          "ex-1": [
+            { reps: "10", weight: "60", done: true },
+            { reps: "10", weight: "60", done: false },
+            { reps: "10", weight: "60", done: false },
+          ],
+        },
+        startedAt: Date.now(),
+        isActive: true,
+        totalSetsDone: 1,
+        pausedAt: null,
+        accumulatedPause: 0,
+      })
+    })
+
+    const checkIcon = document.querySelector('[class*="lucide-check"]')
+    expect(checkIcon).not.toBeInTheDocument()
+  })
+
+  it("shows multiple checkmarks for multiple completed exercises", () => {
+    const { store } = renderWithProviders(
+      <ExerciseStrip
+        exercises={EXERCISES}
+        activeIndex={2}
+        onSelectIndex={() => {}}
+      />,
+    )
+
+    act(() => {
+      store.set(sessionAtom, {
+        currentDayId: "day-1",
+        activeDayId: "day-1",
+        exerciseIndex: 2,
+        setsData: {
+          "ex-1": [
+            { reps: "10", weight: "60", done: true },
+            { reps: "10", weight: "60", done: true },
+            { reps: "10", weight: "60", done: true },
+          ],
+          "ex-2": [
+            { reps: "8", weight: "80", done: true },
+            { reps: "8", weight: "80", done: true },
+            { reps: "8", weight: "80", done: true },
+          ],
+        },
+        startedAt: Date.now(),
+        isActive: true,
+        totalSetsDone: 6,
+        pausedAt: null,
+        accumulatedPause: 0,
+      })
+    })
+
+    const checkIcons = document.querySelectorAll('[class*="lucide-check"]')
+    expect(checkIcons).toHaveLength(2)
+  })
+
+  it("calls onSelectIndex when clicking an exercise", async () => {
+    const user = userEvent.setup()
+    const onSelectIndex = vi.fn()
+    renderWithProviders(
+      <ExerciseStrip
+        exercises={EXERCISES}
+        activeIndex={0}
+        onSelectIndex={onSelectIndex}
+      />,
+    )
+
+    await user.click(screen.getByText("Squat"))
+
+    expect(onSelectIndex).toHaveBeenCalledWith(1)
+  })
+})

--- a/src/components/workout/ExerciseStrip.tsx
+++ b/src/components/workout/ExerciseStrip.tsx
@@ -1,6 +1,7 @@
 import { useAtomValue } from "jotai"
 import { useRef, useEffect } from "react"
-import { prFlagsAtom } from "@/store/atoms"
+import { Check } from "lucide-react"
+import { prFlagsAtom, completedExerciseIdsAtom } from "@/store/atoms"
 import type { WorkoutExercise } from "@/types/database"
 import { useExerciseFromLibrary } from "@/hooks/useExerciseFromLibrary"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
@@ -18,6 +19,7 @@ export function ExerciseStrip({
   onSelectIndex,
 }: ExerciseStripProps) {
   const prFlags = useAtomValue(prFlagsAtom)
+  const completedIds = useAtomValue(completedExerciseIdsAtom)
   const scrollRef = useRef<HTMLDivElement>(null)
   const activeRef = useRef<HTMLButtonElement>(null)
 
@@ -40,6 +42,7 @@ export function ExerciseStrip({
           exercise={ex}
           isActive={idx === activeIndex}
           hasPr={!!prFlags[ex.exercise_id]}
+          isCompleted={completedIds.has(ex.id)}
           ref={idx === activeIndex ? activeRef : undefined}
           onSelect={() => onSelectIndex(idx)}
         />
@@ -54,11 +57,12 @@ interface StripItemProps {
   exercise: WorkoutExercise
   isActive: boolean
   hasPr: boolean
+  isCompleted: boolean
   onSelect: () => void
 }
 
 const StripItem = forwardRef<HTMLButtonElement, StripItemProps>(
-  function StripItem({ exercise, isActive, hasPr, onSelect }, ref) {
+  function StripItem({ exercise, isActive, hasPr, isCompleted, onSelect }, ref) {
     const { data: libExercise } = useExerciseFromLibrary(exercise.exercise_id)
 
     return (
@@ -70,8 +74,14 @@ const StripItem = forwardRef<HTMLButtonElement, StripItemProps>(
           isActive
             ? "w-[8.5rem] scale-110 ring-2 ring-primary shadow-lg z-10"
             : "w-[5rem] opacity-60",
+          isCompleted && "border-green-500/50",
         )}
       >
+        {isCompleted && (
+          <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/40">
+            <Check className="h-8 w-8 text-green-400 drop-shadow-lg" strokeWidth={3} />
+          </div>
+        )}
         {hasPr && (
           <span className="absolute right-1 top-1 z-10 text-xs drop-shadow">🏆</span>
         )}

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { isIOS, isStandalone } from "./platform"
+
+describe("platform detection", () => {
+  beforeEach(() => {
+    vi.stubGlobal("navigator", { userAgent: "" })
+    vi.stubGlobal("window", {
+      matchMedia: vi.fn().mockReturnValue({ matches: false }),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe("isIOS", () => {
+    it("returns true for iPhone user agent", () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15",
+      })
+      expect(isIOS()).toBe(true)
+    })
+
+    it("returns true for iPad user agent", () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) AppleWebKit/605.1.15",
+      })
+      expect(isIOS()).toBe(true)
+    })
+
+    it("returns true for iPod user agent", () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (iPod; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15",
+      })
+      expect(isIOS()).toBe(true)
+    })
+
+    it("returns false for Android user agent", () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Chrome/114.0.0.0 Mobile Safari/537.36",
+      })
+      expect(isIOS()).toBe(false)
+    })
+
+    it("returns false for desktop Chrome user agent", () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/114.0.0.0 Safari/537.36",
+      })
+      expect(isIOS()).toBe(false)
+    })
+
+    it("returns false when MSStream is present (IE mobile)", () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15",
+      })
+      vi.stubGlobal("window", {
+        MSStream: {},
+        matchMedia: vi.fn().mockReturnValue({ matches: false }),
+      })
+      expect(isIOS()).toBe(false)
+    })
+  })
+
+  describe("isStandalone", () => {
+    it("returns true when display-mode is standalone", () => {
+      vi.stubGlobal("window", {
+        matchMedia: vi.fn().mockReturnValue({ matches: true }),
+      })
+      expect(isStandalone()).toBe(true)
+    })
+
+    it("returns false when display-mode is not standalone", () => {
+      vi.stubGlobal("window", {
+        matchMedia: vi.fn().mockReturnValue({ matches: false }),
+      })
+      expect(isStandalone()).toBe(false)
+    })
+  })
+})

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,12 @@
+export function isIOS(): boolean {
+  if (typeof navigator === "undefined") return false
+  return (
+    /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+    !("MSStream" in window)
+  )
+}
+
+export function isStandalone(): boolean {
+  if (typeof window === "undefined") return false
+  return window.matchMedia("(display-mode: standalone)").matches
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -26,5 +26,13 @@
   "adminExercises": "Exercises",
   "adminFeedback": "Feedback",
   "changeProgram": "Change program",
-  "library": "Library"
+  "library": "Library",
+  "iosInstallTitle": "Install on iOS",
+  "iosInstallSubtitle": "Add this app to your home screen for the best experience",
+  "iosInstallStep1Title": "Tap Share",
+  "iosInstallStep1Desc": "Tap the Share button at the bottom of Safari",
+  "iosInstallStep2Title": "Add to Home Screen",
+  "iosInstallStep2Desc": "Scroll down and tap 'Add to Home Screen'",
+  "iosInstallStep3Title": "Confirm",
+  "iosInstallStep3Desc": "Tap 'Add' in the top right corner"
 }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -26,5 +26,13 @@
   "adminExercises": "Exercices",
   "adminFeedback": "Retours",
   "changeProgram": "Changer de programme",
-  "library": "Bibliothèque"
+  "library": "Bibliothèque",
+  "iosInstallTitle": "Installer sur iOS",
+  "iosInstallSubtitle": "Ajoutez cette appli à votre écran d'accueil pour la meilleure expérience",
+  "iosInstallStep1Title": "Appuyez sur Partager",
+  "iosInstallStep1Desc": "Appuyez sur le bouton Partager en bas de Safari",
+  "iosInstallStep2Title": "Sur l'écran d'accueil",
+  "iosInstallStep2Desc": "Faites défiler et appuyez sur « Sur l'écran d'accueil »",
+  "iosInstallStep3Title": "Confirmer",
+  "iosInstallStep3Desc": "Appuyez sur « Ajouter » en haut à droite"
 }

--- a/src/store/atoms.test.ts
+++ b/src/store/atoms.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest"
+import { createStore } from "jotai"
+import { sessionAtom, completedExerciseIdsAtom } from "./atoms"
+
+describe("completedExerciseIdsAtom", () => {
+  it("returns empty set when no sets data exists", () => {
+    const store = createStore()
+    const completed = store.get(completedExerciseIdsAtom)
+    expect(completed.size).toBe(0)
+  })
+
+  it("returns empty set when exercises have no sets", () => {
+    const store = createStore()
+    store.set(sessionAtom, {
+      currentDayId: "day-1",
+      activeDayId: "day-1",
+      exerciseIndex: 0,
+      setsData: {
+        "exercise-1": [],
+      },
+      startedAt: Date.now(),
+      isActive: true,
+      totalSetsDone: 0,
+      pausedAt: null,
+      accumulatedPause: 0,
+    })
+
+    const completed = store.get(completedExerciseIdsAtom)
+    expect(completed.size).toBe(0)
+  })
+
+  it("returns empty set when some sets are not done", () => {
+    const store = createStore()
+    store.set(sessionAtom, {
+      currentDayId: "day-1",
+      activeDayId: "day-1",
+      exerciseIndex: 0,
+      setsData: {
+        "exercise-1": [
+          { reps: "10", weight: "50", done: true },
+          { reps: "10", weight: "50", done: false },
+          { reps: "10", weight: "50", done: true },
+        ],
+      },
+      startedAt: Date.now(),
+      isActive: true,
+      totalSetsDone: 2,
+      pausedAt: null,
+      accumulatedPause: 0,
+    })
+
+    const completed = store.get(completedExerciseIdsAtom)
+    expect(completed.has("exercise-1")).toBe(false)
+  })
+
+  it("returns exercise id when all sets are done", () => {
+    const store = createStore()
+    store.set(sessionAtom, {
+      currentDayId: "day-1",
+      activeDayId: "day-1",
+      exerciseIndex: 0,
+      setsData: {
+        "exercise-1": [
+          { reps: "10", weight: "50", done: true },
+          { reps: "10", weight: "50", done: true },
+          { reps: "10", weight: "50", done: true },
+        ],
+      },
+      startedAt: Date.now(),
+      isActive: true,
+      totalSetsDone: 3,
+      pausedAt: null,
+      accumulatedPause: 0,
+    })
+
+    const completed = store.get(completedExerciseIdsAtom)
+    expect(completed.has("exercise-1")).toBe(true)
+  })
+
+  it("returns multiple exercise ids when multiple exercises are completed", () => {
+    const store = createStore()
+    store.set(sessionAtom, {
+      currentDayId: "day-1",
+      activeDayId: "day-1",
+      exerciseIndex: 2,
+      setsData: {
+        "exercise-1": [
+          { reps: "10", weight: "50", done: true },
+          { reps: "10", weight: "50", done: true },
+        ],
+        "exercise-2": [
+          { reps: "8", weight: "60", done: true },
+          { reps: "8", weight: "60", done: true },
+        ],
+        "exercise-3": [
+          { reps: "12", weight: "40", done: false },
+        ],
+      },
+      startedAt: Date.now(),
+      isActive: true,
+      totalSetsDone: 4,
+      pausedAt: null,
+      accumulatedPause: 0,
+    })
+
+    const completed = store.get(completedExerciseIdsAtom)
+    expect(completed.size).toBe(2)
+    expect(completed.has("exercise-1")).toBe(true)
+    expect(completed.has("exercise-2")).toBe(true)
+    expect(completed.has("exercise-3")).toBe(false)
+  })
+})

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -41,6 +41,17 @@ export const sessionAtom = atomWithStorage<SessionState>(
   defaultSessionState,
 )
 
+export const completedExerciseIdsAtom = atom((get) => {
+  const session = get(sessionAtom)
+  const completed = new Set<string>()
+  for (const [exerciseId, sets] of Object.entries(session.setsData)) {
+    if (sets.length > 0 && sets.every((s) => s.done)) {
+      completed.add(exerciseId)
+    }
+  }
+  return completed
+})
+
 export interface RestState {
   startedAt: number
   durationSeconds: number


### PR DESCRIPTION
## Summary

Closes #71 and #72

- **iOS Install Guide**: Adds a persistent "Install App" menu item for iOS users with step-by-step instructions modal (Share → Add to Home Screen)
- **Completed Exercises Visual**: Shows dimmed overlay with checkmark on exercises where all sets are done during workout sessions

## Changes

| File | Description |
|------|-------------|
| `src/lib/platform.ts` | iOS/standalone detection utilities |
| `src/components/IOSInstallModal.tsx` | Step-by-step iOS install instructions |
| `src/components/SideDrawer.tsx` | Show install button for iOS, wire modal |
| `src/store/atoms.ts` | `completedExerciseIdsAtom` derived atom |
| `src/components/workout/ExerciseStrip.tsx` | Checkmark overlay for completed exercises |
| `src/locales/{en,fr}/common.json` | i18n keys for iOS modal |

## Test plan

- [x] Unit tests for `completedExerciseIdsAtom` (5 tests)
- [x] Unit tests for platform detection (8 tests)
- [x] Unit tests for ExerciseStrip component (6 tests)
- [x] All 444 tests pass
- [ ] Manual test on iOS Safari device
- [ ] Manual test workout session completion visual

Made with [Cursor](https://cursor.com)