### PR TITLE
fix(ci): replace dead vercel-action with direct Vercel CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,12 @@ jobs:
     needs: gate
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
-      - uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: --prod
+      - run: npm i -g vercel@latest
+      - run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## What

- Remove `amondnet/vercel-action@v25` from the deploy job
- Replace with direct `vercel@latest` CLI calls: `pull → build → deploy`

## Why

`amondnet/vercel-action@v25` pins `vercel@25.1.0`. Vercel's API now requires CLI `>= 47.2.2`, so every deploy on `main` fails with:

> Error! Your Vercel CLI version is outdated. This endpoint requires version 47.2.2 or later.

## How

Set `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` as env vars on the job, then run three steps:
1. `vercel pull` — fetch project config
2. `vercel build --prod` — build locally
3. `vercel deploy --prebuilt --prod` — deploy the pre-built output

This is Vercel's own recommended CI pattern and removes the dependency on a third-party action.

Made with [Cursor](https://cursor.com)