### PR TITLE
fix: context-aware session card stats and labels

### DIFF
--- a/docs/Epic_Brief_—_Premature_Session_Stats_Labels.md
+++ b/docs/Epic_Brief_—_Premature_Session_Stats_Labels.md
@@ -1,0 +1,62 @@
+# Epic Brief — Premature Session Stats & Labels
+
+## Summary
+
+Fix the workout session card (overview carousel) so that stats and date labels accurately reflect the **current state** of each day within the active cycle. Currently, the card conflates past session data with the current plan — showing "Aujourd'hui" and aggregated performance stats even when a session hasn't started, leading to user confusion about what is planned vs. what was actually performed.
+
+---
+
+## Context & Problem
+
+**Who is affected:** Every user landing on the main workout screen and swiping through the day card carousel.
+
+**Current state:**
+- `file:src/hooks/useLastSessionForDay.ts` fetches the most recent finished session per day **without cycle scoping** — it pulls data from any past session
+- `file:src/components/workout/WorkoutDayCard.tsx` renders a relative date badge (`formatRelativeDate`) and stats (sets, duration) from this unscoped `lastSession`
+- `file:src/lib/formatters.ts` uses `Intl.RelativeTimeFormat` with `numeric: "auto"`, producing "Aujourd'hui"/"Today" when the last session was today
+
+**Pain points:**
+
+| Pain | Impact |
+|---|---|
+| "Aujourd'hui" badge appears on a day that hasn't been started in the current cycle — just because a past session exists | User thinks the day is planned or active today when it isn't |
+| Stats (24 sets, 58 min) from old sessions show without "Last" or "Estimate" context | User can't tell if these are template targets or past actuals |
+| Exercise count badge is always from template, but sets/duration are from old sessions — mixed sources, no labeling | Cognitive load: is "24 sets" what I should do, or what I did? |
+| No visual distinction between plan/estimate and confirmed performance data | Users can't scan-and-compare at a glance |
+
+---
+
+## Goals
+
+| Goal | Measure |
+|---|---|
+| Context-aware date label | "Aujourd'hui" only appears when a session was finished today in the current cycle |
+| Disambiguated stats | Stats are explicitly labeled as "Estimate" (idle) or "Actual" (done) |
+| Visual plan vs. reality separation | Estimated stats are visually muted; actual stats are prominent |
+| Consistency across carousel | Same logic in WorkoutDayCard, ExerciseListPreview, and any future history views |
+
+---
+
+## Scope
+
+**In scope:**
+1. Add cycle-scoping to `useLastSessionForDay` (use existing `cycleId` parameter path from original tech plan)
+2. Compute template-based estimated stats (sets, duration) for idle days
+3. Context-aware date badge: relative date for cycle-done days, "Last: {date}" for days with only past sessions, hidden when never done
+4. Label stats as "Est." or "Actual" with distinct visual treatment
+5. i18n keys for new labels (EN/FR)
+
+**Out of scope:**
+- Changes to active session UX
+- Session summary redesign
+- History page changes
+- New data model or migrations (all data already exists)
+
+---
+
+## Success Criteria
+
+- **Qualitative:** "Aujourd'hui" label only visible if a session is `active` or `finished` today within the current cycle
+- **Qualitative:** Pre-session stats are labeled as "Estimated" with muted styling
+- **Qualitative:** User can distinguish between template estimates and real performance data at a glance
+- **Qualitative:** Visual hierarchy clearly separates "Plan" from "Reality"

--- a/docs/Tech_Plan_—_Premature_Session_Stats_Labels.md
+++ b/docs/Tech_Plan_—_Premature_Session_Stats_Labels.md
@@ -1,0 +1,131 @@
+# Tech Plan — Premature Session Stats & Labels
+
+## Architectural Approach
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Display logic pivot | Split on existing `isCycleDone` prop in `WorkoutDayCard` | No new hook or query needed. `isCycleDone` already tells us whether the day has a finished session in the current cycle — that's the "plan vs reality" boundary. |
+| Estimated sets source | `exercises.reduce((sum, ex) => sum + ex.sets, 0)` from template | Direct from `workout_exercises.sets` — the user's planned set count. |
+| Estimated duration source | `formatDuration(lastSession.started_at, lastSession.finished_at)` from most recent past session | Same exercises/structure → similar duration. Far better than rest-time arithmetic. Hidden when no past session exists (no data to estimate from). |
+| Date badge on idle | "Last: {relativeDate}" in muted text, hidden if never done | Preserves useful "when did I last do this?" context while eliminating the ambiguous "Aujourd'hui" on unstarted days. |
+| Estimate label style | Tilde prefix (`~24 sets`, `~58 min`) + `outline` badge variant | Lightweight visual shorthand. `outline` badge variant already exists in shadcn/ui — no new CSS. |
+| `useLastSessionForDay` scoping | No changes — stays unscoped | `isCycleDone` handles the display context. The hook still returns the most recent session for both "Last: {date}" info on idle days and actual stats on done days. |
+| Scope boundary | Carousel `WorkoutDayCard` only | SessionSummary (post-finish) and History already show actual data by definition. The bug only manifests in the pre-session carousel. |
+
+### Critical Constraints
+
+**`WorkoutDayCard` is the only file with substantive logic changes.** The card receives `isCycleDone` from `WorkoutDayCarousel` → `completedSet.has(day.id)`. This prop is already wired correctly — it comes from `useCycleProgress` which queries sessions scoped to the active cycle.
+
+**`ExerciseListPreview` in `WorkoutPage` already differentiates correctly** — it uses `templateToPreviewItems(exercises)` for idle days and `summarizeSessionLogs(sessionLogs, exercises)` for done days (lines 87-92 of `file:src/pages/WorkoutPage.tsx`). The card badges need to follow this same pattern.
+
+**The `exercises` data is only fetched when `shouldFetch` is true** (active slide ± 1). Estimated stats computation depends on `exercises` being loaded — same guard as the existing exercise count badge.
+
+---
+
+## Data Model
+
+No data model changes. No migrations. All required data already exists:
+
+- `workout_exercises.sets` → template set count per exercise (for estimated total sets)
+- `sessions.total_sets_done` → actual set count from finished session
+- `sessions.started_at` / `finished_at` → actual duration (also used as estimated duration for idle days with a past session)
+
+---
+
+## Component Architecture
+
+### Layer Overview
+
+```mermaid
+graph TD
+    subgraph carousel ["WorkoutDayCarousel"]
+        WDC["WorkoutDayCard"]
+    end
+
+    subgraph hooks ["Existing Hooks (unchanged)"]
+        useWE["useWorkoutExercises"]
+        useLSD["useLastSessionForDay"]
+    end
+
+    subgraph display ["Display Logic (changed)"]
+        isCycleDone{"isCycleDone?"}
+        ActualBadges["Actual: date badge + sets + duration<br/>(secondary variant)"]
+        EstimateBadges["Estimate: ~sets + ~duration<br/>(outline variant, muted text)<br/>+ 'Last: date' muted label"]
+    end
+
+    WDC --> useWE
+    WDC --> useLSD
+    WDC --> isCycleDone
+    isCycleDone -->|true| ActualBadges
+    isCycleDone -->|false| EstimateBadges
+    ActualBadges -->|"lastSession data"| useLSD
+    EstimateBadges -->|"template sets"| useWE
+    EstimateBadges -->|"last duration + date"| useLSD
+```
+
+### Modified Files & Responsibilities
+
+| File | Change | Purpose |
+|---|---|---|
+| `file:src/components/workout/WorkoutDayCard.tsx` | Major | Split badge rendering on `isCycleDone`: actual stats for done days, estimated stats for idle days. Context-aware date badge. |
+| `file:src/locales/en/workout.json` | Minor | Add `estimatedSets`, `estimatedDuration`, `lastSession` i18n keys |
+| `file:src/locales/fr/workout.json` | Minor | Add `estimatedSets`, `estimatedDuration`, `lastSession` i18n keys |
+
+### `WorkoutDayCard` — Detailed Changes
+
+**New derived value:**
+
+```typescript
+const estimatedTotalSets = useMemo(
+  () => exercises?.reduce((sum, ex) => sum + ex.sets, 0) ?? 0,
+  [exercises],
+)
+```
+
+**Date badge area (currently lines 44-51 of `file:src/components/workout/WorkoutDayCard.tsx`):**
+
+Current behavior: always shows `formatRelativeDate(lastSession.finished_at)` when `lastSession` exists.
+
+New behavior:
+
+| State | Renders |
+|---|---|
+| `isCycleDone` + `lastSession` | `<Badge variant="secondary">` with `formatRelativeDate(lastSession.finished_at)` — actual session date ("Aujourd'hui", "Hier", etc.) |
+| `!isCycleDone` + `lastSession` | `<span className="text-muted-foreground">` with `t("lastSession", { date: formatRelativeDate(...) })` — e.g. "Last: Yesterday" / "Dernier : Hier" |
+| `!isCycleDone` + no `lastSession` | Empty `<span />` — no date info available |
+
+**Stats badges area (currently lines 77-91):**
+
+Current behavior: exercise count (template) + sets (lastSession) + duration (lastSession), all `secondary` variant.
+
+New behavior:
+
+| State | Exercise count | Sets | Duration |
+|---|---|---|---|
+| `isCycleDone` + `lastSession` | `secondary` — `exercises.length` | `secondary` — `lastSession.total_sets_done` | `secondary` — `formatDuration(started_at, finished_at)` |
+| `!isCycleDone` + `lastSession` | `outline` muted — `exercises.length` | `outline` muted — `~{estimatedTotalSets}` | `outline` muted — `~{formatDuration(lastSession.started_at, lastSession.finished_at)}` |
+| `!isCycleDone` + no `lastSession` | `outline` muted — `exercises.length` | `outline` muted — `~{estimatedTotalSets}` | Hidden (no data to estimate from) |
+
+### i18n Keys
+
+| Key | EN | FR |
+|---|---|---|
+| `estimatedSets_one` | `~{{count}} set` | `~{{count}} série` |
+| `estimatedSets_other` | `~{{count}} sets` | `~{{count}} séries` |
+| `estimatedDuration` | `~{{duration}}` | `~{{duration}}` |
+| `lastSession` | `Last: {{date}}` | `Dernier : {{date}}` |
+
+### Failure Mode Analysis
+
+| Failure | Behavior |
+|---|---|
+| `exercises` still loading | No badges shown at all (guarded by `{exercises && ...}`) — same as current behavior |
+| `lastSession` is null + idle day | No date badge, exercise count + estimated sets in outline variant, no duration badge |
+| `lastSession` is null + done day | Shouldn't happen (day can't be done without a session). Defensive: skip sets/duration badges, show exercise count only |
+| Day completed today in current cycle | `formatRelativeDate` correctly shows "Aujourd'hui"/"Today" — now accurate because `isCycleDone` guarantees it's a real session |
+| User resets a day (sets `cycle_id = NULL`) | `isCycleDone` flips to false → card switches to estimate view. Session still exists unscoped, so `lastSession` returns it for "Last: {date}" + estimated duration |
+| No active cycle at all (pre-first-session) | All days idle → all show estimated stats. `lastSession` may exist from pre-cycle history |
+| Template changed since last session (exercises added/removed) | Estimated sets reflect current template (accurate). Estimated duration reflects last session's duration (stale but reasonable). Tilde prefix signals approximation. |
+| Very old last session (6+ months) | "Last: 26 weeks ago" — wordy but correct. Could clamp to absolute date in a follow-up if needed. |

--- a/src/components/workout/WorkoutDayCard.tsx
+++ b/src/components/workout/WorkoutDayCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { CheckCircle2, Dumbbell, Layers, Timer } from "lucide-react"
 import type { WorkoutDay } from "@/types/database"
@@ -27,6 +28,11 @@ export function WorkoutDayCard({
   const heatmapData = useAggregatedMuscles(exercises ?? [])
   const { data: lastSession } = useLastSessionForDay(shouldFetch ? day.id : null)
 
+  const estimatedTotalSets = useMemo(
+    () => exercises?.reduce((sum, ex) => sum + ex.sets, 0) ?? 0,
+    [exercises],
+  )
+
   return (
     <div
       className={cn(
@@ -38,11 +44,17 @@ export function WorkoutDayCard({
     >
       {/* Header: date badge + cycle done */}
       <div className="mb-1 flex items-center justify-between">
-        {lastSession ? (
+        {isCycleDone && lastSession ? (
           <Badge variant="secondary" className="text-[11px] font-medium">
             {formatRelativeDate(lastSession.finished_at, i18n.language)}
           </Badge>
-        ) : <span />}
+        ) : !isCycleDone && lastSession ? (
+          <span className="text-[11px] text-muted-foreground">
+            {t("lastSession", { date: formatRelativeDate(lastSession.finished_at, i18n.language) })}
+          </span>
+        ) : (
+          <span />
+        )}
         {isCycleDone && (
           <CheckCircle2 className="h-5 w-5 text-emerald-500" />
         )}
@@ -69,23 +81,44 @@ export function WorkoutDayCard({
       {/* Badges row below body map */}
       <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
         {exercises && (
-          <Badge variant="secondary" className="gap-1.5">
+          <Badge
+            variant={isCycleDone ? "secondary" : "outline"}
+            className={cn(
+              "gap-1.5",
+              !isCycleDone && "text-muted-foreground",
+            )}
+          >
             <Dumbbell className="h-3 w-3" />
             {t("exerciseCount", { count: exercises.length })}
           </Badge>
         )}
-        {lastSession && (
-          <Badge variant="secondary" className="gap-1.5">
-            <Layers className="h-3 w-3" />
-            {t("setCount", { count: lastSession.total_sets_done })}
-          </Badge>
-        )}
-        {lastSession && (
-          <Badge variant="secondary" className="gap-1.5">
-            <Timer className="h-3 w-3" />
-            {formatDuration(lastSession.started_at, lastSession.finished_at)}
-          </Badge>
-        )}
+        {isCycleDone && lastSession ? (
+          <>
+            <Badge variant="secondary" className="gap-1.5">
+              <Layers className="h-3 w-3" />
+              {t("setCount", { count: lastSession.total_sets_done })}
+            </Badge>
+            <Badge variant="secondary" className="gap-1.5">
+              <Timer className="h-3 w-3" />
+              {formatDuration(lastSession.started_at, lastSession.finished_at)}
+            </Badge>
+          </>
+        ) : !isCycleDone && exercises ? (
+          <>
+            <Badge variant="outline" className="gap-1.5 text-muted-foreground">
+              <Layers className="h-3 w-3" />
+              {t("estimatedSets", { count: estimatedTotalSets })}
+            </Badge>
+            {lastSession && (
+              <Badge variant="outline" className="gap-1.5 text-muted-foreground">
+                <Timer className="h-3 w-3" />
+                {t("estimatedDuration", {
+                  duration: formatDuration(lastSession.started_at, lastSession.finished_at),
+                })}
+              </Badge>
+            )}
+          </>
+        ) : null}
       </div>
     </div>
   )

--- a/src/locales/en/workout.json
+++ b/src/locales/en/workout.json
@@ -66,5 +66,9 @@
   "startNewCycle": "Start new cycle",
   "resetDay": "Reset day",
   "resetDayConfirm": "This will mark the day as not done in the current cycle. Continue?",
-  "finishCycle": "Finish cycle"
+  "finishCycle": "Finish cycle",
+  "estimatedSets_one": "~{{count}} set",
+  "estimatedSets_other": "~{{count}} sets",
+  "estimatedDuration": "~{{duration}}",
+  "lastSession": "Last: {{date}}"
 }

--- a/src/locales/fr/workout.json
+++ b/src/locales/fr/workout.json
@@ -66,5 +66,9 @@
   "startNewCycle": "Nouveau cycle",
   "resetDay": "Réinitialiser le jour",
   "resetDayConfirm": "Le jour sera marqué comme non fait dans le cycle en cours. Continuer ?",
-  "finishCycle": "Terminer le cycle"
+  "finishCycle": "Terminer le cycle",
+  "estimatedSets_one": "~{{count}} série",
+  "estimatedSets_other": "~{{count}} séries",
+  "estimatedDuration": "~{{duration}}",
+  "lastSession": "Dernier : {{date}}"
 }


### PR DESCRIPTION
## What

- **WorkoutDayCard:** Split badges and header on `isCycleDone` — completed days show actual set count + duration (secondary badges); idle days show template-based `~N sets`, optional `~duration` from last similar session, and outline/muted styling.
- **Date label:** Relative “Today” / “Aujourd’hui” only when the day is **done in the current cycle**; otherwise muted **Last: …** when a past session exists.
- **i18n:** New keys for estimated sets/duration and `lastSession` (EN/FR).
- **Docs:** Epic brief + tech plan for #86.

## Why

Session cards were mixing **past session** data with **current plan** browsing: stats and relative dates looked like “today’s workout” even when that day wasn’t started in the cycle (#86).

## How

- No hook or schema changes — branch on existing `isCycleDone` from `WorkoutDayCarousel` / cycle progress.
- `useLastSessionForDay` unchanged; estimates use `sum(workout_exercises.sets)` and last session wall-clock duration when available.

Closes #86
