### PR TITLE
fix: append timestamp to exercise image filename for cache busting

### DIFF
--- a/src/lib/imageUpload.ts
+++ b/src/lib/imageUpload.ts
@@ -39,7 +39,8 @@ export async function uploadExerciseImage(
   previousFilename?: string | null,
 ): Promise<string> {
   const optimized = await optimizeImage(file)
-  const filename = `${toKebabCase(exerciseName)}.webp`
+  const ts = Date.now().toString(36)
+  const filename = `${toKebabCase(exerciseName)}-${ts}.webp`
 
   if (previousFilename && previousFilename !== filename) {
     try {


### PR DESCRIPTION
## What

- Append a base-36 timestamp to the exercise image filename before upload (`exercise-name-m1abc.webp`)

## Why

The previous scheme used a deterministic filename (`exercise-name.webp`). When an admin re-uploaded an image for the same exercise, the storage key didn't change, so CDN and browser caches kept serving the stale version indefinitely.

## How

Generate a short timestamp suffix via `Date.now().toString(36)` and include it in the filename. Each upload now produces a unique key, and the existing `previousFilename` cleanup logic already handles deleting the old file.
