### PR TITLE
fix(#225): measure container for BalanceGauge after Recharts v3 context migration

### DIFF
--- a/src/components/history/balance/BalanceGauge.tsx
+++ b/src/components/history/balance/BalanceGauge.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react"
 import {
   Label,
   PolarAngleAxis,
@@ -122,6 +123,25 @@ export function BalanceGauge({
   const clamped = Math.min(100, Math.max(0, score))
   const gaugeLabel = `${score} ${bandLabel}`
 
+  const chartRef = useRef<HTMLDivElement>(null)
+  const [size, setSize] = useState({ width: 0, height: 0 })
+
+  useEffect(() => {
+    const el = chartRef.current
+    if (!el) return
+    const ro = new ResizeObserver(([entry]) => {
+      if (!entry) return
+      const { width, height } = entry.contentRect
+      setSize((prev) => {
+        const w = Math.round(width)
+        const h = Math.round(height)
+        return prev.width === w && prev.height === h ? prev : { width: w, height: h }
+      })
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
   const chartData = [{ score: clamped, fill: "var(--color-balance)" }]
 
   const chartConfig = {
@@ -142,10 +162,13 @@ export function BalanceGauge({
       aria-label={gaugeLabel}
     >
       <ChartContainer
+        ref={chartRef}
         config={chartConfig}
         className="mx-auto w-full min-w-0 aspect-2/1 [&_.recharts-responsive-container]:h-full [&_.recharts-responsive-container]:min-h-[168px] [&_.recharts-wrapper]:h-full [&_.recharts-wrapper]:w-full"
       >
         <BalanceGaugeRadialChart
+          width={size.width}
+          height={size.height}
           clamped={clamped}
           bandLabel={bandLabel}
           chartData={chartData}


### PR DESCRIPTION
## What

- Add `ResizeObserver` measurement on the `ChartContainer` ref in `BalanceGauge` to pass explicit `width`/`height` to `BalanceGaugeRadialChart`

## Why

PR #226 fixed the console warning (`initialDimension` defaulting to -1) but the gauge still didn't render. Recharts v3 replaced element cloning with a React context ([recharts#6386](https://github.com/recharts/recharts/pull/6386)) — `ResponsiveContainer` no longer injects `width`/`height` props into children. Our custom `BalanceGaugeRadialChart` always received its defaults (`0, 0`), failed its dimension guard, and returned `null`.

This is the correct v3 pattern for any custom wrapper that needs container dimensions for layout computations (not a temporary workaround — see #227 for the temporary part).

## How

Attach a `ref` to `ChartContainer`, observe it with `ResizeObserver`, and pass the measured dimensions to `BalanceGaugeRadialChart`. The component's existing `width > 0 && height > 0` guard now works as intended.

Closes #225
