### PR TITLE
fix(dashboard,history): workout day rollover + history calendar i18n

### DIFF
--- a/src/components/history/TrainingCalendarCard.tsx
+++ b/src/components/history/TrainingCalendarCard.tsx
@@ -1,9 +1,11 @@
 import { useMemo } from "react"
+import { enUS, fr } from "date-fns/locale"
 import { useTranslation } from "react-i18next"
 import { SessionRow } from "@/components/history/SessionRow"
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Calendar } from "@/components/ui/calendar"
 import { formatDate } from "@/lib/formatters"
+import { weekStartsOnForLanguage } from "@/lib/weekStartsOnForLanguage"
 import type { Session } from "@/types/database"
 import type { TrainingDayBucketRow } from "@/types/history"
 
@@ -27,6 +29,8 @@ export function TrainingCalendarCard({
   hasSessionsInVisibleMonth: boolean
 }) {
   const { t, i18n } = useTranslation("history")
+  const locale = i18n.language.startsWith("fr") ? fr : enUS
+  const weekStartsOn = weekStartsOnForLanguage(i18n.language)
 
   const trainingDates = useMemo(() => {
     return monthRows
@@ -55,6 +59,8 @@ export function TrainingCalendarCard({
           <div className="h-[320px] w-full max-w-sm animate-pulse rounded-md bg-muted/30" />
         ) : (
           <Calendar
+            locale={locale}
+            weekStartsOn={weekStartsOn}
             mode="single"
             month={visibleMonth}
             onMonthChange={onVisibleMonthChange}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -4,6 +4,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
 } from "lucide-react"
+import { enUS } from "date-fns/locale"
 import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
@@ -17,6 +18,7 @@ function Calendar({
   buttonVariant = "ghost",
   formatters,
   components,
+  locale = enUS,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>["variant"]
@@ -25,6 +27,7 @@ function Calendar({
 
   return (
     <DayPicker
+      locale={locale}
       showOutsideDays={showOutsideDays}
       className={cn(
         "bg-background group/calendar p-3 [--cell-size:2rem] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
@@ -35,7 +38,7 @@ function Calendar({
       captionLayout={captionLayout}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString("default", { month: "short" }),
+          date.toLocaleString(locale.code ?? "en-US", { month: "short" }),
         ...formatters,
       }}
       classNames={{

--- a/src/hooks/useAdvanceWorkoutDayOnDateRollover.test.ts
+++ b/src/hooks/useAdvanceWorkoutDayOnDateRollover.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { createElement, type ReactNode } from "react"
+import { useAdvanceWorkoutDayOnDateRollover } from "./useAdvanceWorkoutDayOnDateRollover"
+import type { SessionState } from "@/store/atoms"
+
+const DASHBOARD_EVAL_DATE_KEY = "workout-app-dashboard-eval-date"
+
+function baseSession(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    currentDayId: "day-a",
+    activeDayId: null,
+    exerciseIndex: 0,
+    setsData: {},
+    startedAt: null,
+    isActive: false,
+    totalSetsDone: 0,
+    pausedAt: null,
+    accumulatedPause: 0,
+    cycleId: null,
+    ...overrides,
+  }
+}
+
+function setupHook(props: {
+  isSessionActive: boolean
+  currentDayId: string | null
+  completedDayIds: string[]
+  nextDayId: string | null
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+  const setSession = vi.fn()
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+
+  renderHook(
+    () =>
+      useAdvanceWorkoutDayOnDateRollover({
+        ...props,
+        setSession,
+        queryClient,
+      }),
+    { wrapper },
+  )
+
+  return { setSession, invalidateSpy }
+}
+
+describe("useAdvanceWorkoutDayOnDateRollover", () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("advances currentDayId to nextDayId on first eval when viewing a completed day", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date("2025-06-02T10:00:00"))
+
+    const { setSession, invalidateSpy } = setupHook({
+      isSessionActive: false,
+      currentDayId: "day-a",
+      completedDayIds: ["day-a"],
+      nextDayId: "day-b",
+    })
+
+    expect(setSession).toHaveBeenCalledTimes(1)
+    const updater = setSession.mock.calls[0]![0] as (p: SessionState) => SessionState
+    const next = updater(baseSession({ currentDayId: "day-a", totalSetsDone: 3 }))
+    expect(next.currentDayId).toBe("day-b")
+    expect(next.exerciseIndex).toBe(0)
+    expect(next.totalSetsDone).toBe(0)
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["last-session-for-day"] })
+    expect(sessionStorage.getItem(DASHBOARD_EVAL_DATE_KEY)).toBe("2025-06-02")
+  })
+
+  it("does not advance when session is active", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date("2025-06-02T10:00:00"))
+
+    const { setSession } = setupHook({
+      isSessionActive: true,
+      currentDayId: "day-a",
+      completedDayIds: ["day-a"],
+      nextDayId: "day-b",
+    })
+
+    expect(setSession).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem(DASHBOARD_EVAL_DATE_KEY)).toBeNull()
+  })
+
+  it("does not advance when current day is not completed in the cycle", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date("2025-06-02T10:00:00"))
+
+    const { setSession } = setupHook({
+      isSessionActive: false,
+      currentDayId: "day-b",
+      completedDayIds: ["day-a"],
+      nextDayId: "day-b",
+    })
+
+    expect(setSession).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem(DASHBOARD_EVAL_DATE_KEY)).toBe("2025-06-02")
+  })
+
+  it("does not advance again on the same calendar day (sessionStorage gate)", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date("2025-06-02T10:00:00"))
+
+    sessionStorage.setItem(DASHBOARD_EVAL_DATE_KEY, "2025-06-02")
+
+    const { setSession } = setupHook({
+      isSessionActive: false,
+      currentDayId: "day-a",
+      completedDayIds: ["day-a"],
+      nextDayId: "day-b",
+    })
+
+    expect(setSession).not.toHaveBeenCalled()
+  })
+
+  it("advances after the calendar day changes (interval tick)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date("2025-06-02T23:00:00"))
+
+    const { setSession, invalidateSpy } = setupHook({
+      isSessionActive: false,
+      currentDayId: "day-a",
+      completedDayIds: ["day-a"],
+      nextDayId: "day-b",
+    })
+
+    setSession.mockClear()
+    invalidateSpy.mockClear()
+
+    vi.setSystemTime(new Date("2025-06-03T08:00:00"))
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    expect(setSession).toHaveBeenCalledTimes(1)
+    const updater = setSession.mock.calls[0]![0] as (p: SessionState) => SessionState
+    expect(updater(baseSession({ currentDayId: "day-a" })).currentDayId).toBe("day-b")
+    expect(sessionStorage.getItem(DASHBOARD_EVAL_DATE_KEY)).toBe("2025-06-03")
+  })
+})

--- a/src/hooks/useAdvanceWorkoutDayOnDateRollover.ts
+++ b/src/hooks/useAdvanceWorkoutDayOnDateRollover.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef } from "react"
+import type { QueryClient } from "@tanstack/react-query"
+import type { SetStateAction } from "react"
+import { format } from "date-fns"
+import type { SessionState } from "@/store/atoms"
+
+const DASHBOARD_EVAL_DATE_KEY = "workout-app-dashboard-eval-date"
+
+/**
+ * When the local calendar day changes, if the user is still parked on a workout day
+ * already completed in the current cycle, advance selection to the next incomplete day.
+ * Fixes stale dashboard state after midnight (persisted `currentDayId` in localStorage).
+ */
+export function useAdvanceWorkoutDayOnDateRollover({
+  isSessionActive,
+  currentDayId,
+  completedDayIds,
+  nextDayId,
+  setSession,
+  queryClient,
+}: {
+  isSessionActive: boolean
+  currentDayId: string | null
+  completedDayIds: string[]
+  nextDayId: string | null
+  setSession: (value: SetStateAction<SessionState>) => void
+  queryClient: QueryClient
+}) {
+  const tryAdvance = useCallback(() => {
+    if (isSessionActive) return
+
+    const today = format(new Date(), "yyyy-MM-dd")
+    const lastEval = sessionStorage.getItem(DASHBOARD_EVAL_DATE_KEY)
+    if (lastEval === today) return
+    sessionStorage.setItem(DASHBOARD_EVAL_DATE_KEY, today)
+
+    if (!currentDayId || !nextDayId) return
+    if (!completedDayIds.includes(currentDayId)) return
+    if (currentDayId === nextDayId) return
+
+    setSession((prev: SessionState) => ({
+      ...prev,
+      currentDayId: nextDayId,
+      exerciseIndex: 0,
+      totalSetsDone: 0,
+    }))
+    queryClient.invalidateQueries({ queryKey: ["last-session-for-day"] })
+  }, [
+    completedDayIds,
+    currentDayId,
+    isSessionActive,
+    nextDayId,
+    queryClient,
+    setSession,
+  ])
+
+  useEffect(() => {
+    tryAdvance()
+  }, [tryAdvance])
+
+  const calendarDayRef = useRef(format(new Date(), "yyyy-MM-dd"))
+  useEffect(() => {
+    const tick = () => {
+      const d = format(new Date(), "yyyy-MM-dd")
+      if (d !== calendarDayRef.current) {
+        calendarDayRef.current = d
+        sessionStorage.removeItem(DASHBOARD_EVAL_DATE_KEY)
+        tryAdvance()
+      }
+    }
+    const id = setInterval(tick, 60_000)
+    const onVisible = () => {
+      if (document.visibilityState === "visible") tick()
+    }
+    window.addEventListener("focus", tick)
+    document.addEventListener("visibilitychange", onVisible)
+    return () => {
+      clearInterval(id)
+      window.removeEventListener("focus", tick)
+      document.removeEventListener("visibilitychange", onVisible)
+    }
+  }, [tryAdvance])
+}

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -51,6 +51,7 @@ import { canStartPreSession } from "@/lib/canStartPreSession"
 import { fetchLastWeightsForExerciseIds } from "@/lib/lastWeightsFromSetLogs"
 import { WorkoutDayCarousel } from "@/components/workout/WorkoutDayCarousel"
 import { CycleProgressHeader } from "@/components/workout/CycleProgressHeader"
+import { useAdvanceWorkoutDayOnDateRollover } from "@/hooks/useAdvanceWorkoutDayOnDateRollover"
 import { useCycleProgress } from "@/hooks/useCycle"
 import { ExerciseStrip } from "@/components/workout/ExerciseStrip"
 import { ExerciseDetail } from "@/components/workout/ExerciseDetail"
@@ -159,6 +160,14 @@ export function WorkoutPage() {
   const { data: activeCycle } = useActiveCycle(activeProgramId)
   const { data: days, isLoading: daysLoading } = useWorkoutDays(activeProgramId)
   const cycleProgress = useCycleProgress(activeCycle?.id ?? null, days ?? [])
+  useAdvanceWorkoutDayOnDateRollover({
+    isSessionActive: session.isActive,
+    currentDayId: session.currentDayId,
+    completedDayIds: cycleProgress.completedDayIds,
+    nextDayId: cycleProgress.nextDayId,
+    setSession,
+    queryClient,
+  })
   const [finished, setFinished] = useState(false)
   const [finishedQuickInfo, setFinishedQuickInfo] = useState<{
     dayId: string


### PR DESCRIPTION
## What

- **Dashboard (#125):** When a new local calendar day starts, if the user is not in an active workout and is still viewing a cycle day that is already completed, advance `currentDayId` to the next incomplete day (persisted selection no longer stuck after midnight).
- **History (#126):** Activity calendar uses the app i18n locale (`date-fns` `fr` / `enUS`) and week start via `weekStartsOnForLanguage` (e.g. Monday for French). Shared `Calendar` month dropdown uses `locale.code` instead of `"default"`.
- **Tests:** Vitest coverage for `useAdvanceWorkoutDayOnDateRollover` (first eval, guards, day change via interval).

## Why

- [#125](https://github.com/PierreTsia/workout-app/issues/125): Workout card stayed on the previous day after the date rolled over because `currentDayId` lives in localStorage without a day-boundary refresh.
- [#126](https://github.com/PierreTsia/workout-app/issues/126): History calendar ignored locale (English weekday abbreviations and Sunday-first week).

## How

- New hook `useAdvanceWorkoutDayOnDateRollover`: one evaluation per calendar day (`sessionStorage`), invalidates `last-session-for-day` on advance; listens for focus, visibility, and a 60s tick to catch midnight while the app stays open.
- `TrainingCalendarCard` passes `locale` and `weekStartsOn` to `Calendar`; `calendar.tsx` defaults to `enUS` and formats month labels with the active locale.

Closes #125
Closes #126

Made with [Cursor](https://cursor.com)