### PR TITLE
fix: expose missing exercise fields in admin edit form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-scroll-area": "^1.2.10",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
@@ -4401,6 +4402,67 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",

--- a/src/components/admin/exercise-form/ExerciseEditForm.tsx
+++ b/src/components/admin/exercise-form/ExerciseEditForm.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useCallback } from "react"
-import { useForm, FormProvider, useWatch } from "react-hook-form"
+import { useForm, FormProvider, useWatch, Controller } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Activity, AlertTriangle, Settings2, Upload, Wind } from "lucide-react"
 import { useTranslation } from "react-i18next"
@@ -7,6 +7,13 @@ import { toast } from "sonner"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import type { Exercise } from "@/types/database"
 import { useExerciseFilterOptions } from "@/hooks/useExerciseFilterOptions"
 import { getYouTubeEmbedUrl } from "@/lib/youtube"
@@ -45,6 +52,8 @@ export function ExerciseEditForm({
   const equipmentOptions = filterOptions?.equipment ?? []
   const [imgVersion, setImgVersion] = useState(0)
 
+  const measurementType = useWatch({ control, name: "measurement_type" })
+
   const handleImageUploaded = useCallback(
     (filename: string) => {
       methods.setValue("image_url", filename, { shouldDirty: true })
@@ -66,27 +75,55 @@ export function ExerciseEditForm({
           <Field label={t("form.nameEn")}>
             <Input {...methods.register("name_en")} />
           </Field>
-          <Field label={t("form.muscleGroup")} required error={errors.muscle_group?.message}>
-            <select
-              {...methods.register("muscle_group")}
-              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            >
-              <option value="">—</option>
-              {muscleGroups.map((mg) => (
-                <option key={mg} value={mg}>{mg}</option>
-              ))}
-            </select>
+          <Field
+            label={t("form.muscleGroup")}
+            required
+            error={errors.muscle_group?.message}
+          >
+            <Controller
+              control={control}
+              name="muscle_group"
+              render={({ field }) => (
+                <Select
+                  value={field.value}
+                  onValueChange={field.onChange}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="—" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {muscleGroups.map((mg) => (
+                      <SelectItem key={mg} value={mg}>
+                        {mg}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
           </Field>
           <Field label={t("form.equipment")}>
-            <select
-              {...methods.register("equipment")}
-              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            >
-              <option value="">—</option>
-              {equipmentOptions.map((eq) => (
-                <option key={eq} value={eq}>{eq}</option>
-              ))}
-            </select>
+            <Controller
+              control={control}
+              name="equipment"
+              render={({ field }) => (
+                <Select
+                  value={field.value || undefined}
+                  onValueChange={field.onChange}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="—" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {equipmentOptions.map((eq) => (
+                      <SelectItem key={eq} value={eq}>
+                        {eq}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
           </Field>
           <Field label={t("form.emoji")} required error={errors.emoji?.message}>
             <Input {...methods.register("emoji")} className="w-20" />
@@ -97,6 +134,81 @@ export function ExerciseEditForm({
               placeholder="e.g. biceps, forearms"
             />
           </Field>
+        </div>
+
+        <Separator />
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label={t("form.source")}>
+            <Input {...methods.register("source")} readOnly />
+          </Field>
+          <Field label={t("form.difficultyLevel")}>
+            <Controller
+              control={control}
+              name="difficulty_level"
+              render={({ field }) => (
+                <Select
+                  value={field.value || undefined}
+                  onValueChange={(v) =>
+                    field.onChange(v === "__none__" ? "" : v)
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue
+                      placeholder={t("form.nonePlaceholder")}
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">
+                      {t("form.nonePlaceholder")}
+                    </SelectItem>
+                    {(["beginner", "intermediate", "advanced"] as const).map(
+                      (level) => (
+                        <SelectItem key={level} value={level}>
+                          {t(`form.difficulty.${level}`)}
+                        </SelectItem>
+                      ),
+                    )}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </Field>
+          <Field label={t("form.measurementType")}>
+            <Controller
+              control={control}
+              name="measurement_type"
+              render={({ field }) => (
+                <Select
+                  value={field.value}
+                  onValueChange={field.onChange}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(["reps", "duration"] as const).map((mt) => (
+                      <SelectItem key={mt} value={mt}>
+                        {t(`form.measurement.${mt}`)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </Field>
+          {measurementType === "duration" && (
+            <Field label={t("form.defaultDuration")}>
+              <Input
+                {...methods.register("default_duration_seconds", {
+                  setValueAs: (v: string) => (v === "" ? null : Number(v)),
+                })}
+                type="number"
+                min={1}
+                placeholder="30"
+              />
+            </Field>
+          )}
         </div>
 
         <Separator />

--- a/src/components/admin/exercise-form/schema.ts
+++ b/src/components/admin/exercise-form/schema.ts
@@ -11,6 +11,12 @@ export const exerciseFormSchema = z.object({
   secondary_muscles: z.string(),
   youtube_url: z.string().nullable(),
   image_url: z.string().nullable(),
+  source: z.string().nullable(),
+  difficulty_level: z
+    .enum(["beginner", "intermediate", "advanced", ""])
+    .nullable(),
+  measurement_type: z.enum(["reps", "duration"]),
+  default_duration_seconds: z.number().positive().nullable(),
   instructions: z.object({
     setup: z.array(instructionStepSchema),
     movement: z.array(instructionStepSchema),

--- a/src/components/admin/exercise-form/transforms.ts
+++ b/src/components/admin/exercise-form/transforms.ts
@@ -12,6 +12,10 @@ export function toFormValues(exercise: Exercise): ExerciseFormValues {
     secondary_muscles: (exercise.secondary_muscles ?? []).join(", "),
     youtube_url: exercise.youtube_url ?? "",
     image_url: exercise.image_url ?? "",
+    source: exercise.source ?? "",
+    difficulty_level: exercise.difficulty_level ?? "",
+    measurement_type: exercise.measurement_type ?? "reps",
+    default_duration_seconds: exercise.default_duration_seconds ?? null,
     instructions: {
       setup: (ins?.setup ?? []).map((v) => ({ value: v })),
       movement: (ins?.movement ?? []).map((v) => ({ value: v })),
@@ -48,6 +52,23 @@ export function fromLlmJson(
 
   if (raw.youtube_url != null) result.youtube_url = String(raw.youtube_url)
   if (raw.image_url != null) result.image_url = String(raw.image_url)
+  if (raw.source != null) result.source = String(raw.source)
+
+  if (raw.difficulty_level != null) {
+    const dl = String(raw.difficulty_level)
+    result.difficulty_level =
+      dl === "beginner" || dl === "intermediate" || dl === "advanced" ? dl : ""
+  }
+
+  if (raw.measurement_type != null) {
+    const mt = String(raw.measurement_type)
+    result.measurement_type = mt === "duration" ? "duration" : "reps"
+  }
+
+  if (raw.default_duration_seconds != null) {
+    const n = Number(raw.default_duration_seconds)
+    result.default_duration_seconds = Number.isFinite(n) && n > 0 ? n : null
+  }
 
   const ins = raw.instructions as Partial<ExerciseInstructions> | undefined
   if (ins && typeof ins === "object") {
@@ -74,6 +95,13 @@ export function fromFormValues(values: ExerciseFormValues) {
       : null,
     youtube_url: values.youtube_url || null,
     image_url: values.image_url || null,
+    source: values.source || null,
+    difficulty_level: values.difficulty_level || null,
+    measurement_type: values.measurement_type,
+    default_duration_seconds:
+      values.measurement_type === "duration"
+        ? (values.default_duration_seconds ?? null)
+        : null,
     instructions: {
       setup: values.instructions.setup
         .map((s) => s.value.trim())

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,158 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -73,6 +73,21 @@
     "uploadImage": "Upload",
     "uploading": "Uploading…",
     "uploadError": "Upload failed",
+    "source": "Source",
+    "difficultyLevel": "Difficulty",
+    "difficulty": {
+      "beginner": "Beginner",
+      "intermediate": "Intermediate",
+      "advanced": "Advanced"
+    },
+    "measurementType": "Measurement type",
+    "measurement": {
+      "reps": "Reps",
+      "duration": "Duration (time)"
+    },
+    "defaultDuration": "Default duration (seconds)",
+    "selectPlaceholder": "Select…",
+    "nonePlaceholder": "None",
     "setup": "Setup",
     "movement": "Movement",
     "breathing": "Breathing",

--- a/src/locales/fr/admin.json
+++ b/src/locales/fr/admin.json
@@ -73,6 +73,21 @@
     "uploadImage": "Importer",
     "uploading": "Import en cours…",
     "uploadError": "Échec de l'import",
+    "source": "Source",
+    "difficultyLevel": "Difficulté",
+    "difficulty": {
+      "beginner": "Débutant",
+      "intermediate": "Intermédiaire",
+      "advanced": "Avancé"
+    },
+    "measurementType": "Type de mesure",
+    "measurement": {
+      "reps": "Répétitions",
+      "duration": "Durée (temps)"
+    },
+    "defaultDuration": "Durée par défaut (secondes)",
+    "selectPlaceholder": "Sélectionner…",
+    "nonePlaceholder": "Aucun",
     "setup": "Mise en place",
     "movement": "Mouvement",
     "breathing": "Respiration",

--- a/src/pages/library/ExerciseLibraryExercisePage.test.tsx
+++ b/src/pages/library/ExerciseLibraryExercisePage.test.tsx
@@ -5,11 +5,12 @@ import { Routes, Route } from "react-router-dom"
 import { renderWithProviders } from "@/test/utils"
 import { isAdminAtom } from "@/store/atoms"
 import type { Exercise } from "@/types/database"
-import { ExerciseLibraryExercisePage } from "./ExerciseLibraryExercisePage"
 
 vi.mock("@/lib/supabase", () => ({
   supabase: { from: vi.fn() },
 }))
+
+import { ExerciseLibraryExercisePage } from "./ExerciseLibraryExercisePage"
 
 const VALID_ID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
 


### PR DESCRIPTION
## What

- Add 4 missing fields to the admin exercise edit form: `source` (readonly input), `difficulty_level` (select), `measurement_type` (select), and `default_duration_seconds` (number input, conditional on duration type)
- Replace raw `<select>` elements for `muscle_group` and `equipment` with shadcn `Select` components
- Install shadcn Select component (`@radix-ui/react-select`)

## Why

The edit exercise page was not displaying all fields from the exercise JSON. Fields like `source`, `difficulty_level`, `measurement_type`, and `default_duration_seconds` were stored in the DB but had no way to be viewed or edited in the admin UI.

Also, the existing dropdowns were raw HTML `<select>` — violating the project's `prefer-shadcn-components` rule.

## How

- Extended the Zod schema with the 4 new fields (enum selects, coerced number, nullable string)
- Updated `toFormValues`, `fromFormValues`, and `fromLlmJson` transforms to handle the new fields round-trip
- Used `Controller` from react-hook-form for all shadcn Select fields (Radix Select is a controlled component)
- `default_duration_seconds` is conditionally rendered only when `measurement_type === "duration"`
- Added i18n labels in both EN and FR

Made with [Cursor](https://cursor.com)