### PR TITLE
feat: enhance exercise library visual hierarchy (#204)

### DIFF
--- a/src/components/builder/ExerciseLibraryPicker.test.tsx
+++ b/src/components/builder/ExerciseLibraryPicker.test.tsx
@@ -9,6 +9,10 @@ vi.mock("@/lib/supabase", () => ({
   supabase: { from: vi.fn() },
 }))
 
+vi.mock("@/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => true,
+}))
+
 const EXERCISES: Exercise[] = [
   {
     id: "1",

--- a/src/components/builder/ExerciseLibraryPicker.tsx
+++ b/src/components/builder/ExerciseLibraryPicker.tsx
@@ -7,6 +7,7 @@ import {
   useAddExercisesToDay,
   useDeleteExercise,
 } from "@/hooks/useBuilderMutations"
+import { useMediaQuery } from "@/hooks/useMediaQuery"
 import type { Exercise } from "@/types/database"
 import { ExerciseFilterPanel } from "@/components/builder/ExerciseFilterPanel"
 import { ExerciseSelectionContent } from "@/components/builder/ExerciseSelectionContent"
@@ -14,11 +15,17 @@ import type { ExistingDayExercise } from "@/components/builder/ExerciseSelection
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet"
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer"
 import { Command, CommandList } from "@/components/ui/command"
 import { Input } from "@/components/ui/input"
 
@@ -45,6 +52,7 @@ export function ExerciseLibraryPicker({
   onMutationStateChange,
 }: ExerciseLibraryPickerProps) {
   const { t } = useTranslation("builder")
+  const isDesktop = useMediaQuery("(min-width: 768px)")
   const addExercises = useAddExercisesToDay()
   const deleteExercise = useDeleteExercise()
 
@@ -132,117 +140,129 @@ export function ExerciseLibraryPicker({
     ? [...existingSet].sort().join(",")
     : "closed"
 
-  return (
-    <Sheet open={open} onOpenChange={handleOpenChange}>
-      <SheetContent
-        side="bottom"
-        aria-describedby={undefined}
-        onInteractOutside={(e) => e.preventDefault()}
+  const pickerBody = (
+    <Command
+      className="flex min-h-0 flex-1 flex-col"
+      shouldFilter={false}
+    >
+      <div className="flex shrink-0 items-center border-b px-3 pr-2">
+        <Search className="mr-2 h-4 w-4 shrink-0 opacity-50 text-muted-foreground" />
+        <Input
+          type="search"
+          placeholder={t("searchExercises")}
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          className="h-11 flex-1 min-w-0 border-0 bg-transparent shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+          aria-label={t("searchExercises")}
+        />
+        <button
+          type="button"
+          onClick={() => setFiltersOpen(!filtersOpen)}
+          className="relative flex h-11 min-w-11 shrink-0 items-center justify-center rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          aria-label={t("filters")}
+        >
+          <SlidersHorizontal className="h-4 w-4" />
+          {activeFilterCount > 0 && (
+            <span className="absolute -right-0.5 -top-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
+              {activeFilterCount}
+            </span>
+          )}
+        </button>
+      </div>
+
+      <div
         className={cn(
-          "flex max-h-[75vh] flex-col gap-0 p-0 sm:max-h-[80vh]",
-          "xl:left-1/2 xl:right-auto xl:max-w-2xl xl:-translate-x-1/2",
+          "grid shrink-0 transition-[grid-template-rows] duration-200",
+          filtersOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
         )}
       >
-        <SheetHeader className="shrink-0 px-4 pt-4">
-          <SheetTitle>{t("addExercise")}</SheetTitle>
-        </SheetHeader>
-
-        <Command
-          className="flex min-h-0 flex-1 flex-col"
-          shouldFilter={false}
-        >
-          <div className="flex shrink-0 items-center border-b px-3 pr-2">
-            <Search className="mr-2 h-4 w-4 shrink-0 opacity-50 text-muted-foreground" />
-            <Input
-              type="search"
-              placeholder={t("searchExercises")}
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-              className="h-11 flex-1 min-w-0 border-0 bg-transparent shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
-              aria-label={t("searchExercises")}
+        <div className="overflow-hidden">
+          {filtersOpen && (
+            <ExerciseFilterPanel
+              muscleGroups={muscleGroups}
+              equipmentTypes={equipmentTypes}
+              difficultyLevels={difficultyLevels}
+              selectedMuscleGroup={selectedMuscleGroup}
+              selectedEquipment={selectedEquipment}
+              selectedDifficulty={selectedDifficulty}
+              onMuscleGroupChange={setSelectedMuscleGroup}
+              onEquipmentChange={setSelectedEquipment}
+              onDifficultyChange={setSelectedDifficulty}
             />
-            <button
-              type="button"
-              onClick={() => setFiltersOpen(!filtersOpen)}
-              className="relative flex h-11 min-w-11 shrink-0 items-center justify-center rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-              aria-label={t("filters")}
-            >
-              <SlidersHorizontal className="h-4 w-4" />
-              {activeFilterCount > 0 && (
-                <span className="absolute -right-0.5 -top-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
-                  {activeFilterCount}
-                </span>
-              )}
-            </button>
-          </div>
+          )}
+        </div>
+      </div>
 
-          <div
-            className={cn(
-              "grid shrink-0 transition-[grid-template-rows] duration-200",
-              filtersOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
-            )}
-          >
-            <div className="overflow-hidden">
-              {filtersOpen && (
-                <ExerciseFilterPanel
-                  muscleGroups={muscleGroups}
-                  equipmentTypes={equipmentTypes}
-                  difficultyLevels={difficultyLevels}
-                  selectedMuscleGroup={selectedMuscleGroup}
-                  selectedEquipment={selectedEquipment}
-                  selectedDifficulty={selectedDifficulty}
-                  onMuscleGroupChange={setSelectedMuscleGroup}
-                  onEquipmentChange={setSelectedEquipment}
-                  onDifficultyChange={setSelectedDifficulty}
-                />
-              )}
-            </div>
+      <CommandList className="min-h-0 flex-1 max-h-none overflow-x-hidden overflow-y-auto">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           </div>
-
-          <CommandList className="min-h-0 flex-1 max-h-none overflow-x-hidden overflow-y-auto">
-            {isLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        ) : (
+          <>
+            <ExerciseSelectionContent
+              key={selectionKey}
+              initialSelectedIds={existingExercises.map((e) => e.exercise_id)}
+              existingExercises={existingExercises}
+              existingSet={existingSet}
+              filtered={paginatedData}
+              grouped={grouped}
+              dayId={dayId}
+              existingExerciseCount={existingExerciseCount}
+              onMutationStateChange={onMutationStateChange}
+              onClose={() => handleOpenChange(false)}
+              addExercises={addExercises}
+              deleteExercise={deleteExercise}
+            />
+            {hasNextPage && (
+              <div className="flex justify-center border-t py-3">
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="text-muted-foreground hover:text-foreground"
+                  onClick={() => fetchNextPage()}
+                  disabled={isFetchingNextPage}
+                >
+                  {isFetchingNextPage ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <RefreshCw className="h-4 w-4" />
+                  )}
+                  {t("loadMore")}
+                </Button>
               </div>
-            ) : (
-              <>
-                <ExerciseSelectionContent
-                  key={selectionKey}
-                  initialSelectedIds={existingExercises.map((e) => e.exercise_id)}
-                  existingExercises={existingExercises}
-                  existingSet={existingSet}
-                  filtered={paginatedData}
-                  grouped={grouped}
-                  dayId={dayId}
-                  existingExerciseCount={existingExerciseCount}
-                  onMutationStateChange={onMutationStateChange}
-                  onClose={() => handleOpenChange(false)}
-                  addExercises={addExercises}
-                  deleteExercise={deleteExercise}
-                />
-                {hasNextPage && (
-                  <div className="flex justify-center border-t py-3">
-                    <Button
-                      variant="link"
-                      size="sm"
-                      className="text-muted-foreground hover:text-foreground"
-                      onClick={() => fetchNextPage()}
-                      disabled={isFetchingNextPage}
-                    >
-                      {isFetchingNextPage ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <RefreshCw className="h-4 w-4" />
-                      )}
-                      {t("loadMore")}
-                    </Button>
-                  </div>
-                )}
-              </>
             )}
-          </CommandList>
-        </Command>
-      </SheetContent>
-    </Sheet>
+          </>
+        )}
+      </CommandList>
+    </Command>
+  )
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent
+          aria-describedby={undefined}
+          onInteractOutside={(e) => e.preventDefault()}
+          className="flex max-h-[80vh] max-w-2xl flex-col gap-0 p-0"
+        >
+          <DialogHeader className="shrink-0 px-4 pt-4 pb-2">
+            <DialogTitle>{t("addExercise")}</DialogTitle>
+          </DialogHeader>
+          {pickerBody}
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={handleOpenChange}>
+      <DrawerContent className="flex max-h-[75vh] flex-col gap-0 p-0 sm:max-h-[80vh]">
+        <DrawerHeader className="shrink-0 px-4 pt-2 pb-0">
+          <DrawerTitle>{t("addExercise")}</DrawerTitle>
+        </DrawerHeader>
+        {pickerBody}
+      </DrawerContent>
+    </Drawer>
   )
 }

--- a/src/components/builder/ExerciseSelectionContent.tsx
+++ b/src/components/builder/ExerciseSelectionContent.tsx
@@ -12,6 +12,7 @@ import { FeedbackTrigger } from "@/components/feedback/FeedbackTrigger"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
+import { getDifficultyColor } from "@/lib/difficulty"
 import {
   CommandEmpty,
   CommandGroup,
@@ -141,10 +142,7 @@ export function ExerciseSelectionContent({
                     <Badge
                       className={cn(
                         "h-5 shrink-0 px-1.5 text-[10px] border-0",
-                        ex.difficulty_level === "beginner" && "bg-green-600 text-white",
-                        ex.difficulty_level === "intermediate" &&
-                          "bg-yellow-500 text-black",
-                        ex.difficulty_level === "advanced" && "bg-red-600 text-white",
+                        getDifficultyColor(ex.difficulty_level),
                       )}
                     >
                       {t(`difficulty.${ex.difficulty_level}`, ex.difficulty_level)}

--- a/src/lib/difficulty.ts
+++ b/src/lib/difficulty.ts
@@ -1,0 +1,13 @@
+import type { Exercise } from "@/types/database"
+
+type DifficultyLevel = NonNullable<Exercise["difficulty_level"]>
+
+const DIFFICULTY_CLASSES: Record<DifficultyLevel, string> = {
+  beginner: "bg-green-600 text-white border-green-600",
+  intermediate: "bg-yellow-500 text-black border-yellow-500",
+  advanced: "bg-red-600 text-white border-red-600",
+}
+
+export function getDifficultyColor(level: DifficultyLevel): string {
+  return DIFFICULTY_CLASSES[level] ?? ""
+}

--- a/src/pages/BuilderPage.tsx
+++ b/src/pages/BuilderPage.tsx
@@ -110,7 +110,7 @@ export function BuilderPage() {
   }
 
   return (
-    <div className="flex flex-1 flex-col">
+    <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col">
       <BuilderHeader
         programId={programId}
         saveStatus={saveStatus}

--- a/src/pages/library/ExerciseLibraryExercisePage.tsx
+++ b/src/pages/library/ExerciseLibraryExercisePage.tsx
@@ -10,6 +10,8 @@ import { FeedbackTrigger } from "@/components/feedback/FeedbackTrigger"
 import { AddExerciseToDaySheet } from "@/components/library/AddExerciseToDaySheet"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { getDifficultyColor } from "@/lib/difficulty"
+import { cn } from "@/lib/utils"
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -20,6 +22,7 @@ function isValidExerciseId(id: string | undefined): boolean {
 
 export function ExerciseLibraryExercisePage() {
   const { t } = useTranslation("library")
+  const { t: tBuilder } = useTranslation("builder")
   const { t: tWorkout } = useTranslation("workout")
   const { exerciseId } = useParams<{ exerciseId: string }>()
   const [addOpen, setAddOpen] = useState(false)
@@ -61,7 +64,7 @@ export function ExerciseLibraryExercisePage() {
 
   return (
     <>
-      <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-4 pb-8">
+      <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col gap-6 overflow-y-auto px-4 pb-8">
         <div className="flex items-center gap-3 pt-1">
           <Link
             to="/library/exercises"
@@ -97,26 +100,30 @@ export function ExerciseLibraryExercisePage() {
           </AdminOnly>
         </div>
 
-        <div className="flex flex-col gap-3">
-          <div className="flex items-start gap-4">
-            <ExerciseThumbnail
-              imageUrl={exercise.image_url}
-              emoji={exercise.emoji}
-              className="h-16 w-16 shrink-0"
-            />
-            <div className="flex min-w-0 flex-1 flex-col gap-2">
-              <Badge variant="default" className="w-fit text-xs font-normal">
-                {exercise.muscle_group}
+        <div className="flex flex-col gap-4">
+          <ExerciseThumbnail
+            imageUrl={exercise.image_url}
+            emoji={exercise.emoji}
+            className="aspect-[16/9] w-full rounded-xl"
+          />
+
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <Badge variant="default" className="text-xs font-normal">
+              {exercise.muscle_group}
+            </Badge>
+            <Badge variant="secondary" className="text-xs font-normal">
+              {exercise.equipment}
+            </Badge>
+            {exercise.difficulty_level && (
+              <Badge
+                className={cn(
+                  "text-xs font-normal border-0",
+                  getDifficultyColor(exercise.difficulty_level),
+                )}
+              >
+                {tBuilder(`difficulty.${exercise.difficulty_level}`, exercise.difficulty_level)}
               </Badge>
-              <Badge variant="secondary" className="w-fit text-xs font-normal">
-                {exercise.equipment}
-              </Badge>
-              {exercise.difficulty_level && (
-                <Badge variant="outline" className="w-fit text-xs font-normal">
-                  {exercise.difficulty_level}
-                </Badge>
-              )}
-            </div>
+            )}
           </div>
 
           <ExerciseInstructionsPanel exerciseId={exercise.id} defaultExpanded />

--- a/src/pages/library/ExerciseLibraryPage.tsx
+++ b/src/pages/library/ExerciseLibraryPage.tsx
@@ -8,6 +8,7 @@ import type { Exercise } from "@/types/database"
 import { ExerciseFilterPanel } from "@/components/builder/ExerciseFilterPanel"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
 import { Badge } from "@/components/ui/badge"
+import { getDifficultyColor } from "@/lib/difficulty"
 import { Button } from "@/components/ui/button"
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from "@/components/ui/command"
 import { Input } from "@/components/ui/input"
@@ -84,7 +85,7 @@ export function ExerciseLibraryPage() {
   )
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
+    <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col overflow-hidden">
       <div className="flex shrink-0 items-center gap-3 border-b border-border/50 px-4 py-3">
         <button
           type="button"
@@ -167,13 +168,25 @@ export function ExerciseLibraryPage() {
                         <ExerciseThumbnail
                           imageUrl={ex.image_url}
                           emoji={ex.emoji}
-                          className="mr-3 h-10 w-10 shrink-0"
+                          className="mr-3 h-16 w-16 shrink-0 rounded-lg"
                         />
-                        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                        <div className="flex min-w-0 flex-1 flex-col gap-1">
                           <span className="truncate font-medium">{ex.name}</span>
-                          <Badge variant="secondary" className="w-fit text-xs font-normal">
-                            {ex.equipment}
-                          </Badge>
+                          <div className="flex flex-wrap items-center gap-1.5">
+                            <Badge variant="secondary" className="w-fit text-xs font-normal">
+                              {ex.equipment}
+                            </Badge>
+                            {ex.difficulty_level && (
+                              <Badge
+                                className={cn(
+                                  "w-fit text-xs font-normal border-0",
+                                  getDifficultyColor(ex.difficulty_level),
+                                )}
+                              >
+                                {tBuilder(`difficulty.${ex.difficulty_level}`, ex.difficulty_level)}
+                              </Badge>
+                            )}
+                          </div>
                         </div>
                       </CommandItem>
                     ))}


### PR DESCRIPTION
## What

- Larger thumbnails in exercise list view (`h-10` → `h-16`) for faster movement-pattern recognition
- Color-coded difficulty badges (green/yellow/red) on both list and detail views, with proper i18n labels
- Hero-style full-width illustration on exercise detail page, with centered badges below
- `max-w-2xl` constraint on both library pages for sane desktop readability

## Why

In a gym context, users rely on visual pattern recognition over text parsing. Larger thumbnails and semantic color-coding reduce cognitive load when scanning exercises. The detail page previously used a tiny 64px thumbnail next to stacked badges — the hero layout gives immediate visual context. Desktop was also unconstrained, spreading content across the full viewport width.

## How

- New shared `getDifficultyColor()` utility in `src/lib/difficulty.ts` mapping beginner/intermediate/advanced to Tailwind bg+text+border classes
- `ExerciseLibraryPage`: bumped thumbnail size, added difficulty `Badge` with color helper
- `ExerciseLibraryExercisePage`: replaced inline thumb+badge row with `w-full aspect-[16/9]` hero + `justify-center` badge row; added `builder` namespace for i18n difficulty labels
- `ExerciseSelectionContent`: refactored inline color conditions to use shared helper
- Both pages wrapped in `mx-auto max-w-2xl` for desktop containment

Closes #204

Made with [Cursor](https://cursor.com)