### PR TITLE
fix(supabase): delete-account edge function JWT + errors

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -278,6 +278,10 @@ verify_jwt = false
 [functions.generate-program]
 verify_jwt = false
 
+# Gateway JWT verification rejects some valid user access tokens (e.g. ES256); validate in-function.
+[functions.delete-account]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,6 +1,5 @@
 import { corsHeaders } from "../_shared/cors.ts"
-import { decodeJwt } from "../_shared/aiQuota.ts"
-import { createServiceClient } from "../_shared/supabase.ts"
+import { createServiceClient, createUserClient } from "../_shared/supabase.ts"
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -10,43 +9,62 @@ function jsonResponse(body: unknown, status = 200) {
 }
 
 Deno.serve(async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders })
-  }
+  try {
+    if (req.method === "OPTIONS") {
+      return new Response("ok", { headers: corsHeaders })
+    }
 
-  if (req.method !== "POST") {
-    return jsonResponse({ error: "Method not allowed" }, 405)
-  }
+    if (req.method !== "POST") {
+      return jsonResponse({ error: "Method not allowed" }, 405)
+    }
 
-  const authHeader = req.headers.get("Authorization")
-  if (!authHeader?.startsWith("Bearer ")) {
-    return jsonResponse({ error: "Missing authorization header" }, 401)
-  }
+    const authHeader = req.headers.get("Authorization")
+    if (!authHeader?.startsWith("Bearer ")) {
+      return jsonResponse({ error: "Missing authorization header" }, 401)
+    }
 
-  const token = authHeader.replace("Bearer ", "")
-  const jwt = decodeJwt(token)
-  if (!jwt?.sub) {
-    return jsonResponse({ error: "Could not extract user from token" }, 401)
-  }
+    const userClient = createUserClient(authHeader)
+    const {
+      data: { user },
+      error: userErr,
+    } = await userClient.auth.getUser()
+    if (userErr || !user?.id) {
+      return jsonResponse({ error: "Invalid or expired session" }, 401)
+    }
 
-  const supabase = createServiceClient()
-  const userId = jwt.sub
+    const supabase = createServiceClient()
+    const userId = user.id
 
-  // Purge avatar files before deleting the user — once the auth row is gone the
-  // service client can still access storage, but doing it first is safer and
-  // avoids orphaned objects if the delete step fails.
-  const { data: avatarList } = await supabase.storage.from("avatars").list(userId)
-  if (avatarList?.length) {
-    const paths = avatarList.map((o) => `${userId}/${o.name}`)
-    await supabase.storage.from("avatars").remove(paths)
-  }
+    // Purge avatar files before deleting the user — once the auth row is gone the
+    // service client can still access storage, but doing it first is safer and
+    // avoids orphaned objects if the delete step fails. Never block delete on cleanup.
+    const { data: avatarList, error: listErr } = await supabase.storage
+      .from("avatars")
+      .list(userId)
+    if (listErr) {
+      console.error("delete-account avatars list error", listErr)
+    } else if (avatarList?.length) {
+      const paths = avatarList.map((o) => `${userId}/${o.name}`)
+      const { error: removeErr } = await supabase.storage.from("avatars").remove(paths)
+      if (removeErr) console.error("delete-account avatars remove error", removeErr)
+    }
 
-  const { error } = await supabase.auth.admin.deleteUser(userId)
+    const { error } = await supabase.auth.admin.deleteUser(userId)
 
-  if (error) {
-    console.error("delete-account error", error)
+    if (error) {
+      console.error("delete-account auth.admin.deleteUser error", error)
+      return jsonResponse(
+        {
+          error: "Failed to delete account",
+          details: error.message,
+        },
+        500,
+      )
+    }
+
+    return jsonResponse({ success: true })
+  } catch (e) {
+    console.error("delete-account unhandled error", e)
     return jsonResponse({ error: "Failed to delete account" }, 500)
   }
-
-  return jsonResponse({ success: true })
 })


### PR DESCRIPTION
## What

- Turn off Edge gateway `verify_jwt` for `delete-account` and validate the session with `auth.getUser()` so ES256 access tokens are accepted (fixes `Invalid JWT` before the handler runs).
- Log avatar storage list/remove failures without blocking deletion; return `details` from `auth.admin.deleteUser` on failure; catch unhandled errors.

## Why

Production was either missing the function or returning 401 from the gateway on valid user JWTs. Manual JWT payload decoding was not a substitute for Auth validation.

## How

- `supabase/config.toml`: `[functions.delete-account] verify_jwt = false`
- `delete-account/index.ts`: `createUserClient` + `getUser()`, then service client for storage + `admin.deleteUser`

Made with [Cursor](https://cursor.com)