### PR TITLE
fix: resolve stack overflow on WorkoutPage for mobile iOS

### DIFF
--- a/src/components/workout/WorkoutDayCarousel.tsx
+++ b/src/components/workout/WorkoutDayCarousel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useAtom } from "jotai"
 import { sessionAtom } from "@/store/atoms"
 import type { WorkoutDay } from "@/types/database"
@@ -26,6 +26,7 @@ export function WorkoutDayCarousel({
 
   const selectedDayId = session.currentDayId
   const completedSet = new Set(completedDayIds)
+  const carouselOpts = useMemo(() => ({ align: "start" as const, containScroll: false as const }), [])
 
   // Validate currentDayId on mount / when days change — reset if stale
   useEffect(() => {
@@ -83,7 +84,7 @@ export function WorkoutDayCarousel({
     <div className="space-y-3">
       <Carousel
         setApi={setApi}
-        opts={{ align: "start", containScroll: false }}
+        opts={carouselOpts}
         className="px-4"
       >
         <CarouselContent className="-ml-3">

--- a/src/pages/CycleSummaryPage.tsx
+++ b/src/pages/CycleSummaryPage.tsx
@@ -20,7 +20,9 @@ import { useWorkoutDays } from "@/hooks/useWorkoutDays"
 import { formatDate, formatDurationMs } from "@/lib/formatters"
 import { StatCard } from "@/components/cycle-summary/StatCard"
 import { Button } from "@/components/ui/button"
-import type { Cycle } from "@/types/database"
+import type { Cycle, WorkoutDay } from "@/types/database"
+
+const EMPTY_DAYS: WorkoutDay[] = []
 
 export function CycleSummaryPage() {
   const { cycleId } = useParams<{ cycleId: string }>()
@@ -50,7 +52,7 @@ export function CycleSummaryPage() {
     previousCycle?.id,
   )
   const { data: days } = useWorkoutDays(programId)
-  const cycleProgress = useCycleProgress(cycleId ?? null, days ?? [])
+  const cycleProgress = useCycleProgress(cycleId ?? null, days ?? EMPTY_DAYS)
 
   const isLoading = cycleLoading || statsLoading
 

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -93,7 +93,9 @@ import {
   clonePreSessionPatch,
   type PreSessionExercisePatch,
 } from "@/types/preSessionOverrides"
-import type { Exercise, WorkoutExercise } from "@/types/database"
+import type { Exercise, WorkoutDay, WorkoutExercise } from "@/types/database"
+
+const EMPTY_DAYS: WorkoutDay[] = []
 
 function templateWeightKgToString(kg: number): string {
   if (!kg || kg <= 0) return "0"
@@ -172,7 +174,7 @@ export function WorkoutPage() {
   const queryClient = useQueryClient()
   const { data: activeCycle } = useActiveCycle(activeProgramId)
   const { data: days, isLoading: daysLoading } = useWorkoutDays(activeProgramId)
-  const cycleProgress = useCycleProgress(activeCycle?.id ?? null, days ?? [])
+  const cycleProgress = useCycleProgress(activeCycle?.id ?? null, days ?? EMPTY_DAYS)
   useAdvanceWorkoutDayOnDateRollover({
     isSessionActive: session.isActive,
     currentDayId: session.currentDayId,
@@ -552,50 +554,47 @@ export function WorkoutPage() {
   useEffect(() => {
     if (exercises.length === 0) return
 
-    let hasChanges = false
-    const patch: Record<string, SessionSetRow[]> = {}
+    setSession((prev) => {
+      let hasChanges = false
+      const patch: Record<string, SessionSetRow[]> = {}
 
-    for (const ex of exercises) {
-      const existing = session.setsData[ex.id]
-      const storedWeight = Number(ex.weight)
-      const historyWeight = lastWeights[ex.exercise_id] ?? 0
-      const effectiveWeightKg =
-        storedWeight > 0 ? storedWeight : historyWeight
-      const lib = exerciseById.get(ex.exercise_id)
+      for (const ex of exercises) {
+        const existing = prev.setsData[ex.id]
+        const storedWeight = Number(ex.weight)
+        const historyWeight = lastWeights[ex.exercise_id] ?? 0
+        const effectiveWeightKg =
+          storedWeight > 0 ? storedWeight : historyWeight
+        const lib = exerciseById.get(ex.exercise_id)
 
-      if (!existing) {
-        const displayWeight = String(
-          Math.round(toDisplay(effectiveWeightKg) * 10) / 10,
-        )
-        patch[ex.id] = buildInitialSetRowsForExercise(
-          ex,
-          lib,
-          displayWeight,
-        )
-        hasChanges = true
-      } else if (storedWeight === 0 && historyWeight > 0) {
-        const allUntouched = existing.every(
-          (s) => s.weight === "0" && !s.done,
-        )
-        if (allUntouched) {
+        if (!existing) {
           const displayWeight = String(
-            Math.round(toDisplay(historyWeight) * 10) / 10,
+            Math.round(toDisplay(effectiveWeightKg) * 10) / 10,
           )
-          patch[ex.id] = mapRowsUpdateWeight(existing, displayWeight)
+          patch[ex.id] = buildInitialSetRowsForExercise(
+            ex,
+            lib,
+            displayWeight,
+          )
           hasChanges = true
+        } else if (storedWeight === 0 && historyWeight > 0) {
+          const allUntouched = existing.every(
+            (s) => s.weight === "0" && !s.done,
+          )
+          if (allUntouched) {
+            const displayWeight = String(
+              Math.round(toDisplay(historyWeight) * 10) / 10,
+            )
+            patch[ex.id] = mapRowsUpdateWeight(existing, displayWeight)
+            hasChanges = true
+          }
         }
       }
-    }
 
-    if (hasChanges) {
-      setSession((prev) => ({
-        ...prev,
-        setsData: { ...prev.setsData, ...patch },
-      }))
-    }
+      if (!hasChanges) return prev
+      return { ...prev, setsData: { ...prev.setsData, ...patch } }
+    })
   }, [
     exercises,
-    session.setsData,
     setSession,
     toDisplay,
     lastWeights,


### PR DESCRIPTION
## What

- Stabilize `days ?? []` with a module-level frozen `EMPTY_DAYS` constant in `WorkoutPage` and `CycleSummaryPage`
- Move `session.setsData` read inside the `setSession` functional updater, removing it from the hydration effect's dependency array
- Memoize Carousel `opts` object in `WorkoutDayCarousel` to prevent Embla reInit on every render

## Why

Sentry #7370597194 — `RangeError: Maximum call stack size exceeded` on `/` (WorkoutPage), exclusively on Chrome Mobile iOS (iPhone, iOS 26.3.1). Chrome on iOS has a ~3x shallower call stack than desktop, and three compounding reference instabilities were creating a cascade of synchronous re-renders that overflowed it:

1. `days ?? []` produced a new empty array every render while loading, cascading through `useCycleProgress` → `completedDayIds` → `useAdvanceWorkoutDayOnDateRollover`
2. The setsData hydration effect both read and wrote `session.setsData`, creating a self-referential dependency loop
3. Inline `opts={{ ... }}` on the Carousel gave Embla a new options reference every render, potentially triggering reInit → select event → setSession → re-render

## How

- **Stable empty array**: `const EMPTY_DAYS: WorkoutDay[] = []` at module scope — same reference across renders, `useMemo` downstream stays stable
- **Functional updater pattern**: the hydration effect now reads `prev.setsData` inside `setSession((prev) => ...)` instead of closing over `session.setsData` — this breaks the write→read→write feedback loop
- **`useMemo` for opts**: `useMemo(() => ({ align: "start" as const, containScroll: false as const }), [])` — Embla sees the same reference and skips reInit

Closes #171

Made with [Cursor](https://cursor.com)