### PR TITLE
feat(#218): add 6 new achievement tracks

### DIFF
--- a/docs/Epic_Brief_—_MCP-First_Architecture_#231.md
+++ b/docs/Epic_Brief_—_MCP-First_Architecture_#231.md
@@ -1,0 +1,149 @@
+# Epic Brief — MCP-First Architecture (#231)
+
+## Summary
+
+Expose the app's training data, exercise catalog, and domain expertise as an **MCP (Model Context Protocol) server** so that the user's own AI agent (Claude Desktop, Le Chat, etc.) can query, reason about, and eventually write to their workout data. This shifts the app from "AI features locked in a closed loop" to "agent-ready platform" — the intelligence moves to the user's agent, the app provides the specialized domain layer.
+
+---
+
+## Context & Problem
+
+**Who is affected:** Any user who wants to interact with their training data through an AI agent outside the app.
+
+**Current state:**
+
+- AI features follow a **closed loop**: React UI → Supabase Edge Function → Gemini 2.5 Flash → validated response → UI. The user never sees the LLM directly and can't bring their own.
+- **Deterministic expertise** (RIR-based progression, Epley 1RM, volume maps, triple progression) lives in `file:src/lib/` — accessible only through the React UI.
+- **600+ exercise catalog** with rich metadata (muscles, equipment, difficulty, instructions, media) is locked behind in-app search/filter.
+- **Training data** (PRs, session history, volume, programs) has no programmatic access — users must open the app and navigate to the right screen.
+- Every AI generation costs a Gemini API call that we pay for, with a narrow context window (catalog + profile + recent history).
+
+**Pain points:**
+
+
+| Pain                                                                                 | Impact                                                                                          |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| AI features are a closed loop — narrow context, single provider, we choose the model | User's agent (which knows their full life context) can't help with training decisions           |
+| Domain expertise only accessible via React UI                                        | No way for external tools or agents to leverage progression logic, catalog search, or analytics |
+| No programmatic access to training data                                              | Power users can't automate, query, or compose their workout data with other tools               |
+| We pay per Gemini call with limited context                                          | Cost scales with usage; smarter models exist but we're locked to our provider                   |
+
+
+**Market context (April 2026):**
+
+MCP adoption has reached critical mass — 548+ clients listed on PulseMCP, native support in Claude Desktop, ChatGPT, Le Chat (Mistral), Gemini CLI, Cursor, VS Code. SSE transport deprecated April 1 2026, Streamable HTTP is the standard. Supabase ships official MCP server support on Edge Functions with built-in OAuth 2.1.
+
+---
+
+## Goals
+
+
+| Goal                                       | Measure                                                                                                                |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Validate the "agent-ready platform" thesis | A read-only coaching conversation via Claude Desktop + MCP tools is subjectively better than in-app `generate-workout` |
+| Expose training data to external agents    | Agent can discover and call all Phase 1 tools via MCP protocol                                                         |
+| Reuse existing auth and security           | MCP connections go through Supabase OAuth 2.1; RLS applies identically to in-app access                                |
+| Zero new infrastructure                    | MCP server runs as a single Supabase Edge Function using the official SDK                                              |
+
+
+---
+
+## Scope
+
+### In scope
+
+**Phase 1 — Read-Only MCP Server (this epic)**
+
+1. **MCP Edge Function**: single Supabase Edge Function at `/functions/v1/mcp` using `@modelcontextprotocol/sdk` with `WebStandardStreamableHTTPServerTransport` and Hono routing
+2. **Auth**: Supabase OAuth 2.1 (enable on project, configure dynamic client registration, consent page — details deferred to Tech Plan)
+3. **MCP Tools (read-only)**:
+  - `get_workout_history` — query past sessions with optional date range and exercise filters
+  - `search_exercises` — search the catalog by name, muscle group, equipment, difficulty
+  - `get_training_stats` — volume, frequency, PRs for a given period/muscle group
+  - `get_upcoming_workouts` — programmed days and exercises
+  - `get_exercise_details` — full metadata for a specific exercise (instructions, media, muscles)
+4. **MCP Resources (taxonomy)**:
+  - `exercise_catalog_schema` — expose muscle groups, equipment types, difficulty levels as browsable reference data the agent reads once at conversation start
+5. **Validation**: manual end-to-end test with Claude Desktop and Le Chat (Mistral)
+
+### Out of scope
+
+- **Write operations** (add exercise, log set, create workout) → Phase 3
+- **Domain expertise tools** (suggest progression, calculate 1RM, validate plan, muscle balance report) → Phase 2
+- **Deprecation of `generate-workout` / `generate-program`** Edge Functions → Phase 4
+- **Consent page UX design** — deferred to Tech Plan; brief only requires it exists
+- **Tool output format** (structured text vs JSON vs hybrid) — deferred to Tech Plan
+- **Shared domain logic extraction** (moving `src/lib/` code to be importable by Edge Functions) — Phase 2 concern
+- **Mobile/non-desktop agent flows** — Le Chat mobile works but not a design target
+
+---
+
+## Technical Decisions
+
+Resolved during discovery (see [#231 discussion](https://github.com/PierreTsia/workout-app/issues/231)):
+
+
+| Decision                  | Choice                                           | Rationale                                                                                  |
+| ------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| Transport                 | **Streamable HTTP**                              | SSE deprecated April 2026; stateless, fits Edge Functions; supported by all Tier 1 clients |
+| Architecture              | **Single Edge Function** with N `registerTool()` | SDK design; splitting breaks tool discovery; Hono for HTTP, SDK for MCP routing            |
+| Auth                      | **Supabase OAuth 2.1 + PKCE**                    | Built-in discovery endpoint, dynamic client registration, same RLS — zero new auth system  |
+| Exercise catalog exposure | **Resource for taxonomy, Tool for search**       | Stable reference data as Resource (read once); parameterized search as Tool                |
+| Versioning                | **Additive-only, semver on server**              | No URL versioning; never rename/remove tools; description changes = semantic breaks        |
+
+
+## V1 Test Plan
+
+### Step 1 — Technical smoke test (days 1-2)
+
+
+| Client                | Cost                       | Validates                                          |
+| --------------------- | -------------------------- | -------------------------------------------------- |
+| **Cursor**            | 0€ (already paying)        | Transport, auth, tool discovery, data round-trip   |
+| **Claude Code** (CLI) | Existing Anthropic API key | Conversational agent in terminal, multi-tool calls |
+
+
+### Step 2 — Product validation
+
+
+| Client                | Cost                                            | Validates                                    |
+| --------------------- | ----------------------------------------------- | -------------------------------------------- |
+| **Claude Desktop**    | Free (1 custom connector, beta) or Pro ($17/mo) | Real coaching conversation — the thesis test |
+| **Le Chat (Mistral)** | 0€ (free tier, custom MCP connectors)           | Cross-client compatibility, mobile support   |
+
+
+### Compatible by default (no special effort)
+
+ChatGPT Desktop (requires Pro $20+/mo), OpenClaw, LibreChat, 250+ MCP clients — standard Streamable HTTP + OAuth. Apple/Siri MCP (macOS 26.1+ beta) is a future bet — don't design for, don't block.
+
+> Full client census: [#231 comment](https://github.com/PierreTsia/workout-app/issues/231#issuecomment-4274296779)
+> Test plan details: [#231 comment](https://github.com/PierreTsia/workout-app/issues/231#issuecomment-4274395020)
+
+---
+
+## Success Criteria
+
+- **Connectivity**: MCP server is discoverable and connectable from Claude Desktop and Le Chat without custom code
+- **Discovery**: agent lists all 5 tools + 1 resource via MCP protocol handshake
+- **Auth**: OAuth flow works end-to-end — user approves, agent gets scoped token, RLS enforces data isolation
+- **Coaching quality**: a read-only coaching conversation (e.g. "analyze my push/pull balance over the last month") is subjectively more useful than what `generate-workout` produces — because the agent has full conversational context and can make multiple tool calls
+- **No regressions**: existing app features, Edge Functions, and auth are unaffected
+
+---
+
+## Risks & Mitigations
+
+
+| Risk                                                                                  | Mitigation                                                                                    |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Supabase OAuth 2.1 not available on current plan or requires config we haven't tested | Spike OAuth setup first before building tools; fallback to Bearer token auth for personal use |
+| Edge Function cold start too slow for MCP handshake                                   | Monitor latency; MCP clients handle retries; single function keeps cold start minimal         |
+| Tool output format confuses LLMs (too raw, too verbose)                               | Iterate on descriptions and output structure during testing; this is the real product work    |
+| Scope creep into write operations before read-only is validated                       | Hard scope boundary — Phase 1 is read-only, period                                            |
+
+
+---
+
+## Supersedes
+
+- #91 — original MCP issue (narrower scope, absorbed into this epic)

--- a/docs/Epic_Brief_—_New_Achievement_Tracks_#218.md
+++ b/docs/Epic_Brief_—_New_Achievement_Tracks_#218.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Expand the achievement system from 5 groups to 12 by adding 7 new tracks that reward overlooked play styles: ad-hoc workouts, leg training, weekly consistency streaks, muscle-group specialization, heavy-volume sessions, PR hot streaks, and early-morning discipline. Each track follows the existing 5-rank Bronze→Diamond ladder and plugs into the current `check_and_grant_achievements` / `get_badge_status` RPCs with no structural changes to the frontend — the accordion UI from #174 already scales to 10+ groups dynamically.
+Expand the achievement system from 5 groups to 11 by adding 6 new tracks that reward overlooked play styles: ad-hoc workouts, leg training, weekly consistency streaks, heavy-volume sessions, PR hot streaks, and early-morning discipline. Each track follows the existing 5-rank Bronze→Diamond ladder and plugs into the current `check_and_grant_achievements` / `get_badge_status` RPCs with no structural changes to the frontend — the accordion UI from #174 already scales to 10+ groups dynamically.
 
 ---
 
@@ -22,7 +22,7 @@ Expand the achievement system from 5 groups to 12 by adding 7 new tracks that re
 |---|---|
 | Only 5 groups — users who primarily do quick workouts, train legs, or work out early have no recognition | Low engagement ceiling; achievements feel narrow |
 | No streak-based metric — `active_weeks` counts total qualifying weeks, not *consecutive* ones | Misses the "don't break the chain" psychology that drives retention |
-| No muscle-group-specific track — variety is rewarded, but specialization isn't | Users who focus on a body part (e.g. PPL legs day) get no acknowledgment |
+| No muscle-group-specific track — variety is rewarded, but leg training isn't | Users who don't skip leg day get no acknowledgment |
 | Ad-hoc ("quick") sessions are invisible to the achievement system | Power users who skip program days and just lift get zero badge progress beyond volume/PRs |
 
 ---
@@ -31,10 +31,10 @@ Expand the achievement system from 5 groups to 12 by adding 7 new tracks that re
 
 | Goal | Measure |
 |---|---|
-| Broaden the achievement surface to reward 7 distinct play styles | 12 total groups live, each with 5 tiers (60 total tiers) |
+| Broaden the achievement surface to reward 6 distinct play styles | 11 total groups live, each with 5 tiers (55 total tiers) |
 | Introduce streak-based and time-based metrics alongside existing aggregates | Streak King and PR Streak use window-function gap detection; Early Bird uses timezone-aware local hour |
 | Zero frontend component changes — purely backend + data + i18n | No new React components; only migration SQL, seed data, and i18n strings |
-| Retroactive grant for existing users on deploy | All 7 new tracks evaluated for historical data via the same idempotent RPC |
+| Retroactive grant for existing users on deploy | All 6 new tracks evaluated for historical data via the same idempotent RPC |
 
 ---
 
@@ -43,19 +43,18 @@ Expand the achievement system from 5 groups to 12 by adding 7 new tracks that re
 **In scope:**
 
 1. **Quick & Dirty** (`quick_sessions`) — count of finished sessions where `workout_day_id IS NULL`
-2. **Leg Day Survivor** (`leg_day`) — count of sets targeting leg muscle groups (`Quadriceps`, `Ischios`, `Fessiers`)
+2. **Leg Day Survivor** (`leg_day`) — count of sets targeting leg muscle groups (`Quadriceps`, `Ischios`, `Fessiers`, `Adducteurs`, `Mollets`)
 3. **Streak King** (`streak_king`) — longest streak of consecutive calendar weeks with at least 1 finished session
-4. **Le Spécialiste** (`specialist`) — highest set count for any single muscle group (user's best, dynamic)
-5. **Le Marathonien** (`marathoner`) — count of sessions where total volume (weight × reps) exceeds a qualifying threshold
-6. **La Série Ininterrompue** (`pr_streak`) — longest streak of consecutive sessions where at least 1 set was a PR
-7. **Early Bird** (`early_bird`) — count of sessions finished before 8:00 AM local time
+4. **Le Marathonien** (`marathoner`) — count of sessions where total volume (weight × reps) exceeds a qualifying threshold
+5. **La Série Ininterrompue** (`pr_streak`) — longest streak of consecutive sessions where at least 1 set was a PR
+6. **Early Bird** (`early_bird`) — count of sessions finished before 8:00 AM local time
 
 For each track:
 - 1 new row in `achievement_groups` + 5 rows in `achievement_tiers`
 - 1 new `UNION ALL` branch in both RPCs' `metrics` CTE
 - Threshold values following the exponential curve from the rebalance migration
 - i18n strings for group names, descriptions, threshold hints (EN + FR)
-- Badge icon assets (5 ranks × 7 tracks = 35 new icons)
+- Badge icon assets (5 ranks × 6 tracks = 30 new icons)
 
 Supporting infrastructure:
 - `timezone text` column on `user_profiles` (for Early Bird local-time computation)
@@ -65,6 +64,7 @@ Supporting infrastructure:
 **Out of scope:**
 
 - New frontend components or UI changes (accordion already handles N groups)
+- Le Spécialiste / per-muscle-group tracks (e.g. Chest Specialist, Back Specialist — better as distinct groups, deferred)
 - Bodyweight Beast, Marathon Sets, Program Loyalist (stretch tracks from issue — deferred)
 - Admin UI for achievement management
 - Social sharing / leaderboards
@@ -96,9 +96,11 @@ Supporting infrastructure:
 
 ### Track 2: Leg Day Survivor (`leg_day`)
 
-**Metric:** `COUNT(*) FROM set_logs sl JOIN exercises e ON e.id = sl.exercise_id JOIN user_sessions us ON us.id = sl.session_id WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers')`
+**Metric:** `COUNT(*) FROM set_logs sl JOIN exercises e ON e.id = sl.exercise_id JOIN user_sessions us ON us.id = sl.session_id WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')`
 
-**Feasibility:** Straightforward. Requires a JOIN to `exercises` (not done by any existing CTE). The `muscle_group` column uses French taxonomy values — the 3 big leg groups cover the classic "leg day" muscles. Adducteurs and Mollets are excluded (isolation, not compound leg work).
+**Feasibility:** Straightforward. Requires a JOIN to `exercises` (not done by any existing CTE). The `muscle_group` column uses French taxonomy values. All 5 lower-body groups are included — quads, hamstrings, glutes, adductors, and calves are all leg work.
+
+**How it works in plain terms:** Every time you log a set where the exercise's primary muscle group is one of the 5 leg values, that's +1. Do 4 sets of squats + 3 sets of calf raises in one session? That's 7 leg sets. The metric accumulates over your lifetime — it doesn't care whether the sets were in the same session or spread across months.
 
 **Edge cases:**
 - Secondary muscles are NOT counted (`secondary_muscles` array) — only `muscle_group` (primary). Keeps the metric clean and predictable.
@@ -135,35 +137,14 @@ Output is still a single numeric value, so the `eligible`/`granted` CTE pattern 
 | Rank | Title (FR) | Title (EN) | Threshold |
 |---|---|---|---|
 | Bronze | "Trois de suite" | "Three in a Row" | 3 weeks |
-| Silver | "Mois sans faille" | "Flawless Month" | 4 weeks |
+| Silver | "Deux mois d'acier" | "Steel Streak" | 8 weeks |
 | Gold | "Trimestre de fer" | "Iron Quarter" | 12 weeks |
 | Platinum | "Inarrêtable" | "Unstoppable" | 26 weeks |
 | Diamond | "La Chaîne Éternelle" | "The Eternal Chain" | 52 weeks |
 
 ---
 
-### Track 4: Le Spécialiste (`specialist`)
-
-**Metric:** `MAX(muscle_group_count)` — the highest set count for any single `exercises.muscle_group` value across all the user's logged sets.
-
-**Feasibility:** Moderate. GROUP BY `muscle_group`, COUNT sets per group, take MAX. Requires the same JOIN to `exercises` as Leg Day.
-
-**Edge cases:**
-- The "best" muscle group is dynamic per user — a chest-focused user and a back-focused user both progress toward the same thresholds
-- If a user switches focus, the metric tracks their all-time best group — it can only grow (monotonic)
-- Only `muscle_group` (primary) counts, not `secondary_muscles`
-
-| Rank | Title (FR) | Title (EN) | Threshold |
-|---|---|---|---|
-| Bronze | "Apprenti spécialiste" | "Novice Specialist" | 50 sets |
-| Silver | "Mono-obsessionnel" | "Single-Minded" | 200 sets |
-| Gold | "Expert de zone" | "Zone Expert" | 500 sets |
-| Platinum | "Maître d'un art" | "Master of One" | 1,200 sets |
-| Diamond | "Le Chirurgien" | "The Surgeon" | 3,000 sets |
-
----
-
-### Track 5: Le Marathonien (`marathoner`)
+### Track 4: Le Marathonien (`marathoner`)
 
 **Metric:** Count of sessions where `SUM(weight_logged * reps_logged::int) >= 5000` (kg) within that single session.
 
@@ -186,7 +167,7 @@ Output is still a single numeric value, so the `eligible`/`granted` CTE pattern 
 
 ---
 
-### Track 6: La Série Ininterrompue (`pr_streak`)
+### Track 5: La Série Ininterrompue (`pr_streak`)
 
 **Metric:** Longest streak of consecutive sessions (ordered by `finished_at`) where at least 1 set had `was_pr = true`.
 
@@ -204,22 +185,22 @@ Output is still a single numeric value, so the `eligible`/`granted` CTE pattern 
 
 | Rank | Title (FR) | Title (EN) | Threshold |
 |---|---|---|---|
-| Bronze | "Feu de paille" | "Flash Fire" | 3 sessions |
-| Silver | "Série chaude" | "Hot Streak" | 5 sessions |
-| Gold | "Machine à records" | "Record Machine" | 10 sessions |
+| Bronze | "Trois d'affilée" | "Flash Fire" | 3 sessions |
+| Silver | "En feu" | "On Fire" | 5 sessions |
+| Gold | "Enchaînement parfait" | "Perfect Run" | 10 sessions |
 | Platinum | "Fléau des plateaux" | "Plateau Slayer" | 20 sessions |
-| Diamond | "L'Inarrêtable" | "The Relentless" | 40 sessions |
+| Diamond | "Le Phénomène" | "The Phenomenon" | 40 sessions |
 
 ---
 
-### Track 7: Early Bird (`early_bird`)
+### Track 6: Early Bird (`early_bird`)
 
 **Metric:** `COUNT(*) FROM user_sessions us JOIN user_profiles up ON up.user_id = ... WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE up.timezone) < 8`
 
 **Feasibility:** Moderate. `finished_at` is `timestamptz`. Converting to the user's local time requires a `timezone` column on `user_profiles`. The `AT TIME ZONE` conversion in Postgres is well-supported for IANA timezone names (e.g. `'Europe/Paris'`).
 
 **Timezone strategy (settled):**
-- **New column:** `ALTER TABLE user_profiles ADD COLUMN timezone text DEFAULT 'UTC'`
+- **New column:** `ALTER TABLE user_profiles ADD COLUMN timezone text DEFAULT 'Europe/Paris'`
 - **Backfill:** `UPDATE user_profiles SET timezone = 'Europe/Paris'` — all current users are FR
 - **New users:** Captured silently during onboarding via `Intl.DateTimeFormat().resolvedOptions().timeZone` in `file:src/hooks/useCreateUserProfile.ts` — no form field, no question asked
 - **Fallback:** If `timezone` is somehow NULL, the CTE falls back to `'UTC'`
@@ -242,12 +223,12 @@ Output is still a single numeric value, so the `eligible`/`granted` CTE pattern 
 
 ## Success Criteria
 
-- **Numeric:** 12 achievement groups live (5 existing + 7 new), 60 total tiers, all evaluable by the existing idempotent RPC
+- **Numeric:** 11 achievement groups live (5 existing + 6 new), 55 total tiers, all evaluable by the existing idempotent RPC
 - **Numeric:** Both RPCs (`check_and_grant_achievements`, `get_badge_status`) execute in < 200ms for a user with 500 sessions and 10k set_logs (verified via `EXPLAIN ANALYZE`)
-- **Qualitative:** Existing users see retroactively granted badges for the 7 new tracks on first app open after deploy (no overlay flood — silent insert)
-- **Qualitative:** The accordion UI displays all 12 groups with no layout or performance degradation
+- **Qualitative:** Existing users see retroactively granted badges for the 6 new tracks on first app open after deploy (no overlay flood — silent insert)
+- **Qualitative:** The accordion UI displays all 11 groups with no layout or performance degradation
 - **Qualitative:** New users get their timezone captured silently at onboarding — no extra form step
-- **Qualitative:** Adding a 13th track in the future requires only a SQL migration (INSERT groups + tiers + CTE branch) and i18n strings — no React component changes
+- **Qualitative:** Adding a 12th track in the future requires only a SQL migration (INSERT groups + tiers + CTE branch) and i18n strings — no React component changes
 
 ---
 

--- a/docs/Epic_Brief_—_New_Achievement_Tracks_#218.md
+++ b/docs/Epic_Brief_—_New_Achievement_Tracks_#218.md
@@ -225,7 +225,7 @@ Output is still a single numeric value, so the `eligible`/`granted` CTE pattern 
 
 - **Numeric:** 11 achievement groups live (5 existing + 6 new), 55 total tiers, all evaluable by the existing idempotent RPC
 - **Numeric:** Both RPCs (`check_and_grant_achievements`, `get_badge_status`) execute in < 200ms for a user with 500 sessions and 10k set_logs (verified via `EXPLAIN ANALYZE`)
-- **Qualitative:** Existing users see retroactively granted badges for the 6 new tracks on first app open after deploy (no overlay flood — silent insert)
+- **Qualitative:** Existing users discover retroactively granted badges in the accordion grid — no toast/overlay flood. The Realtime provider filters out badges with `granted_at` older than the current session (boot-time gate)
 - **Qualitative:** The accordion UI displays all 11 groups with no layout or performance degradation
 - **Qualitative:** New users get their timezone captured silently at onboarding — no extra form step
 - **Qualitative:** Adding a 12th track in the future requires only a SQL migration (INSERT groups + tiers + CTE branch) and i18n strings — no React component changes

--- a/docs/Epic_Brief_—_New_Achievement_Tracks_#218.md
+++ b/docs/Epic_Brief_—_New_Achievement_Tracks_#218.md
@@ -1,0 +1,264 @@
+# Epic Brief — New Achievement Tracks (#218)
+
+## Summary
+
+Expand the achievement system from 5 groups to 12 by adding 7 new tracks that reward overlooked play styles: ad-hoc workouts, leg training, weekly consistency streaks, muscle-group specialization, heavy-volume sessions, PR hot streaks, and early-morning discipline. Each track follows the existing 5-rank Bronze→Diamond ladder and plugs into the current `check_and_grant_achievements` / `get_badge_status` RPCs with no structural changes to the frontend — the accordion UI from #174 already scales to 10+ groups dynamically.
+
+---
+
+## Context & Problem
+
+**Who is affected:** All users with the achievement system active (post-#129 deployment).
+
+**Current state:**
+- 5 achievement groups exist: Consistency Streak, Volume King, Rhythm Master, Record Hunter, Exercise Variety
+- The UI (#174) renders groups dynamically from `get_badge_status` — supports N groups with no code change
+- The RPC architecture uses a `metrics` CTE with `UNION ALL` branches per `metric_type` — extensible by adding branches
+- The issue (#174) explicitly deferred "new achievement tracks" to a follow-up
+
+**Pain points:**
+
+| Pain | Impact |
+|---|---|
+| Only 5 groups — users who primarily do quick workouts, train legs, or work out early have no recognition | Low engagement ceiling; achievements feel narrow |
+| No streak-based metric — `active_weeks` counts total qualifying weeks, not *consecutive* ones | Misses the "don't break the chain" psychology that drives retention |
+| No muscle-group-specific track — variety is rewarded, but specialization isn't | Users who focus on a body part (e.g. PPL legs day) get no acknowledgment |
+| Ad-hoc ("quick") sessions are invisible to the achievement system | Power users who skip program days and just lift get zero badge progress beyond volume/PRs |
+
+---
+
+## Goals
+
+| Goal | Measure |
+|---|---|
+| Broaden the achievement surface to reward 7 distinct play styles | 12 total groups live, each with 5 tiers (60 total tiers) |
+| Introduce streak-based and time-based metrics alongside existing aggregates | Streak King and PR Streak use window-function gap detection; Early Bird uses timezone-aware local hour |
+| Zero frontend component changes — purely backend + data + i18n | No new React components; only migration SQL, seed data, and i18n strings |
+| Retroactive grant for existing users on deploy | All 7 new tracks evaluated for historical data via the same idempotent RPC |
+
+---
+
+## Scope
+
+**In scope:**
+
+1. **Quick & Dirty** (`quick_sessions`) — count of finished sessions where `workout_day_id IS NULL`
+2. **Leg Day Survivor** (`leg_day`) — count of sets targeting leg muscle groups (`Quadriceps`, `Ischios`, `Fessiers`)
+3. **Streak King** (`streak_king`) — longest streak of consecutive calendar weeks with at least 1 finished session
+4. **Le Spécialiste** (`specialist`) — highest set count for any single muscle group (user's best, dynamic)
+5. **Le Marathonien** (`marathoner`) — count of sessions where total volume (weight × reps) exceeds a qualifying threshold
+6. **La Série Ininterrompue** (`pr_streak`) — longest streak of consecutive sessions where at least 1 set was a PR
+7. **Early Bird** (`early_bird`) — count of sessions finished before 8:00 AM local time
+
+For each track:
+- 1 new row in `achievement_groups` + 5 rows in `achievement_tiers`
+- 1 new `UNION ALL` branch in both RPCs' `metrics` CTE
+- Threshold values following the exponential curve from the rebalance migration
+- i18n strings for group names, descriptions, threshold hints (EN + FR)
+- Badge icon assets (5 ranks × 7 tracks = 35 new icons)
+
+Supporting infrastructure:
+- `timezone text` column on `user_profiles` (for Early Bird local-time computation)
+- Backfill existing users with `'Europe/Paris'` (all current users are FR)
+- Silent timezone capture during onboarding via `Intl.DateTimeFormat().resolvedOptions().timeZone`
+
+**Out of scope:**
+
+- New frontend components or UI changes (accordion already handles N groups)
+- Bodyweight Beast, Marathon Sets, Program Loyalist (stretch tracks from issue — deferred)
+- Admin UI for achievement management
+- Social sharing / leaderboards
+- `user_lifetime_stats` materialized table (optimization — not needed at current scale)
+
+---
+
+## Track Feasibility Analysis
+
+### Track 1: Quick & Dirty (`quick_sessions`)
+
+**Metric:** `COUNT(*) FROM user_sessions WHERE workout_day_id IS NULL`
+
+**Feasibility:** Trivial. `sessions.workout_day_id` is nullable — `NULL` means the user started an ad-hoc / quick workout without selecting a program day. Already indexed via `idx_sessions_user_finished`.
+
+**Edge cases:**
+- Sessions started from a program day but where user deleted the program mid-session: `workout_day_id` may still be set → correctly excluded
+- Offline quick sessions: synced with `workout_day_id = NULL` → correctly counted
+
+| Rank | Title (FR) | Title (EN) | Threshold |
+|---|---|---|---|
+| Bronze | "Pas d'excuse" | "No Excuses" | 5 sessions |
+| Silver | "Franc-tireur" | "Lone Wolf" | 20 sessions |
+| Gold | "Électron libre" | "Free Radical" | 60 sessions |
+| Platinum | "Hors Programme" | "Off Script" | 150 sessions |
+| Diamond | "L'Incontrôlable" | "The Uncontrollable" | 400 sessions |
+
+---
+
+### Track 2: Leg Day Survivor (`leg_day`)
+
+**Metric:** `COUNT(*) FROM set_logs sl JOIN exercises e ON e.id = sl.exercise_id JOIN user_sessions us ON us.id = sl.session_id WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers')`
+
+**Feasibility:** Straightforward. Requires a JOIN to `exercises` (not done by any existing CTE). The `muscle_group` column uses French taxonomy values — the 3 big leg groups cover the classic "leg day" muscles. Adducteurs and Mollets are excluded (isolation, not compound leg work).
+
+**Edge cases:**
+- Secondary muscles are NOT counted (`secondary_muscles` array) — only `muscle_group` (primary). Keeps the metric clean and predictable.
+- Duration exercises (e.g. wall sits) with `reps_logged IS NULL`: still counted — we're counting *sets performed*, not reps.
+
+| Rank | Title (FR) | Title (EN) | Threshold |
+|---|---|---|---|
+| Bronze | "Rescapé du squat" | "Squat Survivor" | 50 sets |
+| Silver | "Anti-chicken legs" | "Anti-Chicken Legs" | 200 sets |
+| Gold | "Roi du Rack" | "Rack Royalty" | 500 sets |
+| Platinum | "Pilier de fonte" | "Iron Pillar" | 1,200 sets |
+| Diamond | "Titan des cuisses" | "Thigh Titan" | 3,000 sets |
+
+---
+
+### Track 3: Streak King (`streak_king`)
+
+**Metric:** Longest streak of consecutive calendar weeks where the user finished at least 1 session.
+
+**Feasibility:** Requires window-function gap detection — a step up from existing simple aggregates. The CTE:
+1. Extract distinct calendar weeks (`date_trunc('week', finished_at)`) from `user_sessions`
+2. Assign a sequential week number (epoch-based or `ROW_NUMBER`)
+3. Use the classic `week_number - ROW_NUMBER()` gap detection trick to group consecutive weeks
+4. `MAX(COUNT(*))` across groups = longest streak
+
+Output is still a single numeric value, so the `eligible`/`granted` CTE pattern is unchanged.
+
+**Edge cases:**
+- ISO weeks (`date_trunc('week', ...)` uses Monday as week start in Postgres) — consistent across users
+- A week with only unfinished sessions (`finished_at IS NULL`) doesn't count → correctly excluded by `user_sessions` CTE
+- Gap of exactly 1 week breaks the streak — intentional (this is "consecutive weeks", not "X out of Y")
+- Unlike `active_weeks` (which requires 3+ sessions/week), this only requires 1 session/week — different behavior, distinct value proposition
+
+| Rank | Title (FR) | Title (EN) | Threshold |
+|---|---|---|---|
+| Bronze | "Trois de suite" | "Three in a Row" | 3 weeks |
+| Silver | "Mois sans faille" | "Flawless Month" | 4 weeks |
+| Gold | "Trimestre de fer" | "Iron Quarter" | 12 weeks |
+| Platinum | "Inarrêtable" | "Unstoppable" | 26 weeks |
+| Diamond | "La Chaîne Éternelle" | "The Eternal Chain" | 52 weeks |
+
+---
+
+### Track 4: Le Spécialiste (`specialist`)
+
+**Metric:** `MAX(muscle_group_count)` — the highest set count for any single `exercises.muscle_group` value across all the user's logged sets.
+
+**Feasibility:** Moderate. GROUP BY `muscle_group`, COUNT sets per group, take MAX. Requires the same JOIN to `exercises` as Leg Day.
+
+**Edge cases:**
+- The "best" muscle group is dynamic per user — a chest-focused user and a back-focused user both progress toward the same thresholds
+- If a user switches focus, the metric tracks their all-time best group — it can only grow (monotonic)
+- Only `muscle_group` (primary) counts, not `secondary_muscles`
+
+| Rank | Title (FR) | Title (EN) | Threshold |
+|---|---|---|---|
+| Bronze | "Apprenti spécialiste" | "Novice Specialist" | 50 sets |
+| Silver | "Mono-obsessionnel" | "Single-Minded" | 200 sets |
+| Gold | "Expert de zone" | "Zone Expert" | 500 sets |
+| Platinum | "Maître d'un art" | "Master of One" | 1,200 sets |
+| Diamond | "Le Chirurgien" | "The Surgeon" | 3,000 sets |
+
+---
+
+### Track 5: Le Marathonien (`marathoner`)
+
+**Metric:** Count of sessions where `SUM(weight_logged * reps_logged::int) >= 5000` (kg) within that single session.
+
+**Feasibility:** Moderate. Requires per-session volume aggregation, then counting qualifying sessions. A subquery groups `set_logs` by `session_id`, computes session volume, filters by threshold, then counts.
+
+**Design decision:** The 5,000 kg qualifying floor is hardcoded in the CTE. This is a "what counts as a heavy session" constant, not a tier threshold. The tiers then reward *how many* heavy sessions you've done. If the floor needs tuning, it's a single value in the migration.
+
+**Edge cases:**
+- Duration-based sets (`reps_logged IS NULL`) excluded from volume computation — same as existing `total_volume_kg` metric
+- Non-numeric `reps_logged` values excluded via `reps_logged ~ '^\d+$'` guard — consistent with existing RPCs
+- Sessions with only bodyweight exercises may never reach 5,000 kg — acceptable, this track rewards heavy volume
+
+| Rank | Title (FR) | Title (EN) | Threshold |
+|---|---|---|---|
+| Bronze | "Séance lourde" | "Heavy Hitter" | 5 sessions |
+| Silver | "Tonnage garanti" | "Tonnage Guaranteed" | 20 sessions |
+| Gold | "Broyeur de barres" | "Bar Crusher" | 60 sessions |
+| Platinum | "Usine à volume" | "Volume Factory" | 150 sessions |
+| Diamond | "Le Marathonien" | "The Marathoner" | 400 sessions |
+
+---
+
+### Track 6: La Série Ininterrompue (`pr_streak`)
+
+**Metric:** Longest streak of consecutive sessions (ordered by `finished_at`) where at least 1 set had `was_pr = true`.
+
+**Feasibility:** Complex — same gap-detection pattern as Streak King, but over sessions instead of weeks. The CTE:
+1. Identify sessions with at least 1 PR (`EXISTS (SELECT 1 FROM set_logs WHERE session_id = us.id AND was_pr = true)`)
+2. Assign ordinal rank to ALL sessions, then identify PR sessions within that sequence
+3. Gap detection via `session_rank - ROW_NUMBER()` on PR sessions only
+4. `MAX(group_size)` = longest PR streak
+
+**Edge cases:**
+- A session with 0 PRs breaks the streak — intentional
+- Quick sessions and program sessions both count — if they have a PR, they're in
+- Two sessions on the same day: ordered by `finished_at` — both count separately
+- Historical PR backfill (`was_pr` already backfilled via `scripts/backfill-was-pr.ts`) means retroactive evaluation is accurate
+
+| Rank | Title (FR) | Title (EN) | Threshold |
+|---|---|---|---|
+| Bronze | "Feu de paille" | "Flash Fire" | 3 sessions |
+| Silver | "Série chaude" | "Hot Streak" | 5 sessions |
+| Gold | "Machine à records" | "Record Machine" | 10 sessions |
+| Platinum | "Fléau des plateaux" | "Plateau Slayer" | 20 sessions |
+| Diamond | "L'Inarrêtable" | "The Relentless" | 40 sessions |
+
+---
+
+### Track 7: Early Bird (`early_bird`)
+
+**Metric:** `COUNT(*) FROM user_sessions us JOIN user_profiles up ON up.user_id = ... WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE up.timezone) < 8`
+
+**Feasibility:** Moderate. `finished_at` is `timestamptz`. Converting to the user's local time requires a `timezone` column on `user_profiles`. The `AT TIME ZONE` conversion in Postgres is well-supported for IANA timezone names (e.g. `'Europe/Paris'`).
+
+**Timezone strategy (settled):**
+- **New column:** `ALTER TABLE user_profiles ADD COLUMN timezone text DEFAULT 'UTC'`
+- **Backfill:** `UPDATE user_profiles SET timezone = 'Europe/Paris'` — all current users are FR
+- **New users:** Captured silently during onboarding via `Intl.DateTimeFormat().resolvedOptions().timeZone` in `file:src/hooks/useCreateUserProfile.ts` — no form field, no question asked
+- **Fallback:** If `timezone` is somehow NULL, the CTE falls back to `'UTC'`
+
+**Edge cases:**
+- Sessions finished at exactly 8:00:00 AM → NOT counted (`< 8`, not `<= 8`)
+- Overnight sessions (started 11 PM, finished 1 AM) → `finished_at` is 1 AM → counts as early bird
+- DST transitions: Postgres handles this correctly with IANA timezone names
+- User who travels: timezone reflects registration timezone, not current location — acceptable for MVP. A future enhancement could update timezone on login.
+
+| Rank | Title (FR) | Title (EN) | Threshold |
+|---|---|---|---|
+| Bronze | "Lève-tôt" | "Early Riser" | 5 sessions |
+| Silver | "Coq du matin" | "Morning Rooster" | 20 sessions |
+| Gold | "Guerrier de l'aube" | "Dawn Warrior" | 60 sessions |
+| Platinum | "Premier au rack" | "First at the Rack" | 150 sessions |
+| Diamond | "Le Soleil se lève pour toi" | "The Sun Rises for You" | 400 sessions |
+
+---
+
+## Success Criteria
+
+- **Numeric:** 12 achievement groups live (5 existing + 7 new), 60 total tiers, all evaluable by the existing idempotent RPC
+- **Numeric:** Both RPCs (`check_and_grant_achievements`, `get_badge_status`) execute in < 200ms for a user with 500 sessions and 10k set_logs (verified via `EXPLAIN ANALYZE`)
+- **Qualitative:** Existing users see retroactively granted badges for the 7 new tracks on first app open after deploy (no overlay flood — silent insert)
+- **Qualitative:** The accordion UI displays all 12 groups with no layout or performance degradation
+- **Qualitative:** New users get their timezone captured silently at onboarding — no extra form step
+- **Qualitative:** Adding a 13th track in the future requires only a SQL migration (INSERT groups + tiers + CTE branch) and i18n strings — no React component changes
+
+---
+
+## References
+
+- Parent issue: #218
+- Predecessor issues: #129 (gamification system), #174 (UI redesign)
+- UI redesign PR: #217
+- Discovery doc: `file:docs/done/Discovery_—_Gamification_Achievement_Badge_System_#129.md`
+- Tech Plan (backend): `file:docs/done/Tech_Plan_—_Gamification_Achievement_Badge_System_#129.md`
+- Tech Plan (UI): `file:docs/Tech_Plan_—_Achievements_UI_Redesign_#174.md`
+- Current RPCs (source of truth): `file:supabase/migrations/20260403000001_rebalance_thresholds_and_replace_rhythm.sql`
+- Muscle taxonomy: `file:src/lib/trainingBalance.ts` (13 French values)
+- Onboarding profile creation: `file:src/hooks/useCreateUserProfile.ts`

--- a/docs/Tech_Plan_—_New_Achievement_Tracks_#218.md
+++ b/docs/Tech_Plan_—_New_Achievement_Tracks_#218.md
@@ -1,0 +1,917 @@
+# Tech Plan — New Achievement Tracks (#218)
+
+## Architectural Approach
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **RPC extension strategy** | Add 7 new `UNION ALL` branches to the `metrics` CTE in both RPCs | Same pattern as existing 5 metrics. No new RPCs, no new tables. The `eligible` / `granted` CTE pattern consumes any `metric_type` generically — adding a new branch is the only change. |
+| **Streak computation** | Window-function gap detection (`ROW_NUMBER` trick) inside the CTE | Outputs a single `numeric` value (longest streak) — fits the existing `metrics` contract. No schema change needed. |
+| **Leg Day join** | JOIN `set_logs` → `exercises` on `exercise_id` | The only way to access `muscle_group`. Acceptable cost: `exercises` table is small (< 1000 rows, likely cached). No new index needed — `exercise_id` FK on `set_logs` is already indexed. |
+| **Specialist metric** | `MAX(count)` over `GROUP BY muscle_group` | Dynamic per user — rewards their strongest area. Monotonic (can only grow), so tiers are never "lost". |
+| **Marathoner qualifying floor** | Hardcoded 5,000 kg per session in the CTE | A design constant, not a tier threshold. Tiers count *how many* heavy sessions. If the floor needs tuning, a single value changes in the migration. |
+| **Early Bird timezone** | New `timezone text` column on `user_profiles` + `AT TIME ZONE` in CTE | Postgres handles IANA timezone names natively. Backfill existing FR users with `'Europe/Paris'`. New users: silent browser capture via `Intl.DateTimeFormat().resolvedOptions().timeZone`. |
+| **Timezone capture** | In `file:src/hooks/useCreateUserProfile.ts` upsert payload | Zero UX friction — no form field. Captured at profile creation (onboarding). Falls back to `'UTC'` if null. |
+| **Migration approach** | Single migration: seed data + RPC replacement + timezone column + backfill | All changes are additive. Existing `user_achievements` rows are untouched — only new groups/tiers are inserted. RPCs are replaced with expanded `metrics` CTE. |
+| **Retroactive grant** | Re-run `check_and_grant_achievements` for all users post-migration | Same idempotent RPC. Existing badges unaffected (`ON CONFLICT DO NOTHING`). New tracks evaluated against historical data. |
+| **i18n** | Extend existing `achievements` namespace with 7 new group entries | Follows established pattern: `groups.*`, `groupDescriptions.*`, `thresholdHint.*`. |
+| **PR strategy** | Single PR: migration + i18n + timezone capture | Low surface area — no UI components changed. The accordion already renders N groups dynamically. |
+
+### Critical Constraints
+
+**RPC replacement is atomic.** Both `check_and_grant_achievements` and `get_badge_status` are replaced via `CREATE OR REPLACE FUNCTION`. The new versions include all 12 metric branches (5 existing + 7 new). If the migration fails mid-way, the old RPCs remain intact. No partial state.
+
+**`user_sessions` CTE is shared.** All 12 metric branches read from the same `user_sessions` CTE. Postgres materializes it once — no redundant `sessions` scans. Adding 7 branches does NOT multiply the session table reads.
+
+**Exercises JOIN cost.** Three metrics (`leg_day`, `specialist`, `early_bird`... no — `leg_day` and `specialist`) require a JOIN to `exercises`. This is a small table (< 1000 rows, fits in shared_buffers). The JOIN is through `set_logs.exercise_id` which already has an FK index. No new index needed.
+
+**`user_profiles` JOIN for Early Bird.** The `early_bird` CTE needs `user_profiles.timezone`. This is a single-row lookup by PK (`user_id`). Negligible cost. The CTE uses `COALESCE(up.timezone, 'UTC')` for null safety.
+
+**Existing `sort_order` values.** Current groups use `sort_order` 1–5. New groups use 6–12. If future reordering is needed, UPDATE is trivial — `sort_order` is only used in the `ORDER BY` of `get_badge_status`.
+
+**`reps_logged` safe cast.** The `^\d+$` regex guard from the rebalance migration (`file:supabase/migrations/20260403000001_rebalance_thresholds_and_replace_rhythm.sql`) is preserved in the `total_volume_kg` and `marathoner` branches. No risk of cast failure.
+
+---
+
+## Data Model
+
+### ER Diagram (additions only)
+
+```mermaid
+erDiagram
+    user_profiles {
+        uuid user_id PK
+        text timezone "NEW — IANA timezone name"
+    }
+    achievement_groups {
+        uuid id PK
+        text slug UK
+        text metric_type "7 new values"
+        int sort_order "6-12 for new groups"
+    }
+    achievement_groups ||--o{ achievement_tiers : "5 tiers each"
+    achievement_tiers {
+        uuid id PK
+        uuid group_id FK
+        int tier_level "1-5"
+        text rank
+        numeric threshold_value
+    }
+```
+
+No new tables. The additions are:
+- 7 rows in `achievement_groups`
+- 35 rows in `achievement_tiers`
+- 1 column on `user_profiles`
+
+### Migration: Timezone Column + Backfill
+
+```sql
+-- Add timezone column to user_profiles
+ALTER TABLE user_profiles ADD COLUMN timezone text;
+
+-- Backfill existing users (all FR)
+UPDATE user_profiles SET timezone = 'Europe/Paris' WHERE timezone IS NULL;
+```
+
+### Migration: Seed New Achievement Groups
+
+```sql
+INSERT INTO achievement_groups (slug, name_fr, name_en, description_fr, description_en, metric_type, sort_order)
+VALUES
+  ('quick_sessions', 'Quick & Dirty',       'Quick & Dirty',       'Séances rapides (sans programme)',              'Quick sessions (no program)',                   'quick_sessions',  6),
+  ('leg_day',        'Leg Day',              'Leg Day',             'Séries ciblant les jambes',                     'Sets targeting leg muscles',                    'leg_day',         7),
+  ('streak_king',    'Streak King',          'Streak King',         'Plus longue série de semaines consécutives',    'Longest streak of consecutive weeks',           'streak_king',     8),
+  ('specialist',     'Le Spécialiste',       'The Specialist',      'Séries sur ton meilleur groupe musculaire',     'Sets on your best muscle group',                'specialist',      9),
+  ('marathoner',     'Le Marathonien',       'The Marathoner',      'Séances avec un volume total ≥ 5 000 kg',      'Sessions with total volume ≥ 5,000 kg',         'marathoner',     10),
+  ('pr_streak',      'Série de Records',     'PR Streak',           'Plus longue série de séances avec au moins 1 PR','Longest streak of sessions with at least 1 PR','pr_streak',      11),
+  ('early_bird',     'Early Bird',           'Early Bird',          'Séances terminées avant 8h',                    'Sessions finished before 8 AM',                 'early_bird',     12);
+```
+
+### Migration: Seed New Achievement Tiers
+
+```sql
+-- Quick & Dirty
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'quick_sessions')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Pas d''excuse',       'No Excuses',          5),
+  ((SELECT id FROM g), 2, 'silver',   'Franc-tireur',        'Lone Wolf',           20),
+  ((SELECT id FROM g), 3, 'gold',     'Électron libre',      'Free Radical',        60),
+  ((SELECT id FROM g), 4, 'platinum', 'Hors Programme',      'Off Script',          150),
+  ((SELECT id FROM g), 5, 'diamond',  'L''Incontrôlable',    'The Uncontrollable',  400);
+
+-- Leg Day Survivor
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'leg_day')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Rescapé du squat',    'Squat Survivor',      50),
+  ((SELECT id FROM g), 2, 'silver',   'Anti-chicken legs',   'Anti-Chicken Legs',   200),
+  ((SELECT id FROM g), 3, 'gold',     'Roi du Rack',         'Rack Royalty',        500),
+  ((SELECT id FROM g), 4, 'platinum', 'Pilier de fonte',     'Iron Pillar',         1200),
+  ((SELECT id FROM g), 5, 'diamond',  'Titan des cuisses',   'Thigh Titan',         3000);
+
+-- Streak King
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'streak_king')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Trois de suite',      'Three in a Row',      3),
+  ((SELECT id FROM g), 2, 'silver',   'Mois sans faille',    'Flawless Month',      4),
+  ((SELECT id FROM g), 3, 'gold',     'Trimestre de fer',    'Iron Quarter',        12),
+  ((SELECT id FROM g), 4, 'platinum', 'Inarrêtable',         'Unstoppable',         26),
+  ((SELECT id FROM g), 5, 'diamond',  'La Chaîne Éternelle', 'The Eternal Chain',   52);
+
+-- Le Spécialiste
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'specialist')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Apprenti spécialiste','Novice Specialist',   50),
+  ((SELECT id FROM g), 2, 'silver',   'Mono-obsessionnel',   'Single-Minded',       200),
+  ((SELECT id FROM g), 3, 'gold',     'Expert de zone',      'Zone Expert',         500),
+  ((SELECT id FROM g), 4, 'platinum', 'Maître d''un art',    'Master of One',       1200),
+  ((SELECT id FROM g), 5, 'diamond',  'Le Chirurgien',       'The Surgeon',         3000);
+
+-- Le Marathonien
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'marathoner')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Séance lourde',       'Heavy Hitter',        5),
+  ((SELECT id FROM g), 2, 'silver',   'Tonnage garanti',     'Tonnage Guaranteed',  20),
+  ((SELECT id FROM g), 3, 'gold',     'Broyeur de barres',   'Bar Crusher',         60),
+  ((SELECT id FROM g), 4, 'platinum', 'Usine à volume',      'Volume Factory',      150),
+  ((SELECT id FROM g), 5, 'diamond',  'Le Marathonien',      'The Marathoner',      400);
+
+-- La Série Ininterrompue (PR Streak)
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'pr_streak')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Feu de paille',       'Flash Fire',          3),
+  ((SELECT id FROM g), 2, 'silver',   'Série chaude',        'Hot Streak',          5),
+  ((SELECT id FROM g), 3, 'gold',     'Machine à records',   'Record Machine',      10),
+  ((SELECT id FROM g), 4, 'platinum', 'Fléau des plateaux',  'Plateau Slayer',      20),
+  ((SELECT id FROM g), 5, 'diamond',  'L''Inarrêtable',      'The Relentless',      40);
+
+-- Early Bird
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'early_bird')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Lève-tôt',                    'Early Riser',              5),
+  ((SELECT id FROM g), 2, 'silver',   'Coq du matin',                'Morning Rooster',          20),
+  ((SELECT id FROM g), 3, 'gold',     'Guerrier de l''aube',         'Dawn Warrior',             60),
+  ((SELECT id FROM g), 4, 'platinum', 'Premier au rack',             'First at the Rack',        150),
+  ((SELECT id FROM g), 5, 'diamond',  'Le Soleil se lève pour toi',  'The Sun Rises for You',    400);
+```
+
+### Table Notes
+
+- **`achievement_groups.metric_type`** — 7 new values: `quick_sessions`, `leg_day`, `streak_king`, `specialist`, `marathoner`, `pr_streak`, `early_bird`. Each maps 1:1 to a CTE alias in both RPCs.
+- **`user_profiles.timezone`** — nullable `text`. Stores IANA timezone names (e.g. `'Europe/Paris'`, `'America/New_York'`). Backfilled to `'Europe/Paris'` for all existing users. New users get it from browser detection. Used only by the `early_bird` CTE.
+- **Marathoner qualifying floor** — the 5,000 kg threshold is NOT in the schema. It's hardcoded in the CTE as a design constant. Changing it requires a migration that replaces the RPC function body.
+
+---
+
+## RPC Definitions
+
+Both RPCs are replaced via `CREATE OR REPLACE FUNCTION`. The full function bodies are shown below. Changes from the current version (`file:supabase/migrations/20260403000001_rebalance_thresholds_and_replace_rhythm.sql`) are limited to the `metrics` CTE — 7 new `UNION ALL` branches are appended. Everything else (auth guard, `user_sessions`, `eligible`, `granted`, return query) is identical.
+
+### New Metric CTE Branches
+
+These 7 branches are appended to the existing `metrics` CTE in both RPCs:
+
+```sql
+    -- === NEW TRACKS (#218) ===
+
+    -- Quick & Dirty: sessions without a program day
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      WHERE us.workout_day_id IS NULL
+
+    -- Leg Day Survivor: sets targeting leg muscle groups
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers')
+
+    -- Streak King: longest consecutive-week streak
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    -- Le Spécialiste: best single muscle group set count
+    UNION ALL
+    SELECT 'specialist', COALESCE(MAX(mg_count), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS mg_count
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        JOIN exercises e ON e.id = sl.exercise_id
+        GROUP BY e.muscle_group
+      ) per_group
+
+    -- Le Marathonien: sessions with total volume >= 5000 kg
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    -- La Série Ininterrompue: longest consecutive-session PR streak
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT pr_rank,
+                 pr_rank - (ROW_NUMBER() OVER (ORDER BY pr_rank))::bigint AS grp
+          FROM (
+            SELECT DENSE_RANK() OVER (ORDER BY us.finished_at) AS pr_rank
+            FROM user_sessions us
+            WHERE EXISTS (
+              SELECT 1 FROM set_logs sl
+              WHERE sl.session_id = us.id AND sl.was_pr = true
+            )
+          ) pr_sessions
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    -- Early Bird: sessions finished before 8 AM local time
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) < 8
+```
+
+### Full `check_and_grant_achievements` (replacement)
+
+```sql
+CREATE OR REPLACE FUNCTION check_and_grant_achievements(p_user_id uuid)
+RETURNS TABLE (
+  tier_id uuid, group_slug text, rank text,
+  title_en text, title_fr text, icon_asset_url text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+BEGIN
+  IF auth.uid() IS NOT NULL AND auth.uid() <> p_user_id THEN
+    RAISE EXCEPTION 'access denied: cannot grant achievements for another user'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_sessions AS (
+    SELECT s.id, s.workout_day_id, s.finished_at
+    FROM sessions s
+    WHERE s.user_id = p_user_id AND s.finished_at IS NOT NULL
+  ),
+  metrics AS (
+    -- === EXISTING TRACKS ===
+    SELECT 'session_count' AS metric_type, COUNT(*)::numeric AS value
+      FROM user_sessions
+
+    UNION ALL
+    SELECT 'total_volume_kg',
+           COALESCE(SUM(sl.weight_logged * sl.reps_logged::int), 0)
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.reps_logged IS NOT NULL
+        AND sl.reps_logged ~ '^\d+$'
+
+    UNION ALL
+    SELECT 'pr_count', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.was_pr = true
+
+    UNION ALL
+    SELECT 'unique_exercises', COUNT(DISTINCT sl.exercise_id)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+
+    UNION ALL
+    SELECT 'active_weeks', COUNT(*)::numeric
+      FROM (
+        SELECT date_trunc('week', us.finished_at) AS wk
+        FROM user_sessions us
+        GROUP BY date_trunc('week', us.finished_at)
+        HAVING COUNT(*) >= 3
+      ) AS weeks_with_3plus
+
+    -- === NEW TRACKS (#218) ===
+
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      WHERE us.workout_day_id IS NULL
+
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers')
+
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'specialist', COALESCE(MAX(mg_count), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS mg_count
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        JOIN exercises e ON e.id = sl.exercise_id
+        GROUP BY e.muscle_group
+      ) per_group
+
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT pr_rank,
+                 pr_rank - (ROW_NUMBER() OVER (ORDER BY pr_rank))::bigint AS grp
+          FROM (
+            SELECT DENSE_RANK() OVER (ORDER BY us.finished_at) AS pr_rank
+            FROM user_sessions us
+            WHERE EXISTS (
+              SELECT 1 FROM set_logs sl
+              WHERE sl.session_id = us.id AND sl.was_pr = true
+            )
+          ) pr_sessions
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) < 8
+  ),
+  eligible AS (
+    SELECT at.id, ag.slug, at.rank AS r,
+           at.title_en, at.title_fr, at.icon_asset_url
+    FROM metrics m
+    JOIN achievement_groups ag ON ag.metric_type = m.metric_type
+    JOIN achievement_tiers at ON at.group_id = ag.id
+    WHERE at.threshold_value <= m.value
+      AND NOT EXISTS (
+        SELECT 1 FROM user_achievements ua
+        WHERE ua.user_id = p_user_id AND ua.tier_id = at.id
+      )
+  ),
+  granted AS (
+    INSERT INTO user_achievements (user_id, tier_id)
+    SELECT p_user_id, e.id FROM eligible e
+    ON CONFLICT (user_id, tier_id) DO NOTHING
+    RETURNING user_achievements.tier_id
+  )
+  SELECT e.id, e.slug, e.r, e.title_en, e.title_fr, e.icon_asset_url
+  FROM eligible e
+  JOIN granted g ON g.tier_id = e.id;
+END;
+$$;
+```
+
+### Full `get_badge_status` (replacement)
+
+```sql
+CREATE OR REPLACE FUNCTION get_badge_status(p_user_id uuid)
+RETURNS TABLE (
+  group_id uuid, group_slug text, group_name_en text, group_name_fr text,
+  tier_id uuid, tier_level int, rank text,
+  title_en text, title_fr text,
+  threshold_value numeric, icon_asset_url text,
+  is_unlocked boolean, granted_at timestamptz,
+  current_value numeric, progress_pct numeric
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+BEGIN
+  IF auth.uid() IS NOT NULL AND auth.uid() <> p_user_id THEN
+    RAISE EXCEPTION 'access denied: cannot read badge status for another user'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_sessions AS (
+    SELECT s.id, s.workout_day_id, s.finished_at
+    FROM sessions s
+    WHERE s.user_id = p_user_id AND s.finished_at IS NOT NULL
+  ),
+  metrics AS (
+    -- === EXISTING TRACKS ===
+    SELECT 'session_count' AS metric_type, COUNT(*)::numeric AS value
+      FROM user_sessions
+
+    UNION ALL
+    SELECT 'total_volume_kg',
+           COALESCE(SUM(sl.weight_logged * sl.reps_logged::int), 0)
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.reps_logged IS NOT NULL
+        AND sl.reps_logged ~ '^\d+$'
+
+    UNION ALL
+    SELECT 'pr_count', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.was_pr = true
+
+    UNION ALL
+    SELECT 'unique_exercises', COUNT(DISTINCT sl.exercise_id)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+
+    UNION ALL
+    SELECT 'active_weeks', COUNT(*)::numeric
+      FROM (
+        SELECT date_trunc('week', us.finished_at) AS wk
+        FROM user_sessions us
+        GROUP BY date_trunc('week', us.finished_at)
+        HAVING COUNT(*) >= 3
+      ) AS weeks_with_3plus
+
+    -- === NEW TRACKS (#218) ===
+
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      WHERE us.workout_day_id IS NULL
+
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers')
+
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'specialist', COALESCE(MAX(mg_count), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS mg_count
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        JOIN exercises e ON e.id = sl.exercise_id
+        GROUP BY e.muscle_group
+      ) per_group
+
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT pr_rank,
+                 pr_rank - (ROW_NUMBER() OVER (ORDER BY pr_rank))::bigint AS grp
+          FROM (
+            SELECT DENSE_RANK() OVER (ORDER BY us.finished_at) AS pr_rank
+            FROM user_sessions us
+            WHERE EXISTS (
+              SELECT 1 FROM set_logs sl
+              WHERE sl.session_id = us.id AND sl.was_pr = true
+            )
+          ) pr_sessions
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) < 8
+  )
+  SELECT
+    ag.id, ag.slug, ag.name_en, ag.name_fr,
+    at.id, at.tier_level, at.rank,
+    at.title_en, at.title_fr,
+    at.threshold_value, at.icon_asset_url,
+    (ua.id IS NOT NULL), ua.granted_at,
+    COALESCE(m.value, 0),
+    LEAST(COALESCE(m.value, 0) / NULLIF(at.threshold_value, 0) * 100, 100)
+  FROM achievement_groups ag
+  JOIN achievement_tiers at ON at.group_id = ag.id
+  LEFT JOIN user_achievements ua ON ua.tier_id = at.id AND ua.user_id = p_user_id
+  LEFT JOIN metrics m ON m.metric_type = ag.metric_type
+  ORDER BY ag.sort_order, at.tier_level;
+END;
+$$;
+```
+
+---
+
+## Component Architecture
+
+### Layer Overview
+
+```mermaid
+graph TD
+    Migration["SQL Migration"]
+    Migration --> SeedGroups["INSERT 7 achievement_groups"]
+    Migration --> SeedTiers["INSERT 35 achievement_tiers"]
+    Migration --> TimezoneCol["ALTER user_profiles ADD timezone"]
+    Migration --> TimezoneBackfill["UPDATE timezone = Europe/Paris"]
+    Migration --> ReplaceRPC1["CREATE OR REPLACE check_and_grant"]
+    Migration --> ReplaceRPC2["CREATE OR REPLACE get_badge_status"]
+
+    Frontend["Frontend Changes"]
+    Frontend --> i18nEN["achievements.json EN — 7 new group entries"]
+    Frontend --> i18nFR["achievements.json FR — 7 new group entries"]
+    Frontend --> TZCapture["useCreateUserProfile — add timezone to upsert"]
+    Frontend --> TypeUpdate["UserProfile type — add timezone field"]
+```
+
+### New Files
+
+| File | Purpose |
+|---|---|
+| `supabase/migrations/2026XXXXXXXXXX_new_achievement_tracks.sql` | Single migration: timezone column, backfill, 7 groups, 35 tiers, both RPCs replaced |
+
+### Modified Files
+
+| File | Change |
+|---|---|
+| `file:src/locales/en/achievements.json` | Add 7 entries each to `groups`, `groupDescriptions`, `thresholdHint` |
+| `file:src/locales/fr/achievements.json` | French equivalents |
+| `file:src/hooks/useCreateUserProfile.ts` | Add `timezone: Intl.DateTimeFormat().resolvedOptions().timeZone` to upsert payload |
+| `file:src/types/onboarding.ts` | Add `timezone: string \| null` to `UserProfile` interface |
+
+### i18n Additions
+
+**English (`achievements.json`):**
+
+```json
+{
+  "groups": {
+    "quick_sessions": "Quick & Dirty",
+    "leg_day": "Leg Day",
+    "streak_king": "Streak King",
+    "specialist": "The Specialist",
+    "marathoner": "The Marathoner",
+    "pr_streak": "PR Streak",
+    "early_bird": "Early Bird"
+  },
+  "groupDescriptions": {
+    "quick_sessions": "Quick sessions (no program)",
+    "leg_day": "Sets targeting leg muscles",
+    "streak_king": "Longest streak of consecutive weeks",
+    "specialist": "Sets on your best muscle group",
+    "marathoner": "Sessions with total volume ≥ 5,000 kg",
+    "pr_streak": "Longest streak of sessions with a PR",
+    "early_bird": "Sessions finished before 8 AM"
+  },
+  "thresholdHint": {
+    "quick_sessions": "Complete {{target}} quick sessions",
+    "leg_day": "Log {{target}} leg sets",
+    "streak_king": "Train {{target}} weeks in a row",
+    "specialist": "Log {{target}} sets for one muscle group",
+    "marathoner": "Complete {{target}} heavy sessions (≥ 5,000 kg)",
+    "pr_streak": "Set PRs in {{target}} sessions in a row",
+    "early_bird": "Finish {{target}} sessions before 8 AM"
+  }
+}
+```
+
+**French (`achievements.json`):**
+
+```json
+{
+  "groups": {
+    "quick_sessions": "Quick & Dirty",
+    "leg_day": "Leg Day",
+    "streak_king": "Streak King",
+    "specialist": "Le Spécialiste",
+    "marathoner": "Le Marathonien",
+    "pr_streak": "Série de Records",
+    "early_bird": "Early Bird"
+  },
+  "groupDescriptions": {
+    "quick_sessions": "Séances rapides (sans programme)",
+    "leg_day": "Séries ciblant les jambes",
+    "streak_king": "Plus longue série de semaines consécutives",
+    "specialist": "Séries sur ton meilleur groupe musculaire",
+    "marathoner": "Séances avec un volume total ≥ 5 000 kg",
+    "pr_streak": "Plus longue série de séances avec au moins 1 PR",
+    "early_bird": "Séances terminées avant 8h"
+  },
+  "thresholdHint": {
+    "quick_sessions": "Terminer {{target}} séances rapides",
+    "leg_day": "Enregistrer {{target}} séries jambes",
+    "streak_king": "S'entraîner {{target}} semaines d'affilée",
+    "specialist": "Enregistrer {{target}} séries pour un groupe musculaire",
+    "marathoner": "Compléter {{target}} séances lourdes (≥ 5 000 kg)",
+    "pr_streak": "Battre des records dans {{target}} séances d'affilée",
+    "early_bird": "Terminer {{target}} séances avant 8h"
+  }
+}
+```
+
+### Frontend Component Impact
+
+**Zero new components.** The accordion UI (`file:src/components/achievements/AchievementAccordion.tsx`) renders groups dynamically from `get_badge_status` RPC output. Adding 7 new groups = 7 more `AccordionItem` instances — no code change, just more data rows.
+
+`BadgeIcon`, `BadgeDetailDrawer`, `BadgeShowcase`, `AchievementUnlockOverlay` — all work generically on `BadgeStatusRow` data. No changes needed.
+
+### Timezone Capture Flow
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant useCreateUserProfile
+    participant Supabase
+
+    Browser->>useCreateUserProfile: onboarding submit
+    useCreateUserProfile->>useCreateUserProfile: timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    useCreateUserProfile->>Supabase: upsert user_profiles { ...profile, timezone }
+    Supabase-->>useCreateUserProfile: OK
+```
+
+No form field. No user interaction. `Intl.DateTimeFormat` is supported in all modern browsers and returns a valid IANA timezone name.
+
+---
+
+## Failure Mode Analysis
+
+| Failure | Behavior |
+|---|---|
+| `exercises` table missing a `muscle_group` value for a logged exercise | `leg_day` and `specialist` CTEs use INNER JOIN — orphaned `exercise_id` rows are silently excluded. No crash. |
+| `user_profiles.timezone` is NULL for a user | `COALESCE(up.timezone, 'UTC')` fallback. Sessions evaluated against UTC. Slightly inaccurate for Early Bird but never crashes. |
+| User has 0 sessions | All metric branches return 0. No tiers granted. `COALESCE(MAX(...), 0)` handles empty streak aggregates. |
+| Streak King with only 1 qualifying week | `MAX(streak_len)` = 1. Below Bronze threshold (3). No badge granted. Correct. |
+| Two sessions with identical `finished_at` timestamps | `DENSE_RANK` in PR Streak handles ties — both get the same rank. `DISTINCT` in Streak King deduplicates weeks. No double-counting. |
+| Marathoner with only duration-based sets in a session | `reps_logged IS NULL` excluded. Session volume = 0. Below 5,000 kg floor. Not counted. Correct. |
+| Migration fails mid-execution | `CREATE OR REPLACE FUNCTION` is atomic per statement. If seed INSERTs fail, RPCs still have old bodies. No partial state — retry the migration. |
+| `Intl.DateTimeFormat` unavailable (very old browser) | `timezone` field will be `undefined` → Supabase stores NULL → CTE uses `'UTC'` fallback. Graceful degradation. |
+
+---
+
+## Testing
+
+### RPC Tests (SQL-level)
+
+| Test | Scenarios |
+|---|---|
+| `quick_sessions` metric | User with 3 quick + 2 program sessions → metric = 3. User with 0 quick → metric = 0. |
+| `leg_day` metric | 10 sets on Quadriceps + 5 on Biceps → metric = 10. Sets on Adducteurs → NOT counted (excluded from leg set). |
+| `streak_king` metric | Sessions in weeks 1,2,3,5,6 → longest streak = 3 (weeks 1-3). Single session → streak = 1. No sessions → streak = 0. |
+| `specialist` metric | 50 chest sets + 30 back sets → metric = 50. Only 1 muscle group → that group's count is the max. |
+| `marathoner` metric | Session A: 6000 kg volume, Session B: 3000 kg → metric = 1 (only A qualifies). Duration-only session → excluded from volume. |
+| `pr_streak` metric | Sessions [PR, PR, no-PR, PR, PR, PR] → longest streak = 3 (last three). Zero PRs → streak = 0. |
+| `early_bird` metric | Session at 6 AM Paris time → counted. Session at 9 AM → not counted. Session at 7:59 AM → counted. Session at 8:00 AM → NOT counted (`< 8`). |
+| Idempotency | Grant twice → second call returns empty, no duplicates in `user_achievements`. |
+| Auth guard | `auth.uid() != p_user_id` → `insufficient_privilege` exception. |
+
+### Frontend Tests
+
+| Test file | Change |
+|---|---|
+| `file:src/hooks/useCreateUserProfile.ts` (new test or extend) | Verify `timezone` is included in the upsert payload. |
+| `file:src/components/SideDrawer.test.tsx` | No change needed — `SideDrawer` reads from `useBadgeStatus` which returns new groups dynamically. |
+| `file:src/pages/AchievementsPage.test.tsx` | No change needed — mocked `useBadgeStatus` can include new group slugs for coverage. |
+
+### Manual Verification
+
+- Run `EXPLAIN ANALYZE` on both RPCs for a user with 200+ sessions to verify < 200ms execution
+- Visual check: accordion shows 12 groups with correct names, descriptions, and progress bars
+- Retroactive grant: verify existing users get badges for historically qualifying tracks
+
+---
+
+## Deployment & Migration
+
+### Migration Sequence
+
+1. Apply migration: timezone column + backfill + seed groups/tiers + replace RPCs
+2. Run retroactive grant: `SELECT check_and_grant_achievements(user_id) FROM user_profiles`
+3. Deploy frontend: i18n strings + timezone capture in `useCreateUserProfile`
+
+### Retroactive Grant Notes
+
+- The retroactive grant uses the same idempotent RPC. Existing badges are unaffected (`ON CONFLICT DO NOTHING`).
+- **No `user_achievements` wipe.** Unlike the rebalance migration (#20260403000001), this migration does NOT delete existing achievements. Thresholds for existing tracks are unchanged. Only new tracks are evaluated.
+- Grant runs server-side before users open the app → no overlay flood. Users discover new badges silently in the accordion.
+- **Early Bird retroactive accuracy:** Existing sessions are evaluated using the backfilled `'Europe/Paris'` timezone. For current FR users this is correct. If non-FR users existed, their early-bird retroactive grant might be inaccurate — acceptable given the all-FR user base.
+
+---
+
+## Badge Asset System
+
+### Architecture Recap
+
+Badges are composited at render time from two layers (established in #129):
+- **Frame (rank layer)** — pure CSS. 5 classes (`badge-frame-bronze` through `badge-frame-diamond`) already exist in `file:src/styles/globals.css`.
+- **Icon (group × rank layer)** — AI-generated transparent PNGs. Just the central icon on a transparent background, overlaid on the CSS frame.
+
+No CSS changes needed — the existing 5 rank frames apply to all groups. Only 35 new icon PNGs are needed.
+
+### Icon Matrix (group × rank)
+
+| | Bronze | Silver | Gold | Platinum | Diamond |
+|---|---|---|---|---|---|
+| **Quick & Dirty** | Single lightning bolt + dumbbell | Crossed lightning bolts + "no plan" torn paper | Renegade skull with barbell horns | Chaos star made of gym equipment | Phoenix rising from a shattered program sheet |
+| **Leg Day Survivor** | Single squat rack, simple | Loaded barbell across shoulders, sweat drops | Greek column legs supporting a massive barbell | Robotic leg exoskeleton with hydraulic pistons | Colossus legs straddling a mountain range |
+| **Streak King** | Short chain of 3 links | Iron chain with a crown pendant | Throne made of interlocking chain links | Infinite chain forming a Möbius strip, glowing | Diamond-studded eternal chain with a royal crown, radiating energy |
+| **Le Spécialiste** | Magnifying glass over a single muscle fiber | Crosshair locked on a muscle group silhouette | Surgical scalpel cutting with precision, muscle diagram | Laser beam sculpting a perfect muscle, blueprint overlay | Robotic arm with surgical precision, holographic muscle map |
+| **Le Marathonien** | Small weight plate with "5T" engraved | Stacked plates on a reinforced dolly | Atlas carrying a massive barbell globe, sweat and determination | Industrial crane lifting a mountain of plates | Nuclear reactor core made of weight plates, radiating shockwaves |
+| **PR Streak** | Single flame | Trail of flames in a row | Meteor shower of flaming arrows | Volcanic eruption with PR markers flying out | Supernova explosion with "PR" branded into the shockwave |
+| **Early Bird** | Simple sunrise over a dumbbell | Rooster standing on a barbell at dawn | Eagle soaring over a gym at golden hour | Phoenix with sun-ray wings descending on a squat rack | Solar deity made of pure light, barbell scepter, gym-temple backdrop |
+
+### AI Prompt Template
+
+Icons are generated **without any frame/border** — just the subject on a transparent background. Same template as #129:
+
+```
+"[ICON_DESCRIPTION], [STYLE_LEVEL] style, centered composition,
+transparent background, game UI icon asset, no border, no frame,
+no text, high detail, 512×512 PNG"
+```
+
+`STYLE_LEVEL` escalates with rank: `minimalist` → `bold` → `dramatic` → `luxurious` → `epic`.
+
+### Prompt Table — Quick & Dirty
+
+| Rank | Prompt |
+|---|---|
+| Bronze | "a single lightning bolt striking a small dumbbell, minimalist style" |
+| Silver | "crossed lightning bolts over a torn workout plan sheet, bold style" |
+| Gold | "a renegade skull with barbell horns and chain necklace, dramatic style" |
+| Platinum | "a chaos star assembled from dumbbells, kettlebells and barbells, intricate and ornate, luxurious style" |
+| Diamond | "a phoenix rising from flames consuming a shattered workout program, radiating energy and freedom, epic style" |
+
+### Prompt Table — Leg Day Survivor
+
+| Rank | Prompt |
+|---|---|
+| Bronze | "a simple squat rack with a light barbell, minimalist style" |
+| Silver | "a heavy loaded barbell resting across broad shoulders, sweat drops flying, bold style" |
+| Gold | "two Greek marble column legs supporting a massive barbell overhead, dramatic style" |
+| Platinum | "a robotic leg exoskeleton with hydraulic pistons and glowing joints, luxurious style" |
+| Diamond | "colossal titan legs straddling a mountain range, barbell balanced across the peaks, radiating power, epic style" |
+
+### Prompt Table — Streak King
+
+| Rank | Prompt |
+|---|---|
+| Bronze | "three simple chain links connected together, minimalist style" |
+| Silver | "an iron chain with a small crown pendant hanging from the center link, bold style" |
+| Gold | "a throne constructed entirely from interlocking chain links, dramatic style" |
+| Platinum | "an infinite chain forming a glowing Möbius strip, iridescent shimmer on the links, luxurious style" |
+| Diamond | "a diamond-studded eternal chain spiraling upward with a royal crown at the apex, radiating light and energy, epic style" |
+
+### Prompt Table — Le Spécialiste
+
+| Rank | Prompt |
+|---|---|
+| Bronze | "a magnifying glass hovering over a single glowing muscle fiber, minimalist style" |
+| Silver | "a crosshair scope locked onto a muscle group silhouette, bold style" |
+| Gold | "a surgical scalpel cutting with precision over a detailed muscle anatomy diagram, dramatic style" |
+| Platinum | "a laser beam sculpting a perfect muscle from raw material, blueprint overlay and measurement lines, luxurious style" |
+| Diamond | "a robotic arm with surgical precision tools projecting a holographic muscle map, circuits and anatomy merged, epic style" |
+
+### Prompt Table — Le Marathonien
+
+| Rank | Prompt |
+|---|---|
+| Bronze | "a single weight plate with '5T' engraved on it, minimalist style" |
+| Silver | "stacked weight plates on a reinforced industrial dolly, bold style" |
+| Gold | "Atlas carrying a massive barbell-shaped globe, straining with determination, dramatic style" |
+| Platinum | "an industrial crane hoisting a mountain of weight plates, steam and sparks, luxurious style" |
+| Diamond | "a nuclear reactor core assembled from weight plates, radiating concentric shockwaves of pure energy, epic style" |
+
+### Prompt Table — La Série Ininterrompue (PR Streak)
+
+| Rank | Prompt |
+|---|---|
+| Bronze | "a single bright flame, minimalist style" |
+| Silver | "a trail of flames burning in a straight line, bold style" |
+| Gold | "a meteor shower of flaming arrows raining down on a target, dramatic style" |
+| Platinum | "a volcanic eruption with PR markers and trophy fragments erupting from the crater, luxurious style" |
+| Diamond | "a supernova explosion with 'PR' branded into the expanding shockwave, stars forming around it, epic style" |
+
+### Prompt Table — Early Bird
+
+| Rank | Prompt |
+|---|---|
+| Bronze | "a simple sunrise peeking over a single dumbbell on the horizon, minimalist style" |
+| Silver | "a rooster standing proudly on a barbell at dawn, first light behind it, bold style" |
+| Gold | "an eagle soaring over a gym building at golden hour, rays of light streaming through, dramatic style" |
+| Platinum | "a phoenix with sun-ray wings descending upon a squat rack, golden light and ornate feather details, luxurious style" |
+| Diamond | "a solar deity figure made of pure light wielding a barbell scepter, standing atop a gym-temple with dawn breaking behind, epic style" |
+
+### Generation Process
+
+1. **Tool:** Use the same AI image generation tool as #129 (Midjourney, DALL-E, or Cursor's `GenerateImage` tool for quick iterations)
+2. **Batch by rank, not by group:** Generate all 7 Bronze icons first (consistent `minimalist` feel), then all Silver, etc. This ensures visual cohesion within each rank tier.
+3. **Post-processing:** Remove any residual background artifacts. Ensure transparency. Resize to 512×512 if needed.
+4. **Upload:** Supabase Storage `badge-icons` bucket, path: `{group_slug}/{rank}.png` (e.g. `quick_sessions/bronze.png`)
+5. **Seed update:** Follow-up migration: `UPDATE achievement_tiers SET icon_asset_url = '...'` for each of the 35 tiers.
+
+### CSS Frame Reuse
+
+No new CSS needed. The existing rank frame classes work for any group:
+
+```tsx
+<div className={cn("badge-frame", `badge-frame-${rank}`)}>
+  <img src={icon_asset_url} className="badge-icon" alt={title} />
+</div>
+```
+
+The CSS custom properties (`--badge-hue`, `--badge-sat`, `--badge-glow`) defined per rank in `file:src/styles/globals.css` automatically style the frame, overlay glow, and particle effects for all 12 groups.
+
+---
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_New_Achievement_Tracks_#218.md`
+- Issue: #218
+- Current RPCs (source of truth): `file:supabase/migrations/20260403000001_rebalance_thresholds_and_replace_rhythm.sql`
+- Seed data format: `file:supabase/migrations/20260401000006_seed_achievement_data.sql`
+- Onboarding hook: `file:src/hooks/useCreateUserProfile.ts`
+- UserProfile type: `file:src/types/onboarding.ts`
+- i18n EN: `file:src/locales/en/achievements.json`
+- i18n FR: `file:src/locales/fr/achievements.json`
+- Muscle taxonomy: `file:src/lib/trainingBalance.ts`

--- a/docs/Tech_Plan_—_New_Achievement_Tracks_#218.md
+++ b/docs/Tech_Plan_—_New_Achievement_Tracks_#218.md
@@ -6,29 +6,28 @@
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| **RPC extension strategy** | Add 7 new `UNION ALL` branches to the `metrics` CTE in both RPCs | Same pattern as existing 5 metrics. No new RPCs, no new tables. The `eligible` / `granted` CTE pattern consumes any `metric_type` generically — adding a new branch is the only change. |
+| **RPC extension strategy** | Add 6 new `UNION ALL` branches to the `metrics` CTE in both RPCs | Same pattern as existing 5 metrics. No new RPCs, no new tables. The `eligible` / `granted` CTE pattern consumes any `metric_type` generically — adding a new branch is the only change. |
 | **Streak computation** | Window-function gap detection (`ROW_NUMBER` trick) inside the CTE | Outputs a single `numeric` value (longest streak) — fits the existing `metrics` contract. No schema change needed. |
-| **Leg Day join** | JOIN `set_logs` → `exercises` on `exercise_id` | The only way to access `muscle_group`. Acceptable cost: `exercises` table is small (< 1000 rows, likely cached). No new index needed — `exercise_id` FK on `set_logs` is already indexed. |
-| **Specialist metric** | `MAX(count)` over `GROUP BY muscle_group` | Dynamic per user — rewards their strongest area. Monotonic (can only grow), so tiers are never "lost". |
+| **Leg Day join** | JOIN `set_logs` → `exercises` on `exercise_id`, filter on all 5 lower-body groups | The only way to access `muscle_group`. All 5 leg groups included: `Quadriceps`, `Ischios`, `Fessiers`, `Adducteurs`, `Mollets`. `exercises` table is small (< 1000 rows, likely cached). No new index needed — `exercise_id` FK on `set_logs` is already indexed. |
 | **Marathoner qualifying floor** | Hardcoded 5,000 kg per session in the CTE | A design constant, not a tier threshold. Tiers count *how many* heavy sessions. If the floor needs tuning, a single value changes in the migration. |
 | **Early Bird timezone** | New `timezone text` column on `user_profiles` + `AT TIME ZONE` in CTE | Postgres handles IANA timezone names natively. Backfill existing FR users with `'Europe/Paris'`. New users: silent browser capture via `Intl.DateTimeFormat().resolvedOptions().timeZone`. |
 | **Timezone capture** | In `file:src/hooks/useCreateUserProfile.ts` upsert payload | Zero UX friction — no form field. Captured at profile creation (onboarding). Falls back to `'UTC'` if null. |
 | **Migration approach** | Single migration: seed data + RPC replacement + timezone column + backfill | All changes are additive. Existing `user_achievements` rows are untouched — only new groups/tiers are inserted. RPCs are replaced with expanded `metrics` CTE. |
 | **Retroactive grant** | Re-run `check_and_grant_achievements` for all users post-migration | Same idempotent RPC. Existing badges unaffected (`ON CONFLICT DO NOTHING`). New tracks evaluated against historical data. |
-| **i18n** | Extend existing `achievements` namespace with 7 new group entries | Follows established pattern: `groups.*`, `groupDescriptions.*`, `thresholdHint.*`. |
+| **i18n** | Extend existing `achievements` namespace with 6 new group entries | Follows established pattern: `groups.*`, `groupDescriptions.*`, `thresholdHint.*`. |
 | **PR strategy** | Single PR: migration + i18n + timezone capture | Low surface area — no UI components changed. The accordion already renders N groups dynamically. |
 
 ### Critical Constraints
 
-**RPC replacement is atomic.** Both `check_and_grant_achievements` and `get_badge_status` are replaced via `CREATE OR REPLACE FUNCTION`. The new versions include all 12 metric branches (5 existing + 7 new). If the migration fails mid-way, the old RPCs remain intact. No partial state.
+**RPC replacement is atomic.** Both `check_and_grant_achievements` and `get_badge_status` are replaced via `CREATE OR REPLACE FUNCTION`. The new versions include all 11 metric branches (5 existing + 6 new). If the migration fails mid-way, the old RPCs remain intact. No partial state.
 
-**`user_sessions` CTE is shared.** All 12 metric branches read from the same `user_sessions` CTE. Postgres materializes it once — no redundant `sessions` scans. Adding 7 branches does NOT multiply the session table reads.
+**`user_sessions` CTE is shared.** All 11 metric branches read from the same `user_sessions` CTE. Postgres materializes it once — no redundant `sessions` scans. Adding 6 branches does NOT multiply the session table reads.
 
-**Exercises JOIN cost.** Three metrics (`leg_day`, `specialist`, `early_bird`... no — `leg_day` and `specialist`) require a JOIN to `exercises`. This is a small table (< 1000 rows, fits in shared_buffers). The JOIN is through `set_logs.exercise_id` which already has an FK index. No new index needed.
+**Exercises JOIN cost.** The `leg_day` metric requires a JOIN to `exercises`. This is a small table (< 1000 rows, fits in shared_buffers). The JOIN is through `set_logs.exercise_id` which already has an FK index. No new index needed.
 
 **`user_profiles` JOIN for Early Bird.** The `early_bird` CTE needs `user_profiles.timezone`. This is a single-row lookup by PK (`user_id`). Negligible cost. The CTE uses `COALESCE(up.timezone, 'UTC')` for null safety.
 
-**Existing `sort_order` values.** Current groups use `sort_order` 1–5. New groups use 6–12. If future reordering is needed, UPDATE is trivial — `sort_order` is only used in the `ORDER BY` of `get_badge_status`.
+**Existing `sort_order` values.** Current groups use `sort_order` 1–5. New groups use 6–11. If future reordering is needed, UPDATE is trivial — `sort_order` is only used in the `ORDER BY` of `get_badge_status`.
 
 **`reps_logged` safe cast.** The `^\d+$` regex guard from the rebalance migration (`file:supabase/migrations/20260403000001_rebalance_thresholds_and_replace_rhythm.sql`) is preserved in the `total_volume_kg` and `marathoner` branches. No risk of cast failure.
 
@@ -47,8 +46,8 @@ erDiagram
     achievement_groups {
         uuid id PK
         text slug UK
-        text metric_type "7 new values"
-        int sort_order "6-12 for new groups"
+        text metric_type "6 new values"
+        int sort_order "6-11 for new groups"
     }
     achievement_groups ||--o{ achievement_tiers : "5 tiers each"
     achievement_tiers {
@@ -61,15 +60,15 @@ erDiagram
 ```
 
 No new tables. The additions are:
-- 7 rows in `achievement_groups`
-- 35 rows in `achievement_tiers`
+- 6 rows in `achievement_groups`
+- 30 rows in `achievement_tiers`
 - 1 column on `user_profiles`
 
 ### Migration: Timezone Column + Backfill
 
 ```sql
 -- Add timezone column to user_profiles
-ALTER TABLE user_profiles ADD COLUMN timezone text;
+ALTER TABLE user_profiles ADD COLUMN timezone text DEFAULT 'Europe/Paris';
 
 -- Backfill existing users (all FR)
 UPDATE user_profiles SET timezone = 'Europe/Paris' WHERE timezone IS NULL;
@@ -81,12 +80,11 @@ UPDATE user_profiles SET timezone = 'Europe/Paris' WHERE timezone IS NULL;
 INSERT INTO achievement_groups (slug, name_fr, name_en, description_fr, description_en, metric_type, sort_order)
 VALUES
   ('quick_sessions', 'Quick & Dirty',       'Quick & Dirty',       'Séances rapides (sans programme)',              'Quick sessions (no program)',                   'quick_sessions',  6),
-  ('leg_day',        'Leg Day',              'Leg Day',             'Séries ciblant les jambes',                     'Sets targeting leg muscles',                    'leg_day',         7),
+  ('leg_day',        'Leg Day',              'Leg Day',             'Séries ciblant les jambes (5 groupes)',          'Sets targeting leg muscles (5 groups)',          'leg_day',         7),
   ('streak_king',    'Streak King',          'Streak King',         'Plus longue série de semaines consécutives',    'Longest streak of consecutive weeks',           'streak_king',     8),
-  ('specialist',     'Le Spécialiste',       'The Specialist',      'Séries sur ton meilleur groupe musculaire',     'Sets on your best muscle group',                'specialist',      9),
-  ('marathoner',     'Le Marathonien',       'The Marathoner',      'Séances avec un volume total ≥ 5 000 kg',      'Sessions with total volume ≥ 5,000 kg',         'marathoner',     10),
-  ('pr_streak',      'Série de Records',     'PR Streak',           'Plus longue série de séances avec au moins 1 PR','Longest streak of sessions with at least 1 PR','pr_streak',      11),
-  ('early_bird',     'Early Bird',           'Early Bird',          'Séances terminées avant 8h',                    'Sessions finished before 8 AM',                 'early_bird',     12);
+  ('marathoner',     'Le Marathonien',       'The Marathoner',      'Séances avec un volume total ≥ 5 000 kg',      'Sessions with total volume ≥ 5,000 kg',         'marathoner',      9),
+  ('pr_streak',      'Série de Records',     'PR Streak',           'Plus longue série de séances avec au moins 1 PR','Longest streak of sessions with at least 1 PR','pr_streak',       10),
+  ('early_bird',     'Early Bird',           'Early Bird',          'Séances terminées avant 8h',                    'Sessions finished before 8 AM',                 'early_bird',     11);
 ```
 
 ### Migration: Seed New Achievement Tiers
@@ -117,20 +115,10 @@ WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'streak_king')
 INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
 VALUES
   ((SELECT id FROM g), 1, 'bronze',   'Trois de suite',      'Three in a Row',      3),
-  ((SELECT id FROM g), 2, 'silver',   'Mois sans faille',    'Flawless Month',      4),
+  ((SELECT id FROM g), 2, 'silver',   'Deux mois d''acier',  'Steel Streak',        8),
   ((SELECT id FROM g), 3, 'gold',     'Trimestre de fer',    'Iron Quarter',        12),
   ((SELECT id FROM g), 4, 'platinum', 'Inarrêtable',         'Unstoppable',         26),
   ((SELECT id FROM g), 5, 'diamond',  'La Chaîne Éternelle', 'The Eternal Chain',   52);
-
--- Le Spécialiste
-WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'specialist')
-INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
-VALUES
-  ((SELECT id FROM g), 1, 'bronze',   'Apprenti spécialiste','Novice Specialist',   50),
-  ((SELECT id FROM g), 2, 'silver',   'Mono-obsessionnel',   'Single-Minded',       200),
-  ((SELECT id FROM g), 3, 'gold',     'Expert de zone',      'Zone Expert',         500),
-  ((SELECT id FROM g), 4, 'platinum', 'Maître d''un art',    'Master of One',       1200),
-  ((SELECT id FROM g), 5, 'diamond',  'Le Chirurgien',       'The Surgeon',         3000);
 
 -- Le Marathonien
 WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'marathoner')
@@ -146,11 +134,11 @@ VALUES
 WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'pr_streak')
 INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
 VALUES
-  ((SELECT id FROM g), 1, 'bronze',   'Feu de paille',       'Flash Fire',          3),
-  ((SELECT id FROM g), 2, 'silver',   'Série chaude',        'Hot Streak',          5),
-  ((SELECT id FROM g), 3, 'gold',     'Machine à records',   'Record Machine',      10),
+  ((SELECT id FROM g), 1, 'bronze',   'Trois d''affilée',    'Flash Fire',          3),
+  ((SELECT id FROM g), 2, 'silver',   'En feu',              'On Fire',             5),
+  ((SELECT id FROM g), 3, 'gold',     'Enchaînement parfait','Perfect Run',         10),
   ((SELECT id FROM g), 4, 'platinum', 'Fléau des plateaux',  'Plateau Slayer',      20),
-  ((SELECT id FROM g), 5, 'diamond',  'L''Inarrêtable',      'The Relentless',      40);
+  ((SELECT id FROM g), 5, 'diamond',  'Le Phénomène',         'The Phenomenon',      40);
 
 -- Early Bird
 WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'early_bird')
@@ -165,7 +153,7 @@ VALUES
 
 ### Table Notes
 
-- **`achievement_groups.metric_type`** — 7 new values: `quick_sessions`, `leg_day`, `streak_king`, `specialist`, `marathoner`, `pr_streak`, `early_bird`. Each maps 1:1 to a CTE alias in both RPCs.
+- **`achievement_groups.metric_type`** — 6 new values: `quick_sessions`, `leg_day`, `streak_king`, `marathoner`, `pr_streak`, `early_bird`. Each maps 1:1 to a CTE alias in both RPCs.
 - **`user_profiles.timezone`** — nullable `text`. Stores IANA timezone names (e.g. `'Europe/Paris'`, `'America/New_York'`). Backfilled to `'Europe/Paris'` for all existing users. New users get it from browser detection. Used only by the `early_bird` CTE.
 - **Marathoner qualifying floor** — the 5,000 kg threshold is NOT in the schema. It's hardcoded in the CTE as a design constant. Changing it requires a migration that replaces the RPC function body.
 
@@ -173,11 +161,11 @@ VALUES
 
 ## RPC Definitions
 
-Both RPCs are replaced via `CREATE OR REPLACE FUNCTION`. The full function bodies are shown below. Changes from the current version (`file:supabase/migrations/20260403000001_rebalance_thresholds_and_replace_rhythm.sql`) are limited to the `metrics` CTE — 7 new `UNION ALL` branches are appended. Everything else (auth guard, `user_sessions`, `eligible`, `granted`, return query) is identical.
+Both RPCs are replaced via `CREATE OR REPLACE FUNCTION`. The full function bodies are shown below. Changes from the current version (`file:supabase/migrations/20260403000001_rebalance_thresholds_and_replace_rhythm.sql`) are limited to the `metrics` CTE — 6 new `UNION ALL` branches are appended. Everything else (auth guard, `user_sessions`, `eligible`, `granted`, return query) is identical.
 
 ### New Metric CTE Branches
 
-These 7 branches are appended to the existing `metrics` CTE in both RPCs:
+These 6 branches are appended to the existing `metrics` CTE in both RPCs:
 
 ```sql
     -- === NEW TRACKS (#218) ===
@@ -194,7 +182,7 @@ These 7 branches are appended to the existing `metrics` CTE in both RPCs:
       FROM set_logs sl
       JOIN user_sessions us ON us.id = sl.session_id
       JOIN exercises e ON e.id = sl.exercise_id
-      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers')
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
 
     -- Streak King: longest consecutive-week streak
     UNION ALL
@@ -213,17 +201,6 @@ These 7 branches are appended to the existing `metrics` CTE in both RPCs:
         GROUP BY grp
       ) streaks
 
-    -- Le Spécialiste: best single muscle group set count
-    UNION ALL
-    SELECT 'specialist', COALESCE(MAX(mg_count), 0)::numeric
-      FROM (
-        SELECT COUNT(*) AS mg_count
-        FROM set_logs sl
-        JOIN user_sessions us ON us.id = sl.session_id
-        JOIN exercises e ON e.id = sl.exercise_id
-        GROUP BY e.muscle_group
-      ) per_group
-
     -- Le Marathonien: sessions with total volume >= 5000 kg
     UNION ALL
     SELECT 'marathoner', COUNT(*)::numeric
@@ -238,21 +215,24 @@ These 7 branches are appended to the existing `metrics` CTE in both RPCs:
       ) heavy_sessions
 
     -- La Série Ininterrompue: longest consecutive-session PR streak
+    -- Key: rank ALL sessions first, then filter to PR ones, so gaps are visible
     UNION ALL
     SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
       FROM (
         SELECT COUNT(*) AS streak_len
         FROM (
-          SELECT pr_rank,
-                 pr_rank - (ROW_NUMBER() OVER (ORDER BY pr_rank))::bigint AS grp
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
           FROM (
-            SELECT DENSE_RANK() OVER (ORDER BY us.finished_at) AS pr_rank
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at) AS session_ord,
+                   EXISTS (
+                     SELECT 1 FROM set_logs sl
+                     WHERE sl.session_id = us.id AND sl.was_pr = true
+                   ) AS has_pr
             FROM user_sessions us
-            WHERE EXISTS (
-              SELECT 1 FROM set_logs sl
-              WHERE sl.session_id = us.id AND sl.was_pr = true
-            )
-          ) pr_sessions
+          ) all_sessions
+          WHERE has_pr
         ) grouped
         GROUP BY grp
       ) streaks
@@ -335,7 +315,7 @@ BEGIN
       FROM set_logs sl
       JOIN user_sessions us ON us.id = sl.session_id
       JOIN exercises e ON e.id = sl.exercise_id
-      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers')
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
 
     UNION ALL
     SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
@@ -354,16 +334,6 @@ BEGIN
       ) streaks
 
     UNION ALL
-    SELECT 'specialist', COALESCE(MAX(mg_count), 0)::numeric
-      FROM (
-        SELECT COUNT(*) AS mg_count
-        FROM set_logs sl
-        JOIN user_sessions us ON us.id = sl.session_id
-        JOIN exercises e ON e.id = sl.exercise_id
-        GROUP BY e.muscle_group
-      ) per_group
-
-    UNION ALL
     SELECT 'marathoner', COUNT(*)::numeric
       FROM (
         SELECT us.id
@@ -380,16 +350,18 @@ BEGIN
       FROM (
         SELECT COUNT(*) AS streak_len
         FROM (
-          SELECT pr_rank,
-                 pr_rank - (ROW_NUMBER() OVER (ORDER BY pr_rank))::bigint AS grp
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
           FROM (
-            SELECT DENSE_RANK() OVER (ORDER BY us.finished_at) AS pr_rank
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at) AS session_ord,
+                   EXISTS (
+                     SELECT 1 FROM set_logs sl
+                     WHERE sl.session_id = us.id AND sl.was_pr = true
+                   ) AS has_pr
             FROM user_sessions us
-            WHERE EXISTS (
-              SELECT 1 FROM set_logs sl
-              WHERE sl.session_id = us.id AND sl.was_pr = true
-            )
-          ) pr_sessions
+          ) all_sessions
+          WHERE has_pr
         ) grouped
         GROUP BY grp
       ) streaks
@@ -500,7 +472,7 @@ BEGIN
       FROM set_logs sl
       JOIN user_sessions us ON us.id = sl.session_id
       JOIN exercises e ON e.id = sl.exercise_id
-      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers')
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
 
     UNION ALL
     SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
@@ -519,16 +491,6 @@ BEGIN
       ) streaks
 
     UNION ALL
-    SELECT 'specialist', COALESCE(MAX(mg_count), 0)::numeric
-      FROM (
-        SELECT COUNT(*) AS mg_count
-        FROM set_logs sl
-        JOIN user_sessions us ON us.id = sl.session_id
-        JOIN exercises e ON e.id = sl.exercise_id
-        GROUP BY e.muscle_group
-      ) per_group
-
-    UNION ALL
     SELECT 'marathoner', COUNT(*)::numeric
       FROM (
         SELECT us.id
@@ -545,16 +507,18 @@ BEGIN
       FROM (
         SELECT COUNT(*) AS streak_len
         FROM (
-          SELECT pr_rank,
-                 pr_rank - (ROW_NUMBER() OVER (ORDER BY pr_rank))::bigint AS grp
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
           FROM (
-            SELECT DENSE_RANK() OVER (ORDER BY us.finished_at) AS pr_rank
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at) AS session_ord,
+                   EXISTS (
+                     SELECT 1 FROM set_logs sl
+                     WHERE sl.session_id = us.id AND sl.was_pr = true
+                   ) AS has_pr
             FROM user_sessions us
-            WHERE EXISTS (
-              SELECT 1 FROM set_logs sl
-              WHERE sl.session_id = us.id AND sl.was_pr = true
-            )
-          ) pr_sessions
+          ) all_sessions
+          WHERE has_pr
         ) grouped
         GROUP BY grp
       ) streaks
@@ -599,8 +563,8 @@ graph TD
     Migration --> ReplaceRPC2["CREATE OR REPLACE get_badge_status"]
 
     Frontend["Frontend Changes"]
-    Frontend --> i18nEN["achievements.json EN — 7 new group entries"]
-    Frontend --> i18nFR["achievements.json FR — 7 new group entries"]
+    Frontend --> i18nEN["achievements.json EN — 6 new group entries"]
+    Frontend --> i18nFR["achievements.json FR — 6 new group entries"]
     Frontend --> TZCapture["useCreateUserProfile — add timezone to upsert"]
     Frontend --> TypeUpdate["UserProfile type — add timezone field"]
 ```
@@ -609,7 +573,7 @@ graph TD
 
 | File | Purpose |
 |---|---|
-| `supabase/migrations/2026XXXXXXXXXX_new_achievement_tracks.sql` | Single migration: timezone column, backfill, 7 groups, 35 tiers, both RPCs replaced |
+| `supabase/migrations/2026XXXXXXXXXX_new_achievement_tracks.sql` | Single migration: timezone column, backfill, 6 groups, 30 tiers, both RPCs replaced |
 
 ### Modified Files
 
@@ -630,7 +594,6 @@ graph TD
     "quick_sessions": "Quick & Dirty",
     "leg_day": "Leg Day",
     "streak_king": "Streak King",
-    "specialist": "The Specialist",
     "marathoner": "The Marathoner",
     "pr_streak": "PR Streak",
     "early_bird": "Early Bird"
@@ -639,7 +602,6 @@ graph TD
     "quick_sessions": "Quick sessions (no program)",
     "leg_day": "Sets targeting leg muscles",
     "streak_king": "Longest streak of consecutive weeks",
-    "specialist": "Sets on your best muscle group",
     "marathoner": "Sessions with total volume ≥ 5,000 kg",
     "pr_streak": "Longest streak of sessions with a PR",
     "early_bird": "Sessions finished before 8 AM"
@@ -648,7 +610,6 @@ graph TD
     "quick_sessions": "Complete {{target}} quick sessions",
     "leg_day": "Log {{target}} leg sets",
     "streak_king": "Train {{target}} weeks in a row",
-    "specialist": "Log {{target}} sets for one muscle group",
     "marathoner": "Complete {{target}} heavy sessions (≥ 5,000 kg)",
     "pr_streak": "Set PRs in {{target}} sessions in a row",
     "early_bird": "Finish {{target}} sessions before 8 AM"
@@ -664,7 +625,6 @@ graph TD
     "quick_sessions": "Quick & Dirty",
     "leg_day": "Leg Day",
     "streak_king": "Streak King",
-    "specialist": "Le Spécialiste",
     "marathoner": "Le Marathonien",
     "pr_streak": "Série de Records",
     "early_bird": "Early Bird"
@@ -673,7 +633,6 @@ graph TD
     "quick_sessions": "Séances rapides (sans programme)",
     "leg_day": "Séries ciblant les jambes",
     "streak_king": "Plus longue série de semaines consécutives",
-    "specialist": "Séries sur ton meilleur groupe musculaire",
     "marathoner": "Séances avec un volume total ≥ 5 000 kg",
     "pr_streak": "Plus longue série de séances avec au moins 1 PR",
     "early_bird": "Séances terminées avant 8h"
@@ -682,7 +641,6 @@ graph TD
     "quick_sessions": "Terminer {{target}} séances rapides",
     "leg_day": "Enregistrer {{target}} séries jambes",
     "streak_king": "S'entraîner {{target}} semaines d'affilée",
-    "specialist": "Enregistrer {{target}} séries pour un groupe musculaire",
     "marathoner": "Compléter {{target}} séances lourdes (≥ 5 000 kg)",
     "pr_streak": "Battre des records dans {{target}} séances d'affilée",
     "early_bird": "Terminer {{target}} séances avant 8h"
@@ -692,7 +650,7 @@ graph TD
 
 ### Frontend Component Impact
 
-**Zero new components.** The accordion UI (`file:src/components/achievements/AchievementAccordion.tsx`) renders groups dynamically from `get_badge_status` RPC output. Adding 7 new groups = 7 more `AccordionItem` instances — no code change, just more data rows.
+**Zero new components.** The accordion UI (`file:src/components/achievements/AchievementAccordion.tsx`) renders groups dynamically from `get_badge_status` RPC output. Adding 6 new groups = 6 more `AccordionItem` instances — no code change, just more data rows.
 
 `BadgeIcon`, `BadgeDetailDrawer`, `BadgeShowcase`, `AchievementUnlockOverlay` — all work generically on `BadgeStatusRow` data. No changes needed.
 
@@ -718,7 +676,7 @@ No form field. No user interaction. `Intl.DateTimeFormat` is supported in all mo
 
 | Failure | Behavior |
 |---|---|
-| `exercises` table missing a `muscle_group` value for a logged exercise | `leg_day` and `specialist` CTEs use INNER JOIN — orphaned `exercise_id` rows are silently excluded. No crash. |
+| `exercises` table missing a `muscle_group` value for a logged exercise | `leg_day` CTE uses INNER JOIN — orphaned `exercise_id` rows are silently excluded. No crash. |
 | `user_profiles.timezone` is NULL for a user | `COALESCE(up.timezone, 'UTC')` fallback. Sessions evaluated against UTC. Slightly inaccurate for Early Bird but never crashes. |
 | User has 0 sessions | All metric branches return 0. No tiers granted. `COALESCE(MAX(...), 0)` handles empty streak aggregates. |
 | Streak King with only 1 qualifying week | `MAX(streak_len)` = 1. Below Bronze threshold (3). No badge granted. Correct. |
@@ -736,9 +694,8 @@ No form field. No user interaction. `Intl.DateTimeFormat` is supported in all mo
 | Test | Scenarios |
 |---|---|
 | `quick_sessions` metric | User with 3 quick + 2 program sessions → metric = 3. User with 0 quick → metric = 0. |
-| `leg_day` metric | 10 sets on Quadriceps + 5 on Biceps → metric = 10. Sets on Adducteurs → NOT counted (excluded from leg set). |
+| `leg_day` metric | 10 sets on Quadriceps + 5 on Biceps + 3 on Mollets → metric = 13. All 5 lower-body groups count (Quadriceps, Ischios, Fessiers, Adducteurs, Mollets). Sets on Biceps → NOT counted. |
 | `streak_king` metric | Sessions in weeks 1,2,3,5,6 → longest streak = 3 (weeks 1-3). Single session → streak = 1. No sessions → streak = 0. |
-| `specialist` metric | 50 chest sets + 30 back sets → metric = 50. Only 1 muscle group → that group's count is the max. |
 | `marathoner` metric | Session A: 6000 kg volume, Session B: 3000 kg → metric = 1 (only A qualifies). Duration-only session → excluded from volume. |
 | `pr_streak` metric | Sessions [PR, PR, no-PR, PR, PR, PR] → longest streak = 3 (last three). Zero PRs → streak = 0. |
 | `early_bird` metric | Session at 6 AM Paris time → counted. Session at 9 AM → not counted. Session at 7:59 AM → counted. Session at 8:00 AM → NOT counted (`< 8`). |
@@ -756,7 +713,7 @@ No form field. No user interaction. `Intl.DateTimeFormat` is supported in all mo
 ### Manual Verification
 
 - Run `EXPLAIN ANALYZE` on both RPCs for a user with 200+ sessions to verify < 200ms execution
-- Visual check: accordion shows 12 groups with correct names, descriptions, and progress bars
+- Visual check: accordion shows 11 groups with correct names, descriptions, and progress bars
 - Retroactive grant: verify existing users get badges for historically qualifying tracks
 
 ---
@@ -786,7 +743,7 @@ Badges are composited at render time from two layers (established in #129):
 - **Frame (rank layer)** — pure CSS. 5 classes (`badge-frame-bronze` through `badge-frame-diamond`) already exist in `file:src/styles/globals.css`.
 - **Icon (group × rank layer)** — AI-generated transparent PNGs. Just the central icon on a transparent background, overlaid on the CSS frame.
 
-No CSS changes needed — the existing 5 rank frames apply to all groups. Only 35 new icon PNGs are needed.
+No CSS changes needed — the existing 5 rank frames apply to all groups. Only 30 new icon PNGs are needed.
 
 ### Icon Matrix (group × rank)
 
@@ -795,7 +752,6 @@ No CSS changes needed — the existing 5 rank frames apply to all groups. Only 3
 | **Quick & Dirty** | Single lightning bolt + dumbbell | Crossed lightning bolts + "no plan" torn paper | Renegade skull with barbell horns | Chaos star made of gym equipment | Phoenix rising from a shattered program sheet |
 | **Leg Day Survivor** | Single squat rack, simple | Loaded barbell across shoulders, sweat drops | Greek column legs supporting a massive barbell | Robotic leg exoskeleton with hydraulic pistons | Colossus legs straddling a mountain range |
 | **Streak King** | Short chain of 3 links | Iron chain with a crown pendant | Throne made of interlocking chain links | Infinite chain forming a Möbius strip, glowing | Diamond-studded eternal chain with a royal crown, radiating energy |
-| **Le Spécialiste** | Magnifying glass over a single muscle fiber | Crosshair locked on a muscle group silhouette | Surgical scalpel cutting with precision, muscle diagram | Laser beam sculpting a perfect muscle, blueprint overlay | Robotic arm with surgical precision, holographic muscle map |
 | **Le Marathonien** | Small weight plate with "5T" engraved | Stacked plates on a reinforced dolly | Atlas carrying a massive barbell globe, sweat and determination | Industrial crane lifting a mountain of plates | Nuclear reactor core made of weight plates, radiating shockwaves |
 | **PR Streak** | Single flame | Trail of flames in a row | Meteor shower of flaming arrows | Volcanic eruption with PR markers flying out | Supernova explosion with "PR" branded into the shockwave |
 | **Early Bird** | Simple sunrise over a dumbbell | Rooster standing on a barbell at dawn | Eagle soaring over a gym at golden hour | Phoenix with sun-ray wings descending on a squat rack | Solar deity made of pure light, barbell scepter, gym-temple backdrop |
@@ -842,16 +798,6 @@ no text, high detail, 512×512 PNG"
 | Platinum | "an infinite chain forming a glowing Möbius strip, iridescent shimmer on the links, luxurious style" |
 | Diamond | "a diamond-studded eternal chain spiraling upward with a royal crown at the apex, radiating light and energy, epic style" |
 
-### Prompt Table — Le Spécialiste
-
-| Rank | Prompt |
-|---|---|
-| Bronze | "a magnifying glass hovering over a single glowing muscle fiber, minimalist style" |
-| Silver | "a crosshair scope locked onto a muscle group silhouette, bold style" |
-| Gold | "a surgical scalpel cutting with precision over a detailed muscle anatomy diagram, dramatic style" |
-| Platinum | "a laser beam sculpting a perfect muscle from raw material, blueprint overlay and measurement lines, luxurious style" |
-| Diamond | "a robotic arm with surgical precision tools projecting a holographic muscle map, circuits and anatomy merged, epic style" |
-
 ### Prompt Table — Le Marathonien
 
 | Rank | Prompt |
@@ -885,10 +831,10 @@ no text, high detail, 512×512 PNG"
 ### Generation Process
 
 1. **Tool:** Use the same AI image generation tool as #129 (Midjourney, DALL-E, or Cursor's `GenerateImage` tool for quick iterations)
-2. **Batch by rank, not by group:** Generate all 7 Bronze icons first (consistent `minimalist` feel), then all Silver, etc. This ensures visual cohesion within each rank tier.
+2. **Batch by rank, not by group:** Generate all 6 Bronze icons first (consistent `minimalist` feel), then all Silver, etc. This ensures visual cohesion within each rank tier.
 3. **Post-processing:** Remove any residual background artifacts. Ensure transparency. Resize to 512×512 if needed.
 4. **Upload:** Supabase Storage `badge-icons` bucket, path: `{group_slug}/{rank}.png` (e.g. `quick_sessions/bronze.png`)
-5. **Seed update:** Follow-up migration: `UPDATE achievement_tiers SET icon_asset_url = '...'` for each of the 35 tiers.
+5. **Seed update:** Follow-up migration: `UPDATE achievement_tiers SET icon_asset_url = '...'` for each of the 30 tiers.
 
 ### CSS Frame Reuse
 
@@ -900,7 +846,7 @@ No new CSS needed. The existing rank frame classes work for any group:
 </div>
 ```
 
-The CSS custom properties (`--badge-hue`, `--badge-sat`, `--badge-glow`) defined per rank in `file:src/styles/globals.css` automatically style the frame, overlay glow, and particle effects for all 12 groups.
+The CSS custom properties (`--badge-hue`, `--badge-sat`, `--badge-glow`) defined per rank in `file:src/styles/globals.css` automatically style the frame, overlay glow, and particle effects for all 11 groups.
 
 ---
 

--- a/docs/Tech_Plan_—_New_Achievement_Tracks_#218.md
+++ b/docs/Tech_Plan_—_New_Achievement_Tracks_#218.md
@@ -23,9 +23,13 @@
 
 **`user_sessions` CTE is shared.** All 11 metric branches read from the same `user_sessions` CTE. Postgres materializes it once — no redundant `sessions` scans. Adding 6 branches does NOT multiply the session table reads.
 
-**Exercises JOIN cost.** The `leg_day` metric requires a JOIN to `exercises`. This is a small table (< 1000 rows, fits in shared_buffers). The JOIN is through `set_logs.exercise_id` which already has an FK index. No new index needed.
+**CTE performance at 11 branches.** With 5→11 `UNION ALL` branches in `metrics`, query planning cost grows linearly but each branch is independently optimized:
+- **Use `EXISTS` over `JOIN` where possible.** Branches that only need to check a condition (e.g. `total_prs`, `pr_streak` checking for `was_pr = true` in `set_logs`) use `EXISTS (SELECT 1 ...)` subqueries — cheaper than materializing a full JOIN result.
+- **Branches that read columns from the joined table** (`leg_day` → `exercises.muscle_group`, `total_volume` / `marathoner` → `set_logs.weight_logged`) legitimately need `JOIN`. No way around it.
+- **`user_profiles` for Early Bird** is a single-row PK lookup — negligible. But to avoid repeating it if future branches also need profile data, we could extract it to a top-level CTE (not blocking for this PR).
+- **Validate with `EXPLAIN ANALYZE`** on a user with 200+ sessions. Target: < 200ms total. If any branch dominates, it can be extracted to a separate CTE that runs conditionally.
 
-**`user_profiles` JOIN for Early Bird.** The `early_bird` CTE needs `user_profiles.timezone`. This is a single-row lookup by PK (`user_id`). Negligible cost. The CTE uses `COALESCE(up.timezone, 'UTC')` for null safety.
+**Exercises JOIN cost.** The `leg_day` metric requires a JOIN to `exercises`. This is a small table (< 1000 rows, fits in shared_buffers). The JOIN is through `set_logs.exercise_id` which already has an FK index. No new index needed.
 
 **Existing `sort_order` values.** Current groups use `sort_order` 1–5. New groups use 6–11. If future reordering is needed, UPDATE is trivial — `sort_order` is only used in the `ORDER BY` of `get_badge_status`.
 
@@ -555,8 +559,8 @@ $$;
 ```mermaid
 graph TD
     Migration["SQL Migration"]
-    Migration --> SeedGroups["INSERT 7 achievement_groups"]
-    Migration --> SeedTiers["INSERT 35 achievement_tiers"]
+    Migration --> SeedGroups["INSERT 6 achievement_groups"]
+    Migration --> SeedTiers["INSERT 30 achievement_tiers"]
     Migration --> TimezoneCol["ALTER user_profiles ADD timezone"]
     Migration --> TimezoneBackfill["UPDATE timezone = Europe/Paris"]
     Migration --> ReplaceRPC1["CREATE OR REPLACE check_and_grant"]
@@ -579,7 +583,7 @@ graph TD
 
 | File | Change |
 |---|---|
-| `file:src/locales/en/achievements.json` | Add 7 entries each to `groups`, `groupDescriptions`, `thresholdHint` |
+| `file:src/locales/en/achievements.json` | Add 6 entries each to `groups`, `groupDescriptions`, `thresholdHint` |
 | `file:src/locales/fr/achievements.json` | French equivalents |
 | `file:src/hooks/useCreateUserProfile.ts` | Add `timezone: Intl.DateTimeFormat().resolvedOptions().timeZone` to upsert payload |
 | `file:src/types/onboarding.ts` | Add `timezone: string \| null` to `UserProfile` interface |
@@ -730,8 +734,36 @@ No form field. No user interaction. `Intl.DateTimeFormat` is supported in all mo
 
 - The retroactive grant uses the same idempotent RPC. Existing badges are unaffected (`ON CONFLICT DO NOTHING`).
 - **No `user_achievements` wipe.** Unlike the rebalance migration (#20260403000001), this migration does NOT delete existing achievements. Thresholds for existing tracks are unchanged. Only new tracks are evaluated.
-- Grant runs server-side before users open the app → no overlay flood. Users discover new badges silently in the accordion.
 - **Early Bird retroactive accuracy:** Existing sessions are evaluated using the backfilled `'Europe/Paris'` timezone. For current FR users this is correct. If non-FR users existed, their early-bird retroactive grant might be inaccurate — acceptable given the all-FR user base.
+
+### Silent Rollout (no toast flood)
+
+The migration-time retroactive grant inserts rows into `user_achievements`. Because `AchievementRealtimeProvider` subscribes to **all** `INSERT` events on that table, those retroactive rows would trigger toast popups — potentially dozens per user.
+
+**Solution: boot-time gate in `AchievementRealtimeProvider`.**
+
+Store a `subscriptionStartedAt` timestamp when the Realtime channel is established. In the `postgres_changes` callback, compare `payload.new.granted_at` against that timestamp. If `granted_at < subscriptionStartedAt`, the badge was granted before this session — skip the toast push silently.
+
+```typescript
+// Inside AchievementRealtimeProvider useEffect
+const subscriptionStartedAt = new Date().toISOString()
+
+const channel = supabase
+  .channel("achievements")
+  .on("postgres_changes", { /* ... */ }, (payload) => {
+    const grantedAt = payload.new.granted_at as string
+    if (grantedAt < subscriptionStartedAt) return // retroactive — silent
+
+    // ... existing enrichment + pushAchievementsToQueue logic
+  })
+  .subscribe()
+```
+
+This means:
+- Retroactive badges from the migration appear silently in the accordion grid
+- Badges earned during a live session still trigger the overlay + chime
+- No schema changes, no migration complexity, purely a frontend guard
+- The `<` comparison works on ISO 8601 strings (lexicographic ordering = chronological)
 
 ---
 

--- a/src/components/SideDrawer.test.tsx
+++ b/src/components/SideDrawer.test.tsx
@@ -194,6 +194,7 @@ describe("SideDrawer achievements", () => {
         training_days_per_week: 4,
         session_duration_minutes: 60,
         active_title_tier_id: "tier-42",
+        timezone: "Europe/Paris",
         created_at: "2026-01-01",
         updated_at: "2026-01-01",
       }),

--- a/src/components/achievements/AchievementRealtimeProvider.tsx
+++ b/src/components/achievements/AchievementRealtimeProvider.tsx
@@ -20,6 +20,8 @@ export function AchievementRealtimeProvider({ children }: { children: React.Reac
   useEffect(() => {
     if (!user || !badgeRows) return
 
+    const subscriptionStartedAt = new Date().toISOString()
+
     const channel = supabase
       .channel("achievements")
       .on(
@@ -31,6 +33,9 @@ export function AchievementRealtimeProvider({ children }: { children: React.Reac
           filter: `user_id=eq.${user.id}`,
         },
         (payload) => {
+          const grantedAt = payload.new.granted_at as string
+          if (grantedAt < subscriptionStartedAt) return
+
           const tierId = payload.new.tier_id as string
           const match = badgeRows.find((r) => r.tier_id === tierId)
           if (!match) return

--- a/src/components/achievements/AchievementRealtimeProvider.tsx
+++ b/src/components/achievements/AchievementRealtimeProvider.tsx
@@ -20,7 +20,7 @@ export function AchievementRealtimeProvider({ children }: { children: React.Reac
   useEffect(() => {
     if (!user || !badgeRows) return
 
-    const subscriptionStartedAt = new Date().toISOString()
+    const subscriptionStartedAt = Date.now()
 
     const channel = supabase
       .channel("achievements")
@@ -34,7 +34,7 @@ export function AchievementRealtimeProvider({ children }: { children: React.Reac
         },
         (payload) => {
           const grantedAt = payload.new.granted_at as string
-          if (grantedAt < subscriptionStartedAt) return
+          if (new Date(grantedAt).getTime() < subscriptionStartedAt) return
 
           const tierId = payload.new.tier_id as string
           const match = badgeRows.find((r) => r.tier_id === tierId)

--- a/src/hooks/useCreateUserProfile.ts
+++ b/src/hooks/useCreateUserProfile.ts
@@ -32,6 +32,8 @@ export function useCreateUserProfile() {
 
       const emailDefault = user.email?.trim() || null
 
+      const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
       const { data, error } = await supabase
         .from("user_profiles")
         .upsert(
@@ -46,6 +48,7 @@ export function useCreateUserProfile() {
             equipment: input.equipment,
             training_days_per_week: input.training_days_per_week,
             session_duration_minutes: input.session_duration_minutes,
+            timezone,
           },
           { onConflict: "user_id" },
         )

--- a/src/hooks/useCreateUserProfile.ts
+++ b/src/hooks/useCreateUserProfile.ts
@@ -2,6 +2,7 @@ import { useMutation } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
 import { supabase } from "@/lib/supabase"
 import { authAtom, weightUnitAtom } from "@/store/atoms"
+import { getResolvedIANATimeZone } from "@/lib/trainingActivityTimezone"
 import type { UserGoal, UserExperience, UserEquipment, UserGender } from "@/types/onboarding"
 
 interface ProfileInput {
@@ -32,7 +33,7 @@ export function useCreateUserProfile() {
 
       const emailDefault = user.email?.trim() || null
 
-      const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+      const timezone = getResolvedIANATimeZone()
 
       const { data, error } = await supabase
         .from("user_profiles")

--- a/src/lib/recommendTemplates.test.ts
+++ b/src/lib/recommendTemplates.test.ts
@@ -31,6 +31,7 @@ function makeProfile(overrides: Partial<UserProfile> = {}): UserProfile {
     training_days_per_week: 4,
     session_duration_minutes: 60,
     active_title_tier_id: null,
+    timezone: null,
     created_at: "",
     updated_at: "",
     ...overrides,

--- a/src/lib/userDisplay.test.ts
+++ b/src/lib/userDisplay.test.ts
@@ -36,6 +36,7 @@ const baseProfile: UserProfile = {
   training_days_per_week: 4,
   session_duration_minutes: 60,
   active_title_tier_id: null,
+  timezone: null,
   created_at: "",
   updated_at: "",
 }

--- a/src/lib/userProfileToGenerateProgramConstraints.test.ts
+++ b/src/lib/userProfileToGenerateProgramConstraints.test.ts
@@ -16,6 +16,7 @@ function baseProfile(over: Partial<UserProfile> = {}): UserProfile {
     training_days_per_week: 4,
     session_duration_minutes: 60,
     active_title_tier_id: null,
+    timezone: null,
     created_at: "",
     updated_at: "",
     ...over,

--- a/src/locales/en/achievements.json
+++ b/src/locales/en/achievements.json
@@ -36,20 +36,38 @@
     "volume_king": "Volume",
     "rhythm_master": "Rhythm",
     "record_hunter": "Records",
-    "exercise_variety": "Variety"
+    "exercise_variety": "Variety",
+    "quick_sessions": "Quick & Dirty",
+    "leg_day": "Leg Day",
+    "streak_king": "Streak King",
+    "marathoner": "The Marathoner",
+    "pr_streak": "PR Streak",
+    "early_bird": "Early Bird"
   },
   "groupDescriptions": {
     "consistency_streak": "Total finished workout sessions",
     "volume_king": "Total volume lifted (kg)",
     "rhythm_master": "Calendar weeks with 3+ sessions",
     "record_hunter": "Personal records broken",
-    "exercise_variety": "Distinct exercises used"
+    "exercise_variety": "Distinct exercises used",
+    "quick_sessions": "Quick sessions (no program)",
+    "leg_day": "Sets targeting leg muscles",
+    "streak_king": "Longest streak of consecutive weeks",
+    "marathoner": "Sessions with total volume ≥ 5,000 kg",
+    "pr_streak": "Longest streak of sessions with a PR",
+    "early_bird": "Sessions finished before 8 AM"
   },
   "thresholdHint": {
     "consistency_streak": "Complete {{target}} sessions",
     "volume_king": "Lift {{target}} kg total",
     "rhythm_master": "Complete {{target}} weeks with 3+ sessions",
     "record_hunter": "Break {{target}} personal records",
-    "exercise_variety": "Use {{target}} different exercises"
+    "exercise_variety": "Use {{target}} different exercises",
+    "quick_sessions": "Complete {{target}} quick sessions",
+    "leg_day": "Log {{target}} leg sets",
+    "streak_king": "Train {{target}} weeks in a row",
+    "marathoner": "Complete {{target}} heavy sessions (≥ 5,000 kg)",
+    "pr_streak": "Set PRs in {{target}} sessions in a row",
+    "early_bird": "Finish {{target}} sessions before 8 AM"
   }
 }

--- a/src/locales/fr/achievements.json
+++ b/src/locales/fr/achievements.json
@@ -36,20 +36,38 @@
     "volume_king": "Volume",
     "rhythm_master": "Rythme",
     "record_hunter": "Records",
-    "exercise_variety": "Variété"
+    "exercise_variety": "Variété",
+    "quick_sessions": "Quick & Dirty",
+    "leg_day": "Leg Day",
+    "streak_king": "Streak King",
+    "marathoner": "Le Marathonien",
+    "pr_streak": "Série de Records",
+    "early_bird": "Early Bird"
   },
   "groupDescriptions": {
     "consistency_streak": "Nombre total de séances terminées",
     "volume_king": "Volume total soulevé (kg)",
     "rhythm_master": "Semaines calendaires avec 3+ séances",
     "record_hunter": "Records personnels battus",
-    "exercise_variety": "Exercices distincts utilisés"
+    "exercise_variety": "Exercices distincts utilisés",
+    "quick_sessions": "Séances rapides (sans programme)",
+    "leg_day": "Séries ciblant les jambes",
+    "streak_king": "Plus longue série de semaines consécutives",
+    "marathoner": "Séances avec un volume total ≥ 5 000 kg",
+    "pr_streak": "Plus longue série de séances avec au moins 1 PR",
+    "early_bird": "Séances terminées avant 8h"
   },
   "thresholdHint": {
     "consistency_streak": "Terminer {{target}} séances",
     "volume_king": "Soulever {{target}} kg au total",
     "rhythm_master": "Compléter {{target}} semaines avec 3+ séances",
     "record_hunter": "Battre {{target}} records personnels",
-    "exercise_variety": "Utiliser {{target}} exercices différents"
+    "exercise_variety": "Utiliser {{target}} exercices différents",
+    "quick_sessions": "Terminer {{target}} séances rapides",
+    "leg_day": "Enregistrer {{target}} séries jambes",
+    "streak_king": "S'entraîner {{target}} semaines d'affilée",
+    "marathoner": "Compléter {{target}} séances lourdes (≥ 5 000 kg)",
+    "pr_streak": "Battre des records dans {{target}} séances d'affilée",
+    "early_bird": "Terminer {{target}} séances avant 8h"
   }
 }

--- a/src/pages/AccountPage.test.tsx
+++ b/src/pages/AccountPage.test.tsx
@@ -39,6 +39,7 @@ const mockProfile: UserProfile = {
   training_days_per_week: 4,
   session_duration_minutes: 60,
   active_title_tier_id: null,
+  timezone: "Europe/Paris",
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
 }

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -4,6 +4,7 @@ import { useAtomValue } from "jotai"
 import { Dumbbell, Loader2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { userProfileToGenerateProgramConstraints } from "@/lib/userProfileToGenerateProgramConstraints"
+import { getResolvedIANATimeZone } from "@/lib/trainingActivityTimezone"
 import { hasProgramAtom, hasProgramLoadingAtom } from "@/store/atoms"
 import { useCreateUserProfile } from "@/hooks/useCreateUserProfile"
 import { useGenerateProgram } from "@/hooks/useGenerateProgram"
@@ -103,7 +104,7 @@ export function OnboardingPage() {
       training_days_per_week: data.training_days_per_week,
       session_duration_minutes: data.session_duration_minutes,
       active_title_tier_id: null,
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timezone: getResolvedIANATimeZone(),
       created_at: "",
       updated_at: "",
     }

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -103,6 +103,7 @@ export function OnboardingPage() {
       training_days_per_week: data.training_days_per_week,
       session_duration_minutes: data.session_duration_minutes,
       active_title_tier_id: null,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       created_at: "",
       updated_at: "",
     }

--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -20,6 +20,7 @@ export interface UserProfile {
   training_days_per_week: number
   session_duration_minutes: number
   active_title_tier_id: string | null
+  timezone: string | null
   created_at: string
   updated_at: string
 }

--- a/supabase/migrations/20260419120000_new_achievement_tracks.sql
+++ b/supabase/migrations/20260419120000_new_achievement_tracks.sql
@@ -1,0 +1,382 @@
+-- =============================================================
+-- New Achievement Tracks (#218)
+-- 6 new groups (quick_sessions, leg_day, streak_king,
+-- marathoner, pr_streak, early_bird) with 30 tiers.
+-- Adds timezone column to user_profiles for Early Bird.
+-- Replaces both RPCs with expanded metrics CTE (11 branches).
+-- =============================================================
+
+-- 1. Timezone column + backfill
+ALTER TABLE user_profiles ADD COLUMN timezone text DEFAULT 'Europe/Paris';
+UPDATE user_profiles SET timezone = 'Europe/Paris' WHERE timezone IS NULL;
+
+-- 2. Seed new achievement groups
+INSERT INTO achievement_groups (slug, name_fr, name_en, description_fr, description_en, metric_type, sort_order)
+VALUES
+  ('quick_sessions', 'Quick & Dirty',   'Quick & Dirty',   'Séances rapides (sans programme)',               'Quick sessions (no program)',                    'quick_sessions',  6),
+  ('leg_day',        'Leg Day',          'Leg Day',         'Séries ciblant les jambes (5 groupes)',           'Sets targeting leg muscles (5 groups)',           'leg_day',         7),
+  ('streak_king',    'Streak King',      'Streak King',     'Plus longue série de semaines consécutives',     'Longest streak of consecutive weeks',            'streak_king',     8),
+  ('marathoner',     'Le Marathonien',   'The Marathoner',  'Séances avec un volume total ≥ 5 000 kg',       'Sessions with total volume ≥ 5,000 kg',          'marathoner',      9),
+  ('pr_streak',      'Série de Records', 'PR Streak',       'Plus longue série de séances avec au moins 1 PR','Longest streak of sessions with at least 1 PR',  'pr_streak',       10),
+  ('early_bird',     'Early Bird',       'Early Bird',      'Séances terminées avant 8h',                     'Sessions finished before 8 AM',                  'early_bird',      11);
+
+-- 3. Seed new achievement tiers (5 ranks × 6 groups = 30)
+
+-- Quick & Dirty
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'quick_sessions')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Pas d''excuse',       'No Excuses',          5),
+  ((SELECT id FROM g), 2, 'silver',   'Franc-tireur',        'Lone Wolf',           20),
+  ((SELECT id FROM g), 3, 'gold',     'Électron libre',      'Free Radical',        60),
+  ((SELECT id FROM g), 4, 'platinum', 'Hors Programme',      'Off Script',          150),
+  ((SELECT id FROM g), 5, 'diamond',  'L''Incontrôlable',    'The Uncontrollable',  400);
+
+-- Leg Day Survivor
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'leg_day')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Rescapé du squat',    'Squat Survivor',      50),
+  ((SELECT id FROM g), 2, 'silver',   'Anti-chicken legs',   'Anti-Chicken Legs',   200),
+  ((SELECT id FROM g), 3, 'gold',     'Roi du Rack',         'Rack Royalty',        500),
+  ((SELECT id FROM g), 4, 'platinum', 'Pilier de fonte',     'Iron Pillar',         1200),
+  ((SELECT id FROM g), 5, 'diamond',  'Titan des cuisses',   'Thigh Titan',         3000);
+
+-- Streak King
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'streak_king')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Trois de suite',      'Three in a Row',      3),
+  ((SELECT id FROM g), 2, 'silver',   'Deux mois d''acier',  'Steel Streak',        8),
+  ((SELECT id FROM g), 3, 'gold',     'Trimestre de fer',    'Iron Quarter',        12),
+  ((SELECT id FROM g), 4, 'platinum', 'Inarrêtable',         'Unstoppable',         26),
+  ((SELECT id FROM g), 5, 'diamond',  'La Chaîne Éternelle', 'The Eternal Chain',   52);
+
+-- Le Marathonien
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'marathoner')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Séance lourde',       'Heavy Hitter',        5),
+  ((SELECT id FROM g), 2, 'silver',   'Tonnage garanti',     'Tonnage Guaranteed',  20),
+  ((SELECT id FROM g), 3, 'gold',     'Broyeur de barres',   'Bar Crusher',         60),
+  ((SELECT id FROM g), 4, 'platinum', 'Usine à volume',      'Volume Factory',      150),
+  ((SELECT id FROM g), 5, 'diamond',  'Le Marathonien',      'The Marathoner',      400);
+
+-- La Série Ininterrompue (PR Streak)
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'pr_streak')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Trois d''affilée',    'Flash Fire',          3),
+  ((SELECT id FROM g), 2, 'silver',   'En feu',              'On Fire',             5),
+  ((SELECT id FROM g), 3, 'gold',     'Enchaînement parfait','Perfect Run',         10),
+  ((SELECT id FROM g), 4, 'platinum', 'Fléau des plateaux',  'Plateau Slayer',      20),
+  ((SELECT id FROM g), 5, 'diamond',  'Le Phénomène',        'The Phenomenon',      40);
+
+-- Early Bird
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'early_bird')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Lève-tôt',                    'Early Riser',              5),
+  ((SELECT id FROM g), 2, 'silver',   'Coq du matin',                'Morning Rooster',          20),
+  ((SELECT id FROM g), 3, 'gold',     'Guerrier de l''aube',         'Dawn Warrior',             60),
+  ((SELECT id FROM g), 4, 'platinum', 'Premier au rack',             'First at the Rack',        150),
+  ((SELECT id FROM g), 5, 'diamond',  'Le Soleil se lève pour toi',  'The Sun Rises for You',    400);
+
+
+-- 4. Replace check_and_grant_achievements with 11-branch metrics CTE
+
+CREATE OR REPLACE FUNCTION check_and_grant_achievements(p_user_id uuid)
+RETURNS TABLE (
+  tier_id uuid, group_slug text, rank text,
+  title_en text, title_fr text, icon_asset_url text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+BEGIN
+  IF auth.uid() IS NOT NULL AND auth.uid() <> p_user_id THEN
+    RAISE EXCEPTION 'access denied: cannot grant achievements for another user'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_sessions AS (
+    SELECT s.id, s.workout_day_id, s.finished_at
+    FROM sessions s
+    WHERE s.user_id = p_user_id AND s.finished_at IS NOT NULL
+  ),
+  metrics AS (
+    -- === EXISTING TRACKS ===
+    SELECT 'session_count' AS metric_type, COUNT(*)::numeric AS value
+      FROM user_sessions
+
+    UNION ALL
+    SELECT 'total_volume_kg',
+           COALESCE(SUM(sl.weight_logged * sl.reps_logged::int), 0)
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.reps_logged IS NOT NULL
+        AND sl.reps_logged ~ '^\d+$'
+
+    UNION ALL
+    SELECT 'pr_count', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.was_pr = true
+
+    UNION ALL
+    SELECT 'unique_exercises', COUNT(DISTINCT sl.exercise_id)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+
+    UNION ALL
+    SELECT 'active_weeks', COUNT(*)::numeric
+      FROM (
+        SELECT date_trunc('week', us.finished_at) AS wk
+        FROM user_sessions us
+        GROUP BY date_trunc('week', us.finished_at)
+        HAVING COUNT(*) >= 3
+      ) AS weeks_with_3plus
+
+    -- === NEW TRACKS (#218) ===
+
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      WHERE us.workout_day_id IS NULL
+
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
+
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
+          FROM (
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at) AS session_ord,
+                   EXISTS (
+                     SELECT 1 FROM set_logs sl
+                     WHERE sl.session_id = us.id AND sl.was_pr = true
+                   ) AS has_pr
+            FROM user_sessions us
+          ) all_sessions
+          WHERE has_pr
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) < 8
+  ),
+  eligible AS (
+    SELECT at.id, ag.slug, at.rank AS r,
+           at.title_en, at.title_fr, at.icon_asset_url
+    FROM metrics m
+    JOIN achievement_groups ag ON ag.metric_type = m.metric_type
+    JOIN achievement_tiers at ON at.group_id = ag.id
+    WHERE at.threshold_value <= m.value
+      AND NOT EXISTS (
+        SELECT 1 FROM user_achievements ua
+        WHERE ua.user_id = p_user_id AND ua.tier_id = at.id
+      )
+  ),
+  granted AS (
+    INSERT INTO user_achievements (user_id, tier_id)
+    SELECT p_user_id, e.id FROM eligible e
+    ON CONFLICT (user_id, tier_id) DO NOTHING
+    RETURNING user_achievements.tier_id
+  )
+  SELECT e.id, e.slug, e.r, e.title_en, e.title_fr, e.icon_asset_url
+  FROM eligible e
+  JOIN granted g ON g.tier_id = e.id;
+END;
+$$;
+
+
+-- 5. Replace get_badge_status with 11-branch metrics CTE
+
+CREATE OR REPLACE FUNCTION get_badge_status(p_user_id uuid)
+RETURNS TABLE (
+  group_id uuid, group_slug text, group_name_en text, group_name_fr text,
+  tier_id uuid, tier_level int, rank text,
+  title_en text, title_fr text,
+  threshold_value numeric, icon_asset_url text,
+  is_unlocked boolean, granted_at timestamptz,
+  current_value numeric, progress_pct numeric
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+BEGIN
+  IF auth.uid() IS NOT NULL AND auth.uid() <> p_user_id THEN
+    RAISE EXCEPTION 'access denied: cannot read badge status for another user'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_sessions AS (
+    SELECT s.id, s.workout_day_id, s.finished_at
+    FROM sessions s
+    WHERE s.user_id = p_user_id AND s.finished_at IS NOT NULL
+  ),
+  metrics AS (
+    -- === EXISTING TRACKS ===
+    SELECT 'session_count' AS metric_type, COUNT(*)::numeric AS value
+      FROM user_sessions
+
+    UNION ALL
+    SELECT 'total_volume_kg',
+           COALESCE(SUM(sl.weight_logged * sl.reps_logged::int), 0)
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.reps_logged IS NOT NULL
+        AND sl.reps_logged ~ '^\d+$'
+
+    UNION ALL
+    SELECT 'pr_count', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.was_pr = true
+
+    UNION ALL
+    SELECT 'unique_exercises', COUNT(DISTINCT sl.exercise_id)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+
+    UNION ALL
+    SELECT 'active_weeks', COUNT(*)::numeric
+      FROM (
+        SELECT date_trunc('week', us.finished_at) AS wk
+        FROM user_sessions us
+        GROUP BY date_trunc('week', us.finished_at)
+        HAVING COUNT(*) >= 3
+      ) AS weeks_with_3plus
+
+    -- === NEW TRACKS (#218) ===
+
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      WHERE us.workout_day_id IS NULL
+
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
+
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
+          FROM (
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at) AS session_ord,
+                   EXISTS (
+                     SELECT 1 FROM set_logs sl
+                     WHERE sl.session_id = us.id AND sl.was_pr = true
+                   ) AS has_pr
+            FROM user_sessions us
+          ) all_sessions
+          WHERE has_pr
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) < 8
+  )
+  SELECT
+    ag.id, ag.slug, ag.name_en, ag.name_fr,
+    at.id, at.tier_level, at.rank,
+    at.title_en, at.title_fr,
+    at.threshold_value, at.icon_asset_url,
+    (ua.id IS NOT NULL), ua.granted_at,
+    COALESCE(m.value, 0),
+    LEAST(COALESCE(m.value, 0) / NULLIF(at.threshold_value, 0) * 100, 100)
+  FROM achievement_groups ag
+  JOIN achievement_tiers at ON at.group_id = ag.id
+  LEFT JOIN user_achievements ua ON ua.tier_id = at.id AND ua.user_id = p_user_id
+  LEFT JOIN metrics m ON m.metric_type = ag.metric_type
+  ORDER BY ag.sort_order, at.tier_level;
+END;
+$$;

--- a/supabase/migrations/20260419130000_fix_pr_streak_and_early_bird.sql
+++ b/supabase/migrations/20260419130000_fix_pr_streak_and_early_bird.sql
@@ -1,0 +1,304 @@
+-- Corrective migration: optimize pr_streak and harden early_bird RPCs
+--
+-- 1. pr_streak: replace correlated EXISTS with precomputed LEFT JOIN,
+--    add us.id tie-breaker for deterministic ROW_NUMBER ordering.
+-- 2. early_bird: INNER JOIN → LEFT JOIN on user_profiles so sessions
+--    are still evaluated (UTC fallback) when profile row is missing.
+--
+-- Applied to both check_and_grant_achievements and get_badge_status.
+
+-- ── check_and_grant_achievements ────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION check_and_grant_achievements(p_user_id uuid)
+RETURNS TABLE (
+  tier_id uuid, group_slug text, rank text,
+  title_en text, title_fr text, icon_asset_url text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+BEGIN
+  IF auth.uid() IS NOT NULL AND auth.uid() <> p_user_id THEN
+    RAISE EXCEPTION 'access denied: cannot grant achievements for another user'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_sessions AS (
+    SELECT s.id, s.workout_day_id, s.finished_at
+    FROM sessions s
+    WHERE s.user_id = p_user_id AND s.finished_at IS NOT NULL
+  ),
+  metrics AS (
+    SELECT 'session_count' AS metric_type, COUNT(*)::numeric AS value
+      FROM user_sessions
+
+    UNION ALL
+    SELECT 'total_volume_kg',
+           COALESCE(SUM(sl.weight_logged * sl.reps_logged::int), 0)
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.reps_logged IS NOT NULL
+        AND sl.reps_logged ~ '^\d+$'
+
+    UNION ALL
+    SELECT 'pr_count', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.was_pr = true
+
+    UNION ALL
+    SELECT 'unique_exercises', COUNT(DISTINCT sl.exercise_id)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+
+    UNION ALL
+    SELECT 'active_weeks', COUNT(*)::numeric
+      FROM (
+        SELECT date_trunc('week', us.finished_at) AS wk
+        FROM user_sessions us
+        GROUP BY date_trunc('week', us.finished_at)
+        HAVING COUNT(*) >= 3
+      ) AS weeks_with_3plus
+
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      WHERE us.workout_day_id IS NULL
+
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
+
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
+          FROM (
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at, us.id) AS session_ord,
+                   (prs.session_id IS NOT NULL) AS has_pr
+            FROM user_sessions us
+            LEFT JOIN (
+              SELECT DISTINCT sl.session_id
+              FROM set_logs sl
+              WHERE sl.was_pr = true
+            ) prs ON prs.session_id = us.id
+          ) all_sessions
+          WHERE has_pr
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) < 8
+  ),
+  eligible AS (
+    SELECT at.id, ag.slug, at.rank AS r,
+           at.title_en, at.title_fr, at.icon_asset_url
+    FROM metrics m
+    JOIN achievement_groups ag ON ag.metric_type = m.metric_type
+    JOIN achievement_tiers at ON at.group_id = ag.id
+    WHERE at.threshold_value <= m.value
+      AND NOT EXISTS (
+        SELECT 1 FROM user_achievements ua
+        WHERE ua.user_id = p_user_id AND ua.tier_id = at.id
+      )
+  ),
+  granted AS (
+    INSERT INTO user_achievements (user_id, tier_id)
+    SELECT p_user_id, e.id FROM eligible e
+    ON CONFLICT (user_id, tier_id) DO NOTHING
+    RETURNING user_achievements.tier_id
+  )
+  SELECT e.id, e.slug, e.r, e.title_en, e.title_fr, e.icon_asset_url
+  FROM eligible e
+  JOIN granted g ON g.tier_id = e.id;
+END;
+$$;
+
+
+-- ── get_badge_status ────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION get_badge_status(p_user_id uuid)
+RETURNS TABLE (
+  group_id uuid, group_slug text, group_name_en text, group_name_fr text,
+  tier_id uuid, tier_level int, rank text,
+  title_en text, title_fr text,
+  threshold_value numeric, icon_asset_url text,
+  is_unlocked boolean, granted_at timestamptz,
+  current_value numeric, progress_pct numeric
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+BEGIN
+  IF auth.uid() IS NOT NULL AND auth.uid() <> p_user_id THEN
+    RAISE EXCEPTION 'access denied: cannot read badge status for another user'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_sessions AS (
+    SELECT s.id, s.workout_day_id, s.finished_at
+    FROM sessions s
+    WHERE s.user_id = p_user_id AND s.finished_at IS NOT NULL
+  ),
+  metrics AS (
+    SELECT 'session_count' AS metric_type, COUNT(*)::numeric AS value
+      FROM user_sessions
+
+    UNION ALL
+    SELECT 'total_volume_kg',
+           COALESCE(SUM(sl.weight_logged * sl.reps_logged::int), 0)
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.reps_logged IS NOT NULL
+        AND sl.reps_logged ~ '^\d+$'
+
+    UNION ALL
+    SELECT 'pr_count', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.was_pr = true
+
+    UNION ALL
+    SELECT 'unique_exercises', COUNT(DISTINCT sl.exercise_id)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+
+    UNION ALL
+    SELECT 'active_weeks', COUNT(*)::numeric
+      FROM (
+        SELECT date_trunc('week', us.finished_at) AS wk
+        FROM user_sessions us
+        GROUP BY date_trunc('week', us.finished_at)
+        HAVING COUNT(*) >= 3
+      ) AS weeks_with_3plus
+
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      WHERE us.workout_day_id IS NULL
+
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
+
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
+          FROM (
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at, us.id) AS session_ord,
+                   (prs.session_id IS NOT NULL) AS has_pr
+            FROM user_sessions us
+            LEFT JOIN (
+              SELECT DISTINCT sl.session_id
+              FROM set_logs sl
+              WHERE sl.was_pr = true
+            ) prs ON prs.session_id = us.id
+          ) all_sessions
+          WHERE has_pr
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) < 8
+  )
+  SELECT
+    ag.id, ag.slug, ag.name_en, ag.name_fr,
+    at.id, at.tier_level, at.rank,
+    at.title_en, at.title_fr,
+    at.threshold_value, at.icon_asset_url,
+    (ua.id IS NOT NULL), ua.granted_at,
+    COALESCE(m.value, 0),
+    LEAST(COALESCE(m.value, 0) / NULLIF(at.threshold_value, 0) * 100, 100)
+  FROM achievement_groups ag
+  JOIN achievement_tiers at ON at.group_id = ag.id
+  LEFT JOIN user_achievements ua ON ua.tier_id = at.id AND ua.user_id = p_user_id
+  LEFT JOIN metrics m ON m.metric_type = ag.metric_type
+  ORDER BY ag.sort_order, at.tier_level;
+END;
+$$;


### PR DESCRIPTION
## What

- **SQL migration**: `timezone` column on `user_profiles` (backfilled `Europe/Paris`), 6 new `achievement_groups` (sort_order 6–11), 30 new `achievement_tiers`, both RPCs replaced with 11-branch `metrics` CTE
- **i18n**: EN + FR entries for `groups`, `groupDescriptions`, and `thresholdHint` across all 6 new tracks
- **Timezone capture**: silent browser detection via `Intl.DateTimeFormat` in `useCreateUserProfile` — zero UX friction
- **Boot-time gate**: `AchievementRealtimeProvider` stores a `subscriptionStartedAt` timestamp and silently drops retroactive badge toasts
- **Epic Brief + Tech Plan**: full specification documents for the 6 tracks

## Why

The achievement surface was narrow — 5 groups rewarding session count, volume, rest times, PRs, and variety. Users who train legs, do ad-hoc workouts, or work out early had no recognition. Streak-based metrics ("don't break the chain") were entirely missing. This expands the system to 11 groups / 55 tiers to reward 6 distinct training behaviors.

## How

- **New metric branches** appended to the existing `UNION ALL` CTE in both `check_and_grant_achievements` and `get_badge_status` — no new RPCs, no schema changes beyond seed data and one column
- **Streak computation**: window-function gap detection (`ROW_NUMBER` trick) for `streak_king` (consecutive weeks) and `pr_streak` (consecutive PR sessions)
- **Leg Day**: JOIN through `set_logs` → `exercises` filtering on 5 lower-body `muscle_group` values
- **Marathoner**: per-session volume aggregation with a 5,000 kg qualifying floor
- **Early Bird**: `AT TIME ZONE COALESCE(up.timezone, 'UTC')` conversion using the new `user_profiles.timezone` column
- **Retroactive safety**: boot-time gate in the Realtime provider ensures migration-time grants don't flood users with toast overlays
- **Zero frontend components changed** — the accordion UI from #174 already renders N groups dynamically

Closes #218