### PR TITLE
fix(workout): calendar relative dates + last-session badge copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "TZ=UTC vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "supabase:start": "supabase start",

--- a/src/components/workout/WorkoutDayCard.test.ts
+++ b/src/components/workout/WorkoutDayCard.test.ts
@@ -10,6 +10,13 @@ describe("formatRelativeDate", () => {
     expect(formatRelativeDate("2026-03-20T10:00:00Z", "en")).toBe("Today")
   })
 
+  it('returns "Yesterday" when the session was under 24h ago but on the previous calendar day', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-03-24T09:57:00Z"))
+    expect(formatRelativeDate("2026-03-23T21:30:00Z", "en")).toBe("Yesterday")
+    expect(formatRelativeDate("2026-03-23T21:30:00Z", "fr")).toBe("Hier")
+  })
+
   it('returns "Yesterday" for a timestamp from one day ago', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-03-20T18:00:00Z"))

--- a/src/components/workout/WorkoutDayCard.tsx
+++ b/src/components/workout/WorkoutDayCard.tsx
@@ -33,6 +33,12 @@ export function WorkoutDayCard({
     [exercises],
   )
 
+  const lastSessionDateLabel = lastSession
+    ? t("lastSession", {
+        date: formatRelativeDate(lastSession.finished_at, i18n.language),
+      })
+    : null
+
   return (
     <div
       className={cn(
@@ -44,13 +50,13 @@ export function WorkoutDayCard({
     >
       {/* Header: date badge + cycle done */}
       <div className="mb-1 flex items-center justify-between">
-        {isCycleDone && lastSession ? (
+        {isCycleDone && lastSessionDateLabel ? (
           <Badge variant="secondary" className="text-[11px] font-medium">
-            {formatRelativeDate(lastSession.finished_at, i18n.language)}
+            {lastSessionDateLabel}
           </Badge>
-        ) : !isCycleDone && lastSession ? (
+        ) : !isCycleDone && lastSessionDateLabel ? (
           <span className="text-[11px] text-muted-foreground">
-            {t("lastSession", { date: formatRelativeDate(lastSession.finished_at, i18n.language) })}
+            {lastSessionDateLabel}
           </span>
         ) : (
           <span />

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -41,11 +41,24 @@ function getRelativeFormatter(locale: string): Intl.RelativeTimeFormat {
   return fmt
 }
 
+/**
+ * Calendar-day distance from `then` to `now` in the user's local timezone
+ * (0 = same local calendar day). Not the same as floor(elapsed ms / 24h), which
+ * mislabels "yesterday evening" as "today" when fewer than 24h have passed.
+ */
+function diffLocalCalendarDays(now: Date, then: Date): number {
+  const startThen = new Date(then.getFullYear(), then.getMonth(), then.getDate())
+  const startNow = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  return Math.round((startNow.getTime() - startThen.getTime()) / 86_400_000)
+}
+
 export function formatRelativeDate(iso: string, locale = "en"): string {
-  const diff = Date.now() - new Date(iso).getTime()
-  const days = Math.floor(diff / 86_400_000)
+  const then = new Date(iso)
+  const now = new Date()
+  const days = Math.max(0, diffLocalCalendarDays(now, then))
   const fmt = getRelativeFormatter(locale)
-  const raw = days < 7 ? fmt.format(-days, "day") : fmt.format(-Math.floor(days / 7), "week")
+  const raw =
+    days < 7 ? fmt.format(-days, "day") : fmt.format(-Math.floor(days / 7), "week")
   return raw.charAt(0).toUpperCase() + raw.slice(1)
 }
 


### PR DESCRIPTION
## What

- `formatRelativeDate` uses local **calendar** day distance instead of `floor(elapsed ms / 24h)`, so a session from yesterday evening shows as Yesterday/Hier even when it was less than 24 hours ago.
- `WorkoutDayCard` shows the same **Last/Dernier : …** label when the cycle is complete as when it is not, so the date clearly refers to the last session for that program day (not “any” workout).
- Unit tests run with `TZ=UTC` for stable expectations; regression test for yesterday evening while still under 24 hours elapsed.

## Why

Wall-clock “24h buckets” mislabeled sessions as “today” across midnight. Separately, the badge showed only the bare relative word when the cycle was done, which was easy to misread next to quick workouts or other sessions.

## How

- `diffLocalCalendarDays` compares local date midnights, then feeds existing `Intl.RelativeTimeFormat` logic.
- Shared `lastSessionDateLabel` string for both cycle-done (badge) and in-progress (muted) rows.

Made with [Cursor](https://cursor.com)