### PR TITLE
fix: work around Recharts v3 ResponsiveContainer -1 initial dimensions

### DIFF
--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -58,7 +58,9 @@ const ChartContainer = React.forwardRef<
         {...props}
       >
         <ChartStyle id={chartId} config={config} />
-        <RechartsPrimitive.ResponsiveContainer>
+        <RechartsPrimitive.ResponsiveContainer
+          initialDimension={{ width: 1, height: 1 }}
+        >
           {children}
         </RechartsPrimitive.ResponsiveContainer>
       </div>


### PR DESCRIPTION
## What

- Add `initialDimension={{ width: 1, height: 1 }}` to `ResponsiveContainer` in `ChartContainer` (`src/components/ui/chart.tsx`)

## Why

After the Recharts 2 → 3 upgrade (`e24f289`), `ResponsiveContainer` defaults `initialDimension` to `{ width: -1, height: -1 }` before `ResizeObserver` measures the container ([recharts#6716](https://github.com/recharts/recharts/issues/6716)). The `BalanceGaugeRadialChart` guard `(width > 0 && height > 0)` returns `null` on that first frame, collapsing the container so the observer never reports valid dimensions — the gauge never renders.

The fix is merged upstream (PR #7174) but not yet released in a Recharts version.

## How

Pass a positive placeholder `initialDimension` to `ResponsiveContainer` inside the shared `ChartContainer` wrapper. This lets the first render produce a non-zero element so `ResizeObserver` can measure real dimensions on the next frame. All chart consumers (`BalanceGauge`, `ExerciseChart`) benefit.

Closes #225
