### PR TITLE
fix: persist theme preference (localStorage + system fallback)

### DIFF
--- a/docs/Tech_Plan_—_Theme_Preference_Persistence.md
+++ b/docs/Tech_Plan_—_Theme_Preference_Persistence.md
@@ -1,0 +1,95 @@
+# Tech Plan — Theme preference persistence
+
+## Architectural Approach
+
+GitHub issue [#75](https://github.com/PierreTsia/workout-app/issues/75) asked for persisted dark/light preference and system fallback. The implementation removes **duplicate persistence** on the `theme` localStorage key: Jotai’s `atomWithStorage` used JSON encoding while **next-themes** expects plain `dark` | `light` | `system`, so both writers could corrupt each other on refresh.
+
+**Outcome:** next-themes is the **only** persisted authority, using localStorage key `workout-app-theme` (not `theme`, which is easily clobbered). file:src/store/atoms.ts no longer exports `themeAtom`. file:src/components/SideDrawer.tsx uses `useTheme()` (`resolvedTheme`, `setTheme`) for the switch. file:src/main.tsx runs file:src/lib/themeStorage.ts `prepareThemeLocalStorage` once at boot, then wraps the app in `ThemeProvider` with `storageKey`, `defaultTheme="system"`, and `enableSystem`. file:index.html includes a small inline script (same keys as file:src/lib/themeStorage.ts) so `document.documentElement` gets the correct `light`/`dark` class before the JS bundle runs.
+
+**Preference order (resolved appearance):** (1) value in localStorage (`workout-app-theme`, after migration from `theme`); (2) if absent or stored `system`, `prefers-color-scheme`; (3) if the media query is unavailable, **dark** (`THEME_FALLBACK_RESOLVED` in file:src/lib/themeStorage.ts). next-themes uses `defaultTheme="system"` so “no key” is modeled as follow-OS, not as hardcoded dark.
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Persistence | next-themes only | Owns `document.documentElement` class; avoids Jotai/next-themes sync effects. |
+| Jotai `themeAtom` | Removed | Only SideDrawer used it; dual storage caused the bug. |
+| Default chain | `defaultTheme="system"` + `enableSystem` + `THEME_FALLBACK_RESOLVED` | Stored pref wins; else OS; else resolved default **dark** (boot script + `resolveThemeClassForBoot`). Explicit toggle sets `dark` or `light` and persists to localStorage. |
+| Switch UI | `resolvedTheme === 'dark'` + `onCheckedChange` → `setTheme` | Reflects actual appearance when `theme === 'system'`; Radix boolean drives explicit theme. |
+| Storage key | `workout-app-theme` + migrate from `theme` | Avoids collisions on the generic `theme` key; `prepareThemeLocalStorage` migrates and removes legacy when canonical is valid. |
+| Legacy data | `normalizeLegacyThemeLocalStorage` | Converts JSON-encoded `dark`/`light` from old Jotai writes to plain strings; trims whitespace; drops invalid values. |
+
+### Critical Constraints
+
+- Do not reintroduce a second persisted theme store; keep `ThemeProvider` `storageKey` aligned with file:src/lib/themeStorage.ts and the inline script in file:index.html.
+- file:src/components/ui/sonner.tsx continues to use `useTheme()`; `resolvedTheme` still drives toast styling when `theme` is `system`.
+- Boot preparation must run **before** React render (file:src/main.tsx: `prepareThemeLocalStorage(localStorage)` then `createRoot`). The inline script in file:index.html reduces flash and matches the same read/parse rules.
+
+---
+
+## Data Model
+
+```mermaid
+flowchart LR
+  subgraph storage [localStorage]
+    themeKey["key workout-app-theme"]
+  end
+  NT[next_themes]
+  NT --> themeKey
+```
+
+**Stored values:** `dark` | `light` | `system` (plain strings, next-themes contract). Legacy `theme` is migrated once then removed when canonical is valid.
+
+### Table notes
+
+- Historical docs under file:docs/done/ may still mention `themeAtom`; those files are archived context, not updated here.
+
+---
+
+## Component Architecture
+
+### Layer Overview
+
+```mermaid
+graph TD
+  Main["main.tsx ThemeProvider"]
+  Router["RouterProvider"]
+  SideDrawer["SideDrawer"]
+  Sonner["Toaster"]
+  Main --> Router
+  Router --> SideDrawer
+  Main --> Sonner
+  SideDrawer --> useTheme["useTheme"]
+```
+
+### New Files & Responsibilities
+
+| File | Purpose |
+|---|---|
+| file:src/lib/themeStorage.ts | `THEME_STORAGE_KEY`, `normalizeLegacyThemeLocalStorage` for one-time legacy fix. |
+| file:src/lib/themeStorage.test.ts | Unit tests for normalization behavior. |
+
+### Component Responsibilities
+
+**ThemeProvider (file:src/main.tsx)**  
+- `attribute="class"` for Tailwind dark mode.  
+- `defaultTheme="system"`, `enableSystem` for OS fallback when nothing valid is stored.
+
+**SideDrawer**  
+- Dark mode row: `resolvedTheme` and `setTheme` from `useTheme()` only.
+
+### Failure Mode Analysis
+
+| Failure | Behavior |
+|---|---|
+| Legacy JSON in `localStorage.theme` | Normalized to plain `dark`/`light` or key removed. |
+| `resolvedTheme` briefly undefined | Switch `checked` is false until resolved; acceptable for CSR. |
+| User wants explicit “use system” in UI | Not in #75 scope; clearing site data or future control could restore `system`. |
+
+---
+
+## References
+
+- [Issue #75 — Theme preference not persisted](https://github.com/PierreTsia/workout-app/issues/75)
+- file:.cursor/rules/docs-format.mdc
+- file:.cursor/rules/react-no-unnecessary-effects.mdc

--- a/index.html
+++ b/index.html
@@ -12,6 +12,44 @@
     <title>Workout</title>
   </head>
   <body>
+    <!-- Keep keys in sync with src/lib/themeStorage.ts (THEME_STORAGE_KEY, LEGACY_THEME_STORAGE_KEY) -->
+    <script>
+      ;(function () {
+        var NEW_KEY = "workout-app-theme"
+        var OLD_KEY = "theme"
+        var FALLBACK = "dark"
+        function parseStored(raw) {
+          if (raw == null || raw === "") return null
+          var t = String(raw).trim()
+          if (t === "dark" || t === "light" || t === "system") return t
+          try {
+            var p = JSON.parse(t)
+            if (p === "dark" || p === "light" || p === "system") return p
+          } catch (e) {}
+          return null
+        }
+        function systemOrFallbackDark() {
+          try {
+            if (window.matchMedia) {
+              return window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light"
+            }
+          } catch (e) {}
+          return FALLBACK
+        }
+        try {
+          var raw =
+            localStorage.getItem(NEW_KEY) || localStorage.getItem(OLD_KEY)
+          var v = parseStored(raw)
+          var resolved =
+            v === "light" || v === "dark" ? v : systemOrFallbackDark()
+          var d = document.documentElement
+          d.classList.remove("light", "dark")
+          d.classList.add(resolved)
+        } catch (e) {}
+      })()
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/components/SideDrawer.tsx
+++ b/src/components/SideDrawer.tsx
@@ -27,7 +27,6 @@ import {
   drawerOpenAtom,
   localeAtom,
   queueSyncMetaAtom,
-  themeAtom,
   weightUnitAtom,
 } from "@/store/atoms"
 import { supabase } from "@/lib/supabase"
@@ -68,12 +67,11 @@ function SegmentedButton<T extends string>({
 export function SideDrawer() {
   const { t, i18n } = useTranslation(["common", "settings"])
   const [open, setOpen] = useAtom(drawerOpenAtom)
-  const [currentTheme, setThemeAtom] = useAtom(themeAtom)
   const [locale, setLocale] = useAtom(localeAtom)
   const [weightUnit, setWeightUnit] = useAtom(weightUnitAtom)
   const user = useAtomValue(authAtom)
   const queueMeta = useAtomValue(queueSyncMetaAtom)
-  const { setTheme } = useTheme()
+  const { resolvedTheme, setTheme } = useTheme()
   const [signOutConfirmOpen, setSignOutConfirmOpen] = useState(false)
   const [iosModalOpen, setIosModalOpen] = useState(false)
   const { canInstall, promptInstall } = useInstallPrompt()
@@ -103,12 +101,6 @@ export function SideDrawer() {
     setSignOutConfirmOpen(false)
     supabase.auth.signOut()
     closeDrawer()
-  }
-
-  function toggleTheme() {
-    const next = currentTheme === "dark" ? "light" : "dark"
-    setTheme(next)
-    setThemeAtom(next)
   }
 
   function handleLocaleChange(v: "en" | "fr") {
@@ -192,8 +184,10 @@ export function SideDrawer() {
             <div className="flex items-center justify-between">
               <span className="text-sm text-foreground">{t("common:darkMode")}</span>
               <Switch
-                checked={currentTheme === "dark"}
-                onCheckedChange={toggleTheme}
+                checked={resolvedTheme === "dark"}
+                onCheckedChange={(checked) =>
+                  setTheme(checked ? "dark" : "light")
+                }
               />
             </div>
 

--- a/src/lib/themeStorage.test.ts
+++ b/src/lib/themeStorage.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it, beforeEach, vi } from "vitest"
+import {
+  LEGACY_THEME_STORAGE_KEY,
+  normalizeLegacyThemeLocalStorage,
+  parseStoredThemePreference,
+  prepareThemeLocalStorage,
+  resolveThemeClassForBoot,
+  THEME_FALLBACK_RESOLVED,
+  THEME_STORAGE_KEY,
+} from "./themeStorage"
+
+function mockStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => {
+      map.set(k, v)
+    },
+    removeItem: (k) => {
+      map.delete(k)
+    },
+    clear: () => map.clear(),
+    key: () => null,
+    get length() {
+      return map.size
+    },
+  }
+}
+
+describe("parseStoredThemePreference", () => {
+  it("returns null for empty", () => {
+    expect(parseStoredThemePreference(null)).toBeNull()
+    expect(parseStoredThemePreference("")).toBeNull()
+    expect(parseStoredThemePreference("   ")).toBeNull()
+  })
+
+  it("parses plain light, dark, system", () => {
+    expect(parseStoredThemePreference("light")).toBe("light")
+    expect(parseStoredThemePreference("dark")).toBe("dark")
+    expect(parseStoredThemePreference("system")).toBe("system")
+  })
+
+  it("parses JSON-encoded values", () => {
+    expect(parseStoredThemePreference(JSON.stringify("light"))).toBe("light")
+    expect(parseStoredThemePreference(JSON.stringify("system"))).toBe("system")
+  })
+})
+
+describe("resolveThemeClassForBoot", () => {
+  afterEach(() => {
+    delete (window as unknown as { matchMedia?: typeof window.matchMedia })
+      .matchMedia
+  })
+
+  function mockOsPrefersDark(osPrefersDark: boolean) {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches:
+        query.includes("prefers-color-scheme: dark") && osPrefersDark,
+      media: query,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  }
+
+  it("returns light or dark when explicitly stored", () => {
+    const s = mockStorage()
+    s.setItem(THEME_STORAGE_KEY, "light")
+    expect(resolveThemeClassForBoot(s)).toBe("light")
+    s.setItem(THEME_STORAGE_KEY, "dark")
+    expect(resolveThemeClassForBoot(s)).toBe("dark")
+  })
+
+  it("when stored system matches dark OS", () => {
+    mockOsPrefersDark(true)
+    const s = mockStorage()
+    s.setItem(THEME_STORAGE_KEY, "system")
+    expect(resolveThemeClassForBoot(s)).toBe("dark")
+  })
+
+  it("when stored system matches light OS", () => {
+    mockOsPrefersDark(false)
+    const s = mockStorage()
+    s.setItem(THEME_STORAGE_KEY, "system")
+    expect(resolveThemeClassForBoot(s)).toBe("light")
+  })
+
+  it("when nothing stored, uses OS (light)", () => {
+    mockOsPrefersDark(false)
+    expect(resolveThemeClassForBoot(mockStorage())).toBe("light")
+  })
+
+  it("when nothing stored, uses OS (dark)", () => {
+    mockOsPrefersDark(true)
+    expect(resolveThemeClassForBoot(mockStorage())).toBe("dark")
+  })
+
+  it("when matchMedia throws, uses THEME_FALLBACK_RESOLVED", () => {
+    window.matchMedia = vi.fn(() => {
+      throw new Error("no media")
+    })
+    expect(resolveThemeClassForBoot(mockStorage())).toBe(THEME_FALLBACK_RESOLVED)
+  })
+})
+
+describe("normalizeLegacyThemeLocalStorage", () => {
+  let storage: Storage
+
+  beforeEach(() => {
+    storage = mockStorage()
+  })
+
+  it("leaves plain dark unchanged", () => {
+    storage.setItem(THEME_STORAGE_KEY, "dark")
+    normalizeLegacyThemeLocalStorage(storage, THEME_STORAGE_KEY)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBe("dark")
+  })
+
+  it("leaves plain light unchanged", () => {
+    storage.setItem(THEME_STORAGE_KEY, "light")
+    normalizeLegacyThemeLocalStorage(storage, THEME_STORAGE_KEY)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBe("light")
+  })
+
+  it("leaves system unchanged", () => {
+    storage.setItem(THEME_STORAGE_KEY, "system")
+    normalizeLegacyThemeLocalStorage(storage, THEME_STORAGE_KEY)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBe("system")
+  })
+
+  it("converts JSON-encoded dark from Jotai-style storage", () => {
+    storage.setItem(THEME_STORAGE_KEY, JSON.stringify("dark"))
+    normalizeLegacyThemeLocalStorage(storage, THEME_STORAGE_KEY)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBe("dark")
+  })
+
+  it("converts JSON-encoded light", () => {
+    storage.setItem(THEME_STORAGE_KEY, JSON.stringify("light"))
+    normalizeLegacyThemeLocalStorage(storage, THEME_STORAGE_KEY)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBe("light")
+  })
+
+  it("trims whitespace around plain values", () => {
+    storage.setItem(THEME_STORAGE_KEY, "  light  ")
+    normalizeLegacyThemeLocalStorage(storage, THEME_STORAGE_KEY)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBe("light")
+  })
+
+  it("removes invalid values", () => {
+    storage.setItem(THEME_STORAGE_KEY, "not-a-theme")
+    normalizeLegacyThemeLocalStorage(storage, THEME_STORAGE_KEY)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBeNull()
+  })
+
+  it("no-ops when key is absent", () => {
+    normalizeLegacyThemeLocalStorage(storage, THEME_STORAGE_KEY)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBeNull()
+  })
+})
+
+describe("prepareThemeLocalStorage", () => {
+  let storage: Storage
+
+  beforeEach(() => {
+    storage = mockStorage()
+  })
+
+  it("migrates plain light from legacy key when canonical key is empty", () => {
+    storage.setItem(LEGACY_THEME_STORAGE_KEY, "light")
+    prepareThemeLocalStorage(storage)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBe("light")
+    expect(storage.getItem(LEGACY_THEME_STORAGE_KEY)).toBeNull()
+  })
+
+  it("migrates JSON-encoded dark from legacy key", () => {
+    storage.setItem(LEGACY_THEME_STORAGE_KEY, JSON.stringify("dark"))
+    prepareThemeLocalStorage(storage)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBe("dark")
+    expect(storage.getItem(LEGACY_THEME_STORAGE_KEY)).toBeNull()
+  })
+
+  it("does not overwrite canonical key when already set but drops stale legacy", () => {
+    storage.setItem(THEME_STORAGE_KEY, "light")
+    storage.setItem(LEGACY_THEME_STORAGE_KEY, "dark")
+    prepareThemeLocalStorage(storage)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBe("light")
+    expect(storage.getItem(LEGACY_THEME_STORAGE_KEY)).toBeNull()
+  })
+
+  it("normalizes JSON on canonical key without legacy", () => {
+    storage.setItem(THEME_STORAGE_KEY, JSON.stringify("light"))
+    prepareThemeLocalStorage(storage)
+    expect(storage.getItem(THEME_STORAGE_KEY)).toBe("light")
+  })
+})

--- a/src/lib/themeStorage.ts
+++ b/src/lib/themeStorage.ts
@@ -1,0 +1,131 @@
+/**
+ * next-themes default is `theme`, which collides with other scripts/extensions.
+ * We use a namespaced key and migrate from the legacy key once.
+ */
+export const THEME_STORAGE_KEY = "workout-app-theme"
+
+/** Previous key (Jotai + old next-themes); migrated on boot */
+export const LEGACY_THEME_STORAGE_KEY = "theme"
+
+/**
+ * When there is no saved preference or it is `system`, we follow the OS.
+ * If `prefers-color-scheme` cannot be read, we use this resolved default (not light).
+ */
+export const THEME_FALLBACK_RESOLVED = "dark" as const
+
+const VALID_PLAIN = new Set(["dark", "light", "system"])
+
+export type StoredThemePreference = "light" | "dark" | "system"
+
+/**
+ * Read-only parse of a single localStorage entry.
+ * Preference order for the app overall:
+ * 1. Persisted `light` | `dark` | `system` under {@link THEME_STORAGE_KEY} (then legacy key, migrated at boot)
+ * 2. If missing or `system`, `prefers-color-scheme` (see {@link resolveThemeClassForBoot})
+ * 3. If the media query is unavailable, {@link THEME_FALLBACK_RESOLVED}
+ */
+export function parseStoredThemePreference(
+  raw: string | null,
+): StoredThemePreference | null {
+  if (raw == null) return null
+  const trimmed = raw.trim()
+  if (trimmed === "") return null
+  if (VALID_PLAIN.has(trimmed)) return trimmed as StoredThemePreference
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (parsed === "dark" || parsed === "light" || parsed === "system") {
+      return parsed as StoredThemePreference
+    }
+  } catch {
+    /* not JSON */
+  }
+  return null
+}
+
+/** `light` | `dark` to put on `document.documentElement` before React (matches next-themes `class` strategy). */
+export function resolveThemeClassForBoot(storage: Storage): "light" | "dark" {
+  const raw =
+    storage.getItem(THEME_STORAGE_KEY) ?? storage.getItem(LEGACY_THEME_STORAGE_KEY)
+  const pref = parseStoredThemePreference(raw)
+  if (pref === "light" || pref === "dark") return pref
+  return resolveSystemOrFallbackDark()
+}
+
+function resolveSystemOrFallbackDark(): "light" | "dark" {
+  try {
+    if (typeof window !== "undefined" && window.matchMedia) {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light"
+    }
+  } catch {
+    /* ignore */
+  }
+  return THEME_FALLBACK_RESOLVED
+}
+
+/**
+ * Jotai `atomWithStorage` used JSON encoding on the same key as next-themes,
+ * which expects plain `dark` | `light` | `system`. Normalize or drop invalid values.
+ */
+export function normalizeLegacyThemeLocalStorage(
+  storage: Storage,
+  key: string = THEME_STORAGE_KEY,
+): void {
+  const raw = storage.getItem(key)
+  if (raw === null) return
+  const trimmed = raw.trim()
+  if (trimmed === "") {
+    storage.removeItem(key)
+    return
+  }
+  if (trimmed !== raw) {
+    storage.setItem(key, trimmed)
+  }
+  const v = storage.getItem(key)!
+  if (VALID_PLAIN.has(v)) return
+  try {
+    const parsed = JSON.parse(v) as unknown
+    if (parsed === "dark" || parsed === "light") {
+      storage.setItem(key, parsed)
+      return
+    }
+  } catch {
+    /* not JSON */
+  }
+  storage.removeItem(key)
+}
+
+/**
+ * Fix JSON-shaped values on the legacy key, copy a valid preference to the
+ * canonical key, then normalize the canonical key. Call once before React mounts.
+ */
+export function prepareThemeLocalStorage(storage: Storage): void {
+  normalizeLegacyThemeLocalStorage(storage, LEGACY_THEME_STORAGE_KEY)
+
+  const existing = storage.getItem(THEME_STORAGE_KEY)
+  if (!existing) {
+    const legacy = storage.getItem(LEGACY_THEME_STORAGE_KEY)
+    if (legacy && VALID_PLAIN.has(legacy)) {
+      storage.setItem(THEME_STORAGE_KEY, legacy)
+      storage.removeItem(LEGACY_THEME_STORAGE_KEY)
+    } else if (legacy) {
+      try {
+        const parsed = JSON.parse(legacy) as unknown
+        if (parsed === "dark" || parsed === "light") {
+          storage.setItem(THEME_STORAGE_KEY, parsed)
+          storage.removeItem(LEGACY_THEME_STORAGE_KEY)
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  normalizeLegacyThemeLocalStorage(storage, THEME_STORAGE_KEY)
+
+  const final = storage.getItem(THEME_STORAGE_KEY)
+  if (final && VALID_PLAIN.has(final)) {
+    storage.removeItem(LEGACY_THEME_STORAGE_KEY)
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,12 +13,25 @@ import { queryClient } from "@/lib/queryClient"
 import { initSyncListeners } from "@/lib/syncService"
 import { Toaster } from "@/components/ui/sonner"
 import { ErrorFallback } from "@/components/ErrorFallback"
+import { prepareThemeLocalStorage, THEME_STORAGE_KEY } from "@/lib/themeStorage"
 
 initSyncListeners()
+prepareThemeLocalStorage(localStorage)
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+    {/*
+      Preference order: localStorage (storageKey) > prefers-color-scheme > resolved default dark.
+      defaultTheme="system" means “no saved value” follows the OS; THEME_FALLBACK_RESOLVED handles
+      matchMedia failure in the inline boot script (index.html) + resolveThemeClassForBoot.
+    */}
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      storageKey={THEME_STORAGE_KEY}
+      themes={["light", "dark", "system"]}
+    >
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary
           fallbackRender={({ error, resetErrorBoundary }) => (

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -61,8 +61,6 @@ export interface RestState {
 
 export const restAtom = atomWithStorage<RestState | null>("rest", null)
 
-export const themeAtom = atomWithStorage<"dark" | "light">("theme", "dark")
-
 export const syncStatusAtom = atom<"idle" | "syncing" | "failed" | "synced">(
   "idle",
 )


### PR DESCRIPTION
## What

- Make **next-themes** the only persisted theme source using a **namespaced** `localStorage` key (`workout-app-theme`), with **migration/cleanup** from the legacy `theme` key (JSON Jotai values + collision avoidance).
- Run **`prepareThemeLocalStorage`** before React mounts and add an **inline boot script** in `index.html` so `<html>` gets the correct `light`/`dark` class before the bundle loads.
- **Remove `themeAtom`**; **SideDrawer** uses `useTheme()` with the switch driven by `resolvedTheme` and `setTheme`.
- Document and implement preference order: **stored value → `prefers-color-scheme` → resolved default dark** when `matchMedia` is unavailable.
- Add **Tech Plan** doc and **unit tests** for `themeStorage` helpers.

## Why

Fixes [#75](https://github.com/PierreTsia/workout-app/issues/75): theme appeared to reset on refresh because Jotai and next-themes both wrote the same key with **incompatible serialization**, and the generic `theme` key is easy for other code/extensions to overwrite.

## How

- `src/lib/themeStorage.ts` — keys, normalization, migration, `resolveThemeClassForBoot`, `THEME_FALLBACK_RESOLVED`.
- `src/main.tsx` — `ThemeProvider` with `storageKey`, `defaultTheme="system"`, `enableSystem`, explicit `themes`.
- `index.html` — synchronous boot script (keep keys in sync with `themeStorage.ts`).
- `src/components/SideDrawer.tsx` — no Jotai theme; Radix `Switch` uses `onCheckedChange` → `setTheme`.
- `src/store/atoms.ts` — drop `themeAtom`.
- `docs/Tech_Plan_—_Theme_Preference_Persistence.md` — architecture and decisions.

Closes #75

Made with [Cursor](https://cursor.com)