### PR TITLE
refactor: replace imperative for-loops with functional array pipelines

### DIFF
--- a/src/components/admin/feedback-table/FeedbackDetailRow.tsx
+++ b/src/components/admin/feedback-table/FeedbackDetailRow.tsx
@@ -10,17 +10,12 @@ function parseErrorDetails(
   errorDetails: Record<string, string[]>,
   t: (key: string) => string,
 ): { field: string; options: string[] }[] {
-  const entries: { field: string; options: string[] }[] = []
-
-  for (const [field, options] of Object.entries(errorDetails)) {
-    if (!Array.isArray(options)) continue
-    entries.push({
+  return Object.entries(errorDetails)
+    .filter((entry): entry is [string, string[]] => Array.isArray(entry[1]))
+    .map(([field, options]) => ({
       field: t(`feedback.fields.${field}`),
       options: options.map((opt) => t(`feedback.errorOptions.${opt}`)),
-    })
-  }
-
-  return entries
+    }))
 }
 
 export function FeedbackDetailRow({ feedback }: FeedbackDetailRowProps) {

--- a/src/components/generator/ExerciseAddPicker.tsx
+++ b/src/components/generator/ExerciseAddPicker.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Search } from "lucide-react"
-import { cn } from "@/lib/utils"
+import { cn, groupBy } from "@/lib/utils"
 import { normalizeForSearch } from "@/lib/search"
 import { Input } from "@/components/ui/input"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
@@ -36,15 +36,10 @@ export function ExerciseAddPicker({
     )
   }, [pool, currentExerciseIds, search])
 
-  const grouped = useMemo(() => {
-    const map = new Map<string, Exercise[]>()
-    for (const ex of candidates) {
-      const list = map.get(ex.muscle_group) ?? []
-      list.push(ex)
-      map.set(ex.muscle_group, list)
-    }
-    return map
-  }, [candidates])
+  const grouped = useMemo(
+    () => groupBy(candidates, (ex) => ex.muscle_group),
+    [candidates],
+  )
 
   return (
     <div className="flex flex-col gap-2 rounded-lg border bg-card p-3">

--- a/src/components/history/SessionRow.tsx
+++ b/src/components/history/SessionRow.tsx
@@ -11,18 +11,15 @@ import { formatSessionRowDuration } from "@/lib/sessionRowDuration"
 import type { Session, SetLog } from "@/types/database"
 
 function groupByExercise(logs: SetLog[]) {
-  const groups: { name: string; sets: SetLog[] }[] = []
-  let current: { name: string; sets: SetLog[] } | null = null
-
-  for (const log of logs) {
-    if (!current || current.name !== log.exercise_name_snapshot) {
-      current = { name: log.exercise_name_snapshot, sets: [] }
-      groups.push(current)
+  return logs.reduce<{ name: string; sets: SetLog[] }[]>((groups, log) => {
+    const last = groups.at(-1)
+    if (last && last.name === log.exercise_name_snapshot) {
+      last.sets.push(log)
+    } else {
+      groups.push({ name: log.exercise_name_snapshot, sets: [log] })
     }
-    current.sets.push(log)
-  }
-
-  return groups
+    return groups
+  }, [])
 }
 
 function SessionSetLogs({ sessionId }: { sessionId: string }) {

--- a/src/components/history/heatmap-calendar.tsx
+++ b/src/components/history/heatmap-calendar.tsx
@@ -210,9 +210,8 @@ export function HeatmapCalendar({
     const totalDays = Math.ceil((end.getTime() - firstWeek.getTime()) / 86400000) + 1
     const weeks = Math.ceil(totalDays / 7)
 
-    const cells: HeatmapCell[] = []
-    for (let w = 0; w < weeks; w++) {
-      for (let d = 0; d < 7; d++) {
+    return Array.from({ length: weeks }, (_, w) =>
+      Array.from({ length: 7 }, (_, d) => {
         const date = addDays(firstWeek, w * 7 + d)
         const inRange = date >= start && date <= end
         const key = toLocalDayKey(date)
@@ -221,7 +220,7 @@ export function HeatmapCalendar({
         const meta = inRange ? valueMap.get(key)?.meta : undefined
         const lvl = inRange ? levelForValue(v) : 0
 
-        cells.push({
+        return {
           date,
           key,
           value: v,
@@ -233,15 +232,9 @@ export function HeatmapCalendar({
             month: "short",
             day: "numeric",
           }),
-        })
-      }
-    }
-
-    const cols: HeatmapCell[][] = []
-    for (let i = 0; i < weeks; i++) {
-      cols.push(cells.slice(i * 7, i * 7 + 7))
-    }
-    return cols
+        }
+      }),
+    )
   }, [valueMap, endDate, rangeDays, weekStartsOn, levelCount, levelForValue])
 
   const monthLabels = React.useMemo(() => {

--- a/src/components/workout/SetsTable.tsx
+++ b/src/components/workout/SetsTable.tsx
@@ -138,22 +138,23 @@ export function SetsTable({
           return prev
         }
 
-        const updated: SessionSetRow[] = exerciseSets.map((r) => {
+        const mapped: SessionSetRow[] = exerciseSets.map((r) => {
           if (!isDurationRow(r) || r.done) return r
           return { ...r, targetSeconds: sugDuration, weight: sugWeight }
         })
 
-        if (suggestion.sets > updated.length) {
-          for (let i = updated.length; i < suggestion.sets; i++) {
-            updated.push({
+        const updated = mapped.concat(
+          Array.from(
+            { length: Math.max(0, suggestion.sets - mapped.length) },
+            (): SessionSetRow => ({
               kind: "duration" as const,
               targetSeconds: sugDuration,
               weight: sugWeight,
               done: false,
               timerStartedAt: null,
-            })
-          }
-        }
+            }),
+          ),
+        )
 
         appliedProgressionRef.current = key
         return {
@@ -173,21 +174,22 @@ export function SetsTable({
         return prev
       }
 
-      const updated: SessionSetRow[] = exerciseSets.map((r) => {
+      const mapped: SessionSetRow[] = exerciseSets.map((r) => {
         if (!isRepsRow(r) || r.done) return r
         return { ...r, reps: sugReps, weight: sugWeight }
       })
 
-      if (suggestion.sets > updated.length) {
-        for (let i = updated.length; i < suggestion.sets; i++) {
-          updated.push({
+      const updated = mapped.concat(
+        Array.from(
+          { length: Math.max(0, suggestion.sets - mapped.length) },
+          (): SessionSetRow => ({
             kind: "reps" as const,
             reps: sugReps,
             weight: sugWeight,
             done: false,
-          })
-        }
-      }
+          }),
+        ),
+      )
 
       appliedProgressionRef.current = key
       return {

--- a/src/components/workout/SwapExerciseSheet.tsx
+++ b/src/components/workout/SwapExerciseSheet.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
+import { groupBy } from "@/lib/utils"
 import { useTranslation } from "react-i18next"
 import { Info, Loader2, RefreshCw, Search, SlidersHorizontal } from "lucide-react"
 import { useExerciseLibraryPaginated } from "@/hooks/useExerciseLibraryPaginated"
@@ -87,16 +88,14 @@ export function SwapExerciseSheet({
 
   const excludeSet = useMemo(() => new Set(currentExerciseIds), [currentExerciseIds])
 
-  const grouped = useMemo(() => {
-    const map = new Map<string, Exercise[]>()
-    for (const ex of paginatedData ?? []) {
-      if (excludeSet.has(ex.id)) continue
-      const list = map.get(ex.muscle_group) ?? []
-      list.push(ex)
-      map.set(ex.muscle_group, list)
-    }
-    return map
-  }, [paginatedData, excludeSet])
+  const grouped = useMemo(
+    () =>
+      groupBy(
+        (paginatedData ?? []).filter((ex) => !excludeSet.has(ex.id)),
+        (ex) => ex.muscle_group,
+      ),
+    [paginatedData, excludeSet],
+  )
 
   const activeFilterCount =
     (selectedMuscleGroup ? 1 : 0) + selectedEquipment.length + selectedDifficulty.length

--- a/src/lib/deriveEquipmentContexts.ts
+++ b/src/lib/deriveEquipmentContexts.ts
@@ -6,10 +6,8 @@ export function deriveEquipmentContexts(
   template: ProgramTemplate,
   alternatives: ExerciseAlternative[],
 ): UserEquipment[] {
-  const contexts: UserEquipment[] = ["gym"]
-
-  for (const ctx of ["home", "minimal"] as const) {
-    const allCovered = template.template_days.every((day) =>
+  const extra = (["home", "minimal"] as const).filter((ctx) =>
+    template.template_days.every((day) =>
       day.template_exercises.every((te) => {
         const eq = te.exercise?.equipment?.toLowerCase() ?? ""
         if (BODYWEIGHT_EQUIPMENT.includes(eq)) return true
@@ -17,9 +15,7 @@ export function deriveEquipmentContexts(
           (a) => a.exercise_id === te.exercise_id && a.equipment_context === ctx,
         )
       }),
-    )
-    if (allCovered) contexts.push(ctx)
-  }
-
-  return contexts
+    ),
+  )
+  return ["gym", ...extra]
 }

--- a/src/lib/exerciseHistorySheet.ts
+++ b/src/lib/exerciseHistorySheet.ts
@@ -87,23 +87,18 @@ function parseSession(raw: unknown): ExerciseHistorySessionRow | null {
   if (typeof session_id !== "string") return null
   if (typeof finished_at !== "string") return null
   if (!Array.isArray(setsRaw)) return null
-  const sets: ExerciseHistorySetRow[] = []
-  for (const s of setsRaw) {
-    const row = parseSet(s)
-    if (row) sets.push(row)
-  }
+  const sets = setsRaw
+    .map(parseSet)
+    .filter((r): r is ExerciseHistorySetRow => r !== null)
   return { session_id, finished_at, sets }
 }
 
 /** Parses RPC jsonb result from get_exercise_history_for_sheet. */
 export function parseExerciseHistorySheetPayload(data: unknown): ExerciseHistorySessionRow[] {
   if (!Array.isArray(data)) return []
-  const out: ExerciseHistorySessionRow[] = []
-  for (const row of data) {
-    const s = parseSession(row)
-    if (s) out.push(s)
-  }
-  return out
+  return data
+    .map(parseSession)
+    .filter((s): s is ExerciseHistorySessionRow => s !== null)
 }
 
 /** Estimated 1RM (kg) for one logged set — prefers stored value, else Epley from weight × reps. */

--- a/src/lib/generateWorkout.ts
+++ b/src/lib/generateWorkout.ts
@@ -1,4 +1,5 @@
 import type { Exercise } from "@/types/database"
+import { groupBy } from "@/lib/utils"
 import type {
   GeneratorConstraints,
   GeneratedWorkout,
@@ -55,25 +56,19 @@ function pickDistributed(
   targetCount: number,
   groups: readonly string[],
 ): Exercise[] {
-  const byGroup = new Map<string, Exercise[]>()
-  for (const ex of pool) {
-    const list = byGroup.get(ex.muscle_group) ?? []
-    list.push(ex)
-    byGroup.set(ex.muscle_group, list)
-  }
+  const byGroup = groupBy(pool, (ex) => ex.muscle_group)
 
   const availableGroups = groups.filter((g) => byGroup.has(g))
   if (availableGroups.length === 0) return pickWithVariety(pool, targetCount)
 
   const perGroup = Math.max(1, Math.floor(targetCount / availableGroups.length))
   const remainder = targetCount - perGroup * availableGroups.length
-  const picked: Exercise[] = []
 
-  for (let i = 0; i < availableGroups.length; i++) {
-    const groupPool = shuffleArray(byGroup.get(availableGroups[i]) ?? [])
+  const picked = availableGroups.flatMap((group, i) => {
+    const groupPool = shuffleArray(byGroup.get(group) ?? [])
     const take = perGroup + (i < remainder ? 1 : 0)
-    picked.push(...groupPool.slice(0, take))
-  }
+    return groupPool.slice(0, take)
+  })
 
   if (picked.length < targetCount) {
     const pickedIds = new Set(picked.map((e) => e.id))

--- a/src/lib/mergeWorkoutExercises.ts
+++ b/src/lib/mergeWorkoutExercises.ts
@@ -5,12 +5,10 @@ export function mergeWorkoutExercises(
   base: WorkoutExercise[],
   patch: PreSessionExercisePatch,
 ): WorkoutExercise[] {
-  const out: WorkoutExercise[] = []
-  for (const row of base) {
-    if (patch.deletedIds.has(row.id)) continue
-    out.push(patch.swappedRows.get(row.id) ?? row)
-  }
-  out.push(...patch.addedRows)
-  out.sort((a, b) => a.sort_order - b.sort_order)
-  return out
+  return [
+    ...base
+      .filter((row) => !patch.deletedIds.has(row.id))
+      .map((row) => patch.swappedRows.get(row.id) ?? row),
+    ...patch.addedRows,
+  ].sort((a, b) => a.sort_order - b.sort_order)
 }

--- a/src/lib/muscleMapping.ts
+++ b/src/lib/muscleMapping.ts
@@ -66,17 +66,11 @@ export function buildBodyMapData(
     }
   }
 
-  const result: IExerciseData[] = []
-  for (const [slug, freq] of frequencyBySlug) {
-    const names = exercisesBySlug.get(slug)!
-    result.push({
-      name: [...names].join(", "),
-      muscles: [slug as Muscle],
-      frequency: freq,
-    })
-  }
-
-  return result
+  return [...frequencyBySlug].map(([slug, freq]) => ({
+    name: [...exercisesBySlug.get(slug)!].join(", "),
+    muscles: [slug as Muscle],
+    frequency: freq,
+  }))
 }
 
 /**
@@ -88,21 +82,16 @@ export function buildSingleExerciseData(
   muscleGroup: string,
   secondaryMuscles?: string[] | null,
 ): IExerciseData[] {
-  const data: IExerciseData[] = []
-
   const primarySlugs = mapMuscleToSlugs(muscleGroup)
-  if (primarySlugs.length > 0) {
-    data.push({ name: muscleGroup, muscles: primarySlugs, frequency: 2 })
-  }
+  const primary: IExerciseData[] =
+    primarySlugs.length > 0
+      ? [{ name: muscleGroup, muscles: primarySlugs, frequency: 2 }]
+      : []
 
-  if (secondaryMuscles) {
-    for (const sec of secondaryMuscles) {
-      const slugs = mapMuscleToSlugs(sec)
-      if (slugs.length > 0) {
-        data.push({ name: sec, muscles: slugs, frequency: 1 })
-      }
-    }
-  }
+  const secondary: IExerciseData[] = (secondaryMuscles ?? [])
+    .map((sec) => ({ name: sec, muscles: mapMuscleToSlugs(sec) }))
+    .filter(({ muscles }) => muscles.length > 0)
+    .map(({ name, muscles }) => ({ name, muscles, frequency: 1 }))
 
-  return data
+  return [...primary, ...secondary]
 }

--- a/src/lib/sessionSummary.ts
+++ b/src/lib/sessionSummary.ts
@@ -1,4 +1,5 @@
 import { formatSecondsMMSS } from "@/lib/formatters"
+import { groupBy } from "@/lib/utils"
 import type { SetLog, WorkoutExercise } from "@/types/database"
 
 function setLogDisplayValue(log: SetLog): string {
@@ -60,36 +61,19 @@ export function summarizeSessionLogs(
   logs: SetLog[],
   templateExercises: WorkoutExercise[],
 ): ExercisePreviewItem[] {
-  const grouped = new Map<
-    string,
-    {
-      name: string
-      reps: string[]
-      maxWeight: number
-      /** True if any set for this exercise was logged as duration (not reps). */
-      hasDuration: boolean
-    }
-  >()
+  const logsByExercise = groupBy(logs, (log) => log.exercise_id)
 
-  for (const log of logs) {
-    let entry = grouped.get(log.exercise_id)
-    if (!entry) {
-      entry = {
-        name: log.exercise_name_snapshot,
-        reps: [],
-        maxWeight: 0,
-        hasDuration: false,
-      }
-      grouped.set(log.exercise_id, entry)
-    }
-    if (log.duration_seconds != null) {
-      entry.hasDuration = true
-    }
-    entry.reps.push(setLogDisplayValue(log))
-    if (log.weight_logged > entry.maxWeight) {
-      entry.maxWeight = log.weight_logged
-    }
-  }
+  const grouped = new Map(
+    [...logsByExercise].map(([exerciseId, exerciseLogs]) => [
+      exerciseId,
+      {
+        name: exerciseLogs[0].exercise_name_snapshot,
+        reps: exerciseLogs.map(setLogDisplayValue),
+        maxWeight: Math.max(...exerciseLogs.map((l) => l.weight_logged)),
+        hasDuration: exerciseLogs.some((l) => l.duration_seconds != null),
+      },
+    ]),
+  )
 
   const emojiByExerciseId = new Map<string, string>()
   const orderByExerciseId = new Map<string, number>()
@@ -98,22 +82,19 @@ export function summarizeSessionLogs(
     orderByExerciseId.set(ex.exercise_id, ex.sort_order)
   }
 
-  const items: ExercisePreviewItem[] = []
-  for (const [exerciseId, entry] of grouped) {
-    const repsLabel = repsRangeLabel(
-      entry.reps,
-      entry.hasDuration ? "duration" : "reps",
-    )
-
-    items.push({
+  const items: ExercisePreviewItem[] = [...grouped].map(
+    ([exerciseId, entry]) => ({
       id: exerciseId,
       emoji: emojiByExerciseId.get(exerciseId) ?? "🏋️",
       name: entry.name,
       sets: entry.reps.length,
-      reps: repsLabel,
+      reps: repsRangeLabel(
+        entry.reps,
+        entry.hasDuration ? "duration" : "reps",
+      ),
       maxWeight: entry.maxWeight,
-    })
-  }
+    }),
+  )
 
   items.sort(
     (a, b) =>

--- a/src/lib/syncService.ts
+++ b/src/lib/syncService.ts
@@ -1,4 +1,5 @@
 import { getDefaultStore } from "jotai"
+import { groupBy } from "@/lib/utils"
 import { supabase } from "@/lib/supabase"
 import { queryClient } from "@/lib/queryClient"
 import {
@@ -309,13 +310,7 @@ export async function drainQueue(userId: string): Promise<void> {
   const exerciseIds = new Set<string>()
   const ensuredSessions = new Set<string>()
 
-  // Group by realSessionId to ensure session rows exist before set_logs
-  const sessionGroups = new Map<string, QueueItem[]>()
-  for (const item of queue) {
-    const group = sessionGroups.get(item.realSessionId) ?? []
-    group.push(item)
-    sessionGroups.set(item.realSessionId, group)
-  }
+  const sessionGroups = groupBy(queue, (item) => item.realSessionId)
 
   const surviving: QueueItem[] = []
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/** Groups items by a key function into a Map of arrays. */
+export function groupBy<T, K>(items: T[], keyFn: (item: T) => K): Map<K, T[]> {
+  return items.reduce((map, item) => {
+    const key = keyFn(item)
+    const list = map.get(key) ?? []
+    list.push(item)
+    map.set(key, list)
+    return map
+  }, new Map<K, T[]>())
+}


### PR DESCRIPTION
## What

- Extracted a shared `groupBy<T, K>` utility to `src/lib/utils.ts`
- Refactored 12 imperative for-push loops into declarative `.filter()`, `.map()`, `.flatMap()`, `.reduce()`, `Array.from()`, and `.concat()` pipelines across 11 files
- Migrated 6 manual map-accumulate grouping patterns to use the new `groupBy` helper (or `.reduce()` for the run-length case in `SessionRow`)

## Why

The codebase rule `prefer-functional-style.mdc` prescribes declarative pipelines over mutable-array for-loops. A codebase audit found 24 occurrences — this PR addresses the 18 actionable ones (12 easy wins + 6 grouping patterns), leaving 4 intentionally untouched (state machines, async side-effect loops).

Net result: **-59 lines**, 14 files touched, zero test changes needed.

## How

- **`groupBy` helper**: generic `(items, keyFn) → Map<K, T[]>` using `.reduce()` — covers the 4 identical group-by-property patterns in `generateWorkout`, `SwapExerciseSheet`, `ExerciseAddPicker`, and `syncService`
- **Run-length grouping** (`SessionRow`): converted to `.reduce()` inline since consecutive-key grouping is a distinct algorithm from standard `groupBy`
- **Accumulation grouping** (`sessionSummary`): split into `groupBy` + `.map()` transform to separate grouping from aggregation
- **Set extension** (`SetsTable`): replaced mutating `.push()` in for-loops with `.concat(Array.from())`
- **Nested grid construction** (`heatmap-calendar`): replaced two for-loops (cells + slicing) with a single `Array.from()` that directly produces the 2D column structure

Closes #162

Made with [Cursor](https://cursor.com)