### PR TITLE
Increase emoji size in ExerciseThumbnail fallback

### DIFF
--- a/src/components/exercise/ExerciseThumbnail.tsx
+++ b/src/components/exercise/ExerciseThumbnail.tsx
@@ -16,7 +16,16 @@ export function ExerciseThumbnail({
   const [error, setError] = useState(false)
 
   if (!imageUrl || error) {
-    return <span className={cn("flex shrink-0 items-center justify-center bg-muted text-center", className)}>{emoji}</span>
+    return (
+      <span
+        className={cn(
+          "@container flex shrink-0 items-center justify-center overflow-hidden bg-muted text-center leading-none [font-size:max(1rem,min(3rem,45cqw))]",
+          className,
+        )}
+      >
+        {emoji}
+      </span>
+    )
   }
 
   return (


### PR DESCRIPTION
## What

- Increased emoji font size in `ExerciseThumbnail` fallback (when no image is available)
- Emoji now scales responsively based on thumbnail container dimensions using CSS container queries

## Why

The emoji in exercise thumbnail cards was too small and hard to see, especially in the horizontal carousel (`ExerciseStrip`) where cards are large (`aspect-[4/3] w-full`). The emoji appeared as a tiny speck in the middle of an otherwise empty card.

## How

Implemented container query-based font sizing: `font-size: max(1rem, min(3rem, 45cqw))`. This ensures:
- Minimum readable size (1rem) in small contexts like list rows (`h-7 w-7`)
- Scales up to 3rem in larger carousel cards
- Uses 45% of container width (`45cqw`) for proportional scaling
- Added `leading-none` and `overflow-hidden` for proper emoji rendering

The solution adapts to any container size without breaking existing usages across the app.
