### PR TITLE
feat(mcp): OAuth 2.1 discovery, connection docs & exercise count fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,98 @@
-# Workout App
+# GymLogic
 
-A mobile-first PWA for tracking strength training sessions — with offline support, progression tracking, and workout analytics.
+A mobile-first PWA for tracking strength training — with offline support, progression tracking, workout analytics, and an **MCP server that lets your AI agent coach you using your real training data**.
 
-Built with React 19, TypeScript, Supabase, and Tailwind CSS.
+Built with React 19, TypeScript, Supabase, and Tailwind CSS. Live at [gymlogic.me](https://gymlogic.me).
+
+---
+
+## Connect your AI agent
+
+GymLogic exposes your training data as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server. This means Claude, Cursor, Le Chat, and other MCP-compatible agents can search your exercise catalog, pull your session history, analyze your training stats, and check your upcoming workouts — all through natural conversation.
+
+**Setup guides:**
+
+- [Cursor](docs/mcp-connect/cursor.md)
+- [Le Chat (Mistral)](docs/mcp-connect/le-chat.md)
+- [Claude Desktop](docs/mcp-connect/claude-desktop.md)
+
+**Available tools:**
+
+| Tool | What it does |
+|---|---|
+| `search_exercises` | Search 360+ exercises by name (FR/EN), muscle group, equipment, difficulty |
+| `get_exercise_details` | Full exercise metadata: instructions, muscles, equipment, media |
+| `get_workout_history` | Past sessions with sets, weights, and PR flags |
+| `get_training_stats` | Volume by muscle group, personal records, session frequency |
+| `get_upcoming_workouts` | Programmed training days and exercises |
+
+Plus 1 MCP Resource (`exercise_catalog_schema`) exposing the domain taxonomy so agents understand the vocabulary without burning tool calls.
+
+The MCP server runs as a single Supabase Edge Function with hand-rolled JSON-RPC 2.0, OAuth 2.1 for client auth, and RLS-scoped queries so each user only sees their own data.
+
+> See the [Epic Brief](docs/Epic_Brief_—_MCP-First_Architecture_%23231.md) and [Tech Plan](docs/Tech_Plan_—_MCP-First_Architecture_%23231.md) for architecture details.
 
 ---
 
 ## Features
 
-### Onboarding & programs
-- First-run **onboarding** (profile / equipment) before the main app
-- **Create program** flow: pick a **template**, start **blank**, or build an **AI-generated** multi-day program (constraints wizard, preview, confirm) via Supabase Edge Function + Gemini
-- Template path resolves **equipment swaps** using the exercise alternatives catalog where needed
-- **Onboarding guard**: main shell routes require an active program; users without one are guided through `/create-program`
-
 ### Workout session
 - Day selector and horizontal **exercise strip**; per-exercise **sets table** (reps, weight, done checkbox)
-- **RIR (reps in reserve)** per set, with **in-session load suggestions** for the next set based on the previous set’s RIR
+- **RIR (reps in reserve)** per set with **in-session load suggestions** based on previous set performance
 - Full-screen **rest timer** (countdown, audio, vibration, notifications) and **session timer**; **session summary** on completion
 - **Last session** reference per exercise
-- **Exercise detail**: structured **instructions**, YouTube demo (lazy thumbnails), illustration, **body-map** muscle highlight (`react-body-highlighter`), and an **exercise history** sheet (past sessions + trend chart)
+- **Exercise detail**: structured **instructions**, YouTube demo, illustration, **body-map** muscle highlight, and **exercise history** sheet (past sessions + trend chart)
 - **Quick workout**: generate a **single ad-hoc session** with AI (constraints + Edge Function) when you want something off-program
-- **Offline-first**: set logs and session completion are **queued** and synced when back online (see below)
 
-### Training cycles
-- Sessions can be linked to a **training cycle**; **cycle summary** route surfaces completion stats and history for a finished cycle
-- “Quick” / off-cycle sessions avoid attaching to the active cycle when appropriate
+### Programs & cycles
+- **Create program** flow: pick a **template**, start **blank**, or build an **AI-generated** multi-day program (constraints wizard, preview, confirm) via Gemini
+- Template path resolves **equipment swaps** using the exercise alternatives catalog
+- Sessions linked to **training cycles**; **cycle summary** route surfaces completion stats and history
+- Full **CRUD** for programs (workout days, slot exercises) with **drag-and-drop** reorder and **exercise library picker**
 
 ### Progression & PRs
-- **Epley estimated 1RM** from logged sets; **automatic PR detection** with a **PR badge** on the exercise strip when you beat your previous best
+- **Epley estimated 1RM** from logged sets; **automatic PR detection** with a **PR badge** when you beat your previous best
 - `estimated_1rm`, `was_pr`, and **RIR** persisted on `set_logs` for history and suggestions
 
 ### History & analytics
-- **Stats** dashboard (sessions, sets, PRs, etc.) and reverse-chronological **session list** with expandable details
-- Per-exercise **1RM-over-time** charts (Recharts)
-- **Workout overview** cards with muscle coverage / body-map style summaries where the UI presents them
+- **Stats dashboard** (sessions, sets, PRs, volume) and reverse-chronological **session list** with expandable details
+- Per-exercise **1RM-over-time** charts
+- **Activity heatmap** and **muscle group breakdown**
 
-### Workout library
-- Dedicated **`/library`** page: large **exercise catalog** (~600+ items) with search, **muscle group** and **equipment** filters, and **difficulty** badges / filtering where data exists
-- Rich catalog metadata: FR/EN names, instructions (JSON sections), YouTube URLs, illustrations, secondary muscles, provenance
+### Achievements
+- **Badge system** with multiple tracks (consistency, strength, volume, exploration)
+- Achievement **detail drawer** with progress tracking
+- **Title system** — unlock display titles based on achievements
 
-### Workout builder
-- Full **CRUD** for **programs** (workout days and slot exercises)
-- **Exercise library picker** (search + filters, cmdk) and **drag-and-drop** reorder (dnd-kit)
-- Snapshot fields on `workout_exercises` keep exercise copy stable when catalog content changes
-- **Online-only** editing with a clear offline state
+### Exercise library
+- **360+ exercise catalog** with search, **muscle group** and **equipment** filters, **difficulty** badges
+- Rich metadata: FR/EN names, instructions (setup, movement, breathing, common mistakes), YouTube URLs, illustrations, secondary muscles
+- **Exercise detail page** with body-map, instructions, history, and media
 
-### Exercise content & feedback
-- Users can **report content issues** from multiple entry points; **admins** triage feedback from the admin area
+### Account & email
+- **Account page** with avatar upload, display name, weight unit preference
+- **Transactional emails** via Resend (welcome, lifecycle) with unsubscribe management
+- **Custom domain** email (`admin@gymlogic.me`)
 
 ### Offline-first sync
 - `SyncService` queues set logs and session finishes in **localStorage** with **fingerprint-based deduplication**
-- Queue **drains** on reconnect and on load when authenticated
+- Queue drains on reconnect and on load when authenticated
 - **Sync status** chip in the UI
 
 ### PWA & shell
-- Install prompt (banner + settings), **Workbox** service worker (app shell + runtime caching for Supabase API), standalone display
-- **Route-level error boundaries** for failed navigations / lazy chunks
-- Bottom nav + drawer **App shell** for workout, history, builder, library
+- Install prompt, **Workbox** service worker (app shell + runtime caching), standalone display
+- **Route-level error boundaries** for failed navigations
+- Bottom nav + drawer **App shell** for workout, history, builder, library, achievements
 
 ### Internationalization & theming
-- **FR / EN** via react-i18next with **per-feature namespaces** (e.g. workout, history, builder, onboarding, create-program, library, generator, admin, exercise, settings, errors)
-- **kg / lbs** display preference (storage in kg)
-- **Dark / light** theme via next-themes
+- **FR / EN** via react-i18next with per-feature namespaces
+- **kg / lbs** display preference (storage always in kg)
+- **Dark / light** theme
 
 ### Auth & admin
 - **Google OAuth** via Supabase Auth; **AuthGuard** on protected routes
-- Notification permission prompt for timer / alerts
-- **Admin**: exercise review (`/admin/exercises`) and **feedback triage** (`/admin/feedback`), gated by `admin_users`
-
-### Quality
-- **Vitest** + Testing Library (Epley, weight units, SyncService, hooks, key components)
-- **Playwright** E2E (login, workout, builder, onboarding paths as covered in `e2e/`)
-- **GitHub Actions**: lint, type-check, unit tests, E2E against **local Supabase**, deploy (e.g. Vercel)
+- **OAuth 2.1 server** for MCP client authentication with consent page
+- **Admin**: exercise review, enrichment tools, feedback triage, gated by `admin_users`
 
 ---
 
@@ -85,15 +105,20 @@ Built with React 19, TypeScript, Supabase, and Tailwind CSS.
 | Language | TypeScript 5.9 |
 | State | Jotai (atomWithStorage for persistence) |
 | Server state | TanStack React Query 5 |
-| Backend | Supabase (Postgres + Auth + RLS) |
+| Backend | Supabase (Postgres + Auth + RLS + Edge Functions) |
+| MCP server | Hand-rolled JSON-RPC 2.0 on Supabase Edge Functions |
+| AI generation | Google Gemini 2.5 Flash (via Edge Functions) |
 | UI components | shadcn/ui (Radix primitives) |
 | Styling | Tailwind CSS 3.4 + tailwindcss-animate |
 | Charts | Recharts |
 | Drag & drop | dnd-kit |
 | i18n | react-i18next + i18next-browser-languagedetector |
+| Email | Resend (transactional) |
 | Icons | lucide-react |
 | PWA | vite-plugin-pwa (Workbox) |
 | Theming | next-themes |
+| Testing | Vitest + Testing Library + Playwright |
+| CI/CD | GitHub Actions + Vercel |
 
 ---
 
@@ -163,15 +188,13 @@ Use a local stack so day-to-day usage and experiments do not write to production
 
 The app reads Supabase URL/anon key from Vite env (`import.meta.env`). Restart `npm run dev` after changing env files.
 
-### Environment files (important)
+### Environment files
 
 | File | Who reads it | Purpose |
 |------|----------------|---------|
 | **`.env.local`** | Vite (`npm run dev`, `npm run build` locally) | `VITE_*` for the browser client — use for local API URL + anon key |
 | **`.env`** (project root) | **Supabase CLI** when parsing `supabase/config.toml` | `env(...)` placeholders (e.g. Google OAuth for local Auth). **The CLI does not load `.env.local`.** |
 | **Vercel / CI** | Production builds | Set `VITE_*` in the dashboard; nothing from `.env.local` is deployed |
-
-Duplicate keys where both tools need them (e.g. Google client id/secret in **`.env`** for `supabase start`, plus whatever you use elsewhere).
 
 ### Service URLs and ports (default)
 
@@ -180,88 +203,50 @@ Duplicate keys where both tools need them (e.g. Google client id/secret in **`.e
 | **54321** | REST / Auth / Edge Functions API (`VITE_SUPABASE_URL`) |
 | **54322** | Postgres (`postgresql://postgres:postgres@127.0.0.1:54322/postgres`) |
 | **54323** | [Supabase Studio](http://127.0.0.1:54323) — table editor, SQL, Auth users |
-| **54324** | [Inbucket](http://127.0.0.1:54324) — captures auth emails locally (magic links, etc.) |
-
-### Inspecting tables and data
-
-- **Studio** at `http://127.0.0.1:54323` is the default place to browse tables and run SQL.
-- Any Postgres client can use the DB URL above for heavier querying.
+| **54324** | [Inbucket](http://127.0.0.1:54324) — captures auth emails locally |
 
 ### Google Sign-In locally
 
 `supabase/config.toml` enables Google when the corresponding vars exist in **project-root `.env`**. In [Google Cloud Console](https://console.cloud.google.com/) → **APIs & Services** → **Credentials** → your **Web** OAuth client:
 
-- **Authorized redirect URIs** must include exactly:  
-  `http://127.0.0.1:54321/auth/v1/callback`  
-  (Supabase Auth receives the OAuth callback here — **not** `http://127.0.0.1:5173/...`.)
-- Keep your hosted callback too if you use the same client for prod, e.g.  
-  `https://<project-ref>.supabase.co/auth/v1/callback`
-- **Authorized JavaScript origins** should include your dev app origin, e.g. `http://localhost:5173` and `http://127.0.0.1:5173`.
+- **Authorized redirect URIs** must include: `http://127.0.0.1:54321/auth/v1/callback`
+- Keep your hosted callback too if you use the same client for prod
+- **Authorized JavaScript origins**: `http://localhost:5173` and `http://127.0.0.1:5173`
 
 After changing `config.toml` or `.env` auth vars, run `npm run supabase:stop` then `npm run supabase:start`.
 
-### Schema and seed
+### Edge Functions
 
-- Migrations: `supabase/migrations/`
-- Seed data (e.g. exercise catalog): `supabase/seed.sql` (applied on `supabase db reset`)
-- Prefer **new migration files** for schema changes rather than only editing data in Studio, so git stays the source of truth.
+With `VITE_SUPABASE_URL` pointing at localhost, `supabase.functions.invoke` hits **local** functions.
 
-### History / Activity / calendar dev data (local)
+| Function | Purpose |
+|---|---|
+| `generate-program` | AI program generation via Gemini |
+| `generate-workout` | Quick workout generation via Gemini |
+| `mcp` | MCP server (JSON-RPC 2.0, 5 tools + 1 resource) |
+| `send-transactional-email` | Welcome and lifecycle emails via Resend |
+| `email-unsubscribe` | Email preference management |
+| `delete-account` | Account deletion with data cleanup |
 
-Login is **Google-only** in the app, so session history cannot be tied to a fixed email in `seed.sql` for your real account. Use the **service-role** script instead:
+The Gemini key must be available to the Edge runtime:
 
-1. `npm run supabase:start` (or ensure local API is up).
-2. Sign in once with **Google**, then copy your user id from **Supabase Studio** → **Authentication** → **Users** (or run `select id, email from auth.users` in the SQL editor).
-3. Run:
+1. Copy `supabase/functions/.env.example` → `supabase/functions/.env`
+2. Set `GEMINI_API_KEY=` to a key from [Google AI Studio](https://aistudio.google.com/apikey)
+3. Restart: `npm run supabase:stop` then `npm run supabase:start`
+
+For **hosted** Supabase, set secrets via `supabase secrets set GEMINI_API_KEY=...` or the dashboard.
+
+### History seed data
 
 ```bash
 npm run seed:history -- --user-id=<your-auth-uuid>
 ```
 
-Or set `SUPABASE_HISTORY_SEED_USER_ID` in `.env.local` and run `npm run seed:history`.
-
-To **list user ids** on the same instance the script will hit:
-
-```bash
-npm run seed:history -- --list-users
-```
-
-**Target URL:** the script defaults to **`http://127.0.0.1:54321`** (local Supabase CLI). It **does not** read `VITE_SUPABASE_URL`, so a `.env` pointed at hosted prod will not send seed data to production.
-
-Override only when you mean it:
-
-- `SUPABASE_HISTORY_SEED_URL` or `SEED_SUPABASE_URL`, or
-- `npm run seed:history -- --url=https://….supabase.co --user-id=…` (then you **must** set `SUPABASE_SERVICE_ROLE_KEY` for that project).
-
-If you see `sessions_user_id_fkey`, the UUID is **not** in `auth.users` for that URL—typical causes: id from another Supabase project, or **`supabase db reset` cleared auth** so you must sign in again and use the new id.
-
-This inserts ~30+ **finished** sessions over the last ~90 days (labels `Local seed — …`) plus `set_logs`, after removing any previous `Local seed%` rows for that user. Safe to re-run.
-
-For **local** URLs (`127.0.0.1` / `localhost`), the script always uses the [local demo service role](https://supabase.com/docs/guides/local-development/cli). **`SUPABASE_SERVICE_ROLE_KEY` in `.env` is ignored** for loopback targets so a hosted project’s key does not get sent to local Auth (which would produce `invalid JWT` / `signature is invalid`). Override for this script only with **`SUPABASE_HISTORY_SEED_SERVICE_ROLE_KEY`** (e.g. if you changed local JWT secrets — use the service role from `supabase status`).
-
-### Row Level Security (RLS)
-
-RLS policies apply to the **anon key + user JWT** used by the app. Studio often uses elevated access, so something can “work in Studio but fail in the app” when RLS blocks the client.
-
-### Edge Functions (e.g. AI generation)
-
-With `VITE_SUPABASE_URL` pointing at localhost, `supabase.functions.invoke` hits **local** functions. The Gemini key is **not** read from the Vite app’s `.env.local` — it must be available to the **Edge runtime**.
-
-1. Copy `supabase/functions/.env.example` → `supabase/functions/.env`.
-2. Set `GEMINI_API_KEY=` to a key from [Google AI Studio](https://aistudio.google.com/apikey).
-3. Restart Docker so the functions container picks it up: `npm run supabase:stop` then `npm run supabase:start`.
-
-If you see `{ "error": "GEMINI_API_KEY is not set" }` from `generate-program` / `generate-workout`, the local `.env` is missing or the stack was not restarted after adding it.
-
-For **hosted** Supabase, set the same variable in the [Dashboard → Edge Functions → Secrets](https://supabase.com/dashboard/project/_/settings/functions) or via `supabase secrets set GEMINI_API_KEY=...` on a linked project. See [Supabase — Environment variables](https://supabase.com/docs/guides/functions/secrets).
+Inserts ~30+ finished sessions over the last ~90 days. See the script for options (`--list-users`, `--url`, etc.).
 
 ### E2E tests
 
-Playwright tests expect local Supabase (see `e2e/`). Start the stack before `npm run test:e2e` when tests hit the API.
-
-### CLI vs linked remote
-
-`supabase link` can warn that local Docker image versions differ from the linked project. Usually safe to ignore for daily dev; upgrade the CLI or re-link when you want them aligned.
+Playwright tests expect local Supabase. Start the stack before `npm run test:e2e`.
 
 ---
 
@@ -270,70 +255,64 @@ Playwright tests expect local Supabase (see `e2e/`). Start the stack before `npm
 ```
 src/
 ├── components/
-│   ├── ui/            # shadcn primitives (button, dialog, table, tabs, etc.)
+│   ├── ui/            # shadcn primitives
 │   ├── workout/       # DaySelector, ExerciseStrip, SetsTable, RestTimerOverlay, SessionSummary
-│   ├── history/       # StatsDashboard, SessionList, ExerciseChart, ExerciseTab
-│   ├── builder/       # DayList, DayEditor, ExerciseLibraryPicker, ExerciseDetailEditor
-│   ├── AppShell.tsx   # Layout shell with bottom nav
-│   ├── SideDrawer.tsx # Settings, theme, language, weight unit, install, sign out
-│   └── SyncStatusChip.tsx
-├── hooks/             # 17 hooks (useWorkoutDays, useLastSession, useBestPerformance, useWeightUnit, etc.)
-├── lib/               # supabase client, syncService, epley 1RM, i18n init, formatters, query client
-├── locales/           # en/ and fr/ JSON translation files (6 namespaces each)
-├── pages/             # LoginPage, WorkoutPage, HistoryPage, BuilderPage
+│   ├── history/       # StatsDashboard, SessionList, ActivityTab, Heatmap
+│   ├── builder/       # DayList, DayEditor, ExerciseLibraryPicker
+│   ├── library/       # ExerciseCatalog, AddExerciseToDaySheet
+│   ├── body-map/      # BodyMap muscle highlight visualization
+│   ├── achievements/  # BadgeGrid, AchievementDetailDrawer
+│   └── AppShell.tsx   # Layout shell with bottom nav
+├── hooks/             # useWorkoutDays, useLastSession, useBestPerformance, useWeightUnit, etc.
+├── lib/               # supabase client, syncService, epley 1RM, i18n, formatters, supabase-oauth
+├── locales/           # en/ and fr/ JSON translation files
+├── pages/             # LoginPage, WorkoutPage, HistoryPage, BuilderPage, AchievementsPage, etc.
 ├── router/            # Routes + AuthGuard
-├── store/             # Jotai atoms (session, rest, auth, sync, locale, theme, etc.)
-├── types/             # TypeScript types (auth, database)
+├── store/             # Jotai atoms (session, rest, auth, sync, locale, theme)
+├── types/             # TypeScript types (auth, database, achievements, etc.)
 └── main.tsx
+
+supabase/
+├── functions/
+│   ├── mcp/           # MCP server (JSON-RPC handler, tools, resources, formatters)
+│   ├── generate-program/
+│   ├── generate-workout/
+│   ├── send-transactional-email/
+│   ├── email-unsubscribe/
+│   └── delete-account/
+├── migrations/        # Postgres schema migrations
+└── seed.sql           # Exercise catalog + seed data
+
+docs/
+├── mcp-connect/       # Per-client MCP connection guides
+├── Epic_Brief_*       # Epic briefs for current work
+├── Tech_Plan_*        # Technical plans
+├── T*                 # Implementation tickets
+└── done/              # Completed epic/ticket docs
 ```
 
 ---
 
 ## Database
 
-Five tables with row-level security scoped to the authenticated user:
+Core tables with row-level security scoped to the authenticated user:
 
 | Table | Purpose |
 |---|---|
-| `exercises` | Exercise catalog (name, muscle group, emoji) |
-| `workout_days` | User's training days (label, emoji, sort order) |
+| `exercises` | Exercise catalog (360+ items, FR/EN names, instructions, media) |
+| `programs` | User training programs |
+| `cycles` | Training cycles within a program |
+| `workout_days` | Training days (label, sort order) |
 | `workout_exercises` | Exercises assigned to a day (sets, reps, weight, rest) |
 | `sessions` | Completed workout sessions |
-| `set_logs` | Individual set records (reps, weight, 1RM, PR flag) |
+| `set_logs` | Individual set records (reps, weight, 1RM, PR flag, RIR) |
+| `achievements` | Badge definitions and user progress |
+| `admin_users` | Admin access control |
+| `exercise_feedback` | User-reported content issues |
+| `transactional_email_log` | Email delivery tracking |
+| `email_preferences` | User email opt-in/out |
 
 See `supabase/migrations/` for the full schema.
-
----
-
-## Roadmap — Next Iteration
-
-Things that would make sense to tackle next, roughly ordered by impact:
-
-**Testing & CI**
-- Broaden unit/integration coverage (edge cases, fewer mocks, visual regression optional).
-- Expand Playwright coverage (AI flows, cycles, library) and keep local Supabase fixtures maintainable.
-
-**CI/CD**
-- Further harden pipeline (bundle budgets, preview deploys, scheduled E2E).
-
-**Performance**
-- Lazy-load routes (`React.lazy` + `Suspense`).
-- Bundle analysis and tree-shaking audit.
-
-**Data Export**
-- CSV or JSON export of workout history from the History page.
-
-**Richer Analytics**
-- Total volume over time, muscle-group breakdown, streak tracking.
-
-**Accessibility**
-- Keyboard navigation audit, ARIA labels, screen reader testing.
-
-**Onboarding & programs**
-- Deeper coaching or analytics on top of the existing wizard (templates, blank, AI program).
-
-**Exercise Name Translations**
-- Exercise names are user-owned Supabase data and currently not translated. Could offer a translation layer or let users rename.
 
 ---
 

--- a/docs/Epic_Brief_—_MCP-First_Architecture_#231.md
+++ b/docs/Epic_Brief_—_MCP-First_Architecture_#231.md
@@ -28,7 +28,7 @@ This shifts the app from "AI features locked in a closed loop" to "agent-ready p
 
 - AI features follow a **closed loop**: React UI → Supabase Edge Function → Gemini 2.5 Flash → validated response → UI. The user never sees the LLM directly and can't bring their own.
 - **Deterministic expertise** (RIR-based progression, Epley 1RM, volume maps, triple progression) lives in `file:src/lib/` — accessible only through the React UI.
-- **600+ exercise catalog** with rich metadata (muscles, equipment, difficulty, instructions, media) is locked behind in-app search/filter.
+- **360+ exercise catalog** with rich metadata (muscles, equipment, difficulty, instructions, media) is locked behind in-app search/filter.
 - **Training data** (PRs, session history, volume, programs) has no programmatic access — users must open the app and navigate to the right screen.
 - Every AI generation costs a Gemini API call that we pay for, with a narrow context window (catalog + profile + recent history).
 

--- a/docs/T65_—_Manual_Testing_Guide.md
+++ b/docs/T65_—_Manual_Testing_Guide.md
@@ -1,0 +1,228 @@
+# T65 — Manual Testing Guide (Post-Merge)
+
+## Pre-flight (do this once)
+
+### 0.1 — Merge and deploy
+
+1. Merge PR #234 into `main`
+2. Wait for Vercel deploy to complete (check [Vercel dashboard](https://vercel.com) — the consent page at `https://gymlogic.me/oauth/consent` must be live)
+3. Deploy the Edge Function:
+   ```bash
+   supabase functions deploy --no-verify-jwt mcp
+   ```
+4. In [Supabase Dashboard](https://supabase.com/dashboard) > Authentication > OAuth Server:
+   - Confirm OAuth 2.1 is **enabled**
+   - Authorization URL path = `/oauth/consent`
+   - Dynamic client registration = **enabled**
+   - Site URL = `https://gymlogic.me`
+
+### 0.2 — Get a fresh Bearer token
+
+Go to `https://gymlogic.me`, sign in, open browser DevTools > Application > Local Storage > find the `sb-*-auth-token` key, copy the `access_token` value. You'll need this for Cursor and for smoke-testing.
+
+### 0.3 — Verify the server is alive
+
+```bash
+curl -s -X POST https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <YOUR_TOKEN>" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq .
+```
+
+Expected: JSON response with 5 tools. If this fails, stop — nothing else will work.
+
+---
+
+## Client 1 — Cursor (Bearer auth, easiest)
+
+Cursor uses Bearer auth via the existing config. No OAuth needed.
+
+### Step 1 — Update the token
+
+Edit `~/.cursor/mcp.json`. Replace the `Authorization` header value with `Bearer <YOUR_FRESH_TOKEN>` from step 0.2.
+
+### Step 2 — Restart Cursor MCP
+
+Cursor Settings > MCP > click the refresh icon next to `gymlogic` (or toggle off/on).
+
+### Step 3 — Verify discovery
+
+Open a **new Agent chat** (not an existing one — Cursor caches tools per session).
+
+Ask: **"What tools does gymlogic have?"**
+
+Expected: the agent lists all 5 tools + 1 resource (`search_exercises`, `get_exercise_details`, `get_workout_history`, `get_training_stats`, `get_upcoming_workouts`, `exercise_catalog_schema`).
+
+If only `search_exercises` shows up: close Cursor entirely, reopen the project, and try again (known Cursor caching issue).
+
+### Step 4 — Run test prompts
+
+One by one, in the same chat:
+
+| Prompt | Expected tool call | What to check |
+|---|---|---|
+| "Cherche 'rowing'" | `search_exercises` | Returns multiple results, no IDs exposed |
+| "Cherche 'kroc row'" | `search_exercises` | Single result WITH exercise ID shown |
+| "Donne-moi les details de cet exercice" | `get_exercise_details` | Uses the UUID from above, returns full instructions |
+| "Mes 5 dernieres seances" | `get_workout_history` | Returns your session data with dates and sets |
+| "Mes stats de volume ce mois" | `get_training_stats` | Returns volume by muscle group + PRs |
+| "C'est quoi mon prochain training ?" | `get_upcoming_workouts` | Returns program schedule or graceful "no active program" |
+
+### Step 5 — Coaching conversation
+
+Ask: **"Analyse mon equilibre push/pull sur le dernier mois et dis-moi ce que je devrais ameliorer"**
+
+Expected: agent calls `get_training_stats` and possibly `get_workout_history`, then reasons about the data. This is the thesis test — is it better than in-app generate-workout?
+
+---
+
+## Client 2 — Le Chat / Mistral (free tier, OAuth)
+
+Le Chat supports custom MCP "Connectors" via their UI. Free tier works.
+
+### Step 1 — Go to Le Chat
+
+Open [chat.mistral.ai](https://chat.mistral.ai) and sign in (free account works).
+
+### Step 2 — Add a Connector
+
+1. Go to **Agents** (left sidebar) > create a new Agent or edit an existing one
+2. In the Agent config, look for **Connectors** / **Tools** section
+3. Click **Add Connector** > **Custom MCP Server**
+4. Fill in:
+   - **Name**: `gymlogic`
+   - **URL**: `https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp`
+   - **Auth**: If OAuth is offered, select it. Le Chat should auto-discover the OAuth endpoints from Supabase's `/.well-known/oauth-authorization-server/auth/v1` discovery doc. If it asks for a Bearer token instead, paste the token from step 0.2.
+
+### Step 3 — OAuth consent (if OAuth flow triggers)
+
+- Le Chat should redirect you to `https://gymlogic.me/oauth/consent`
+- You should see the GymLogic consent page with client name and scopes
+- Click **Approve**
+- You should be redirected back to Le Chat with the connection established
+
+If the consent page doesn't load or shows an error:
+- Check that Vercel deploy is live (`https://gymlogic.me/oauth/consent?authorization_id=test` should at least render the loading state)
+- Check that Supabase Dashboard has OAuth 2.1 enabled
+- Check that Site URL is set to `https://gymlogic.me` (not a Vercel preview URL)
+
+### Step 4 — Test prompts
+
+Same prompts as Cursor:
+1. "What did I train this week?" — expects `get_workout_history`
+2. "Search for bench press exercises" — expects `search_exercises`
+3. "What are my training stats for this month?" — expects `get_training_stats`
+
+### Step 5 — Note what breaks
+
+Le Chat may handle tool calls differently from Cursor. Note:
+- Does it discover all 5 tools?
+- Does it respect the anti-spam pattern (not spamming `get_exercise_details`)?
+- Are the structured text responses readable in Le Chat's UI?
+
+---
+
+## Client 3 — Claude Desktop (free mode, needs adapter)
+
+Claude Desktop's JSON config only supports stdio, not HTTP. You need an adapter.
+
+### Step 1 — Install the adapter
+
+```bash
+npm install -g @anthropic-ai/mcp-remote
+```
+
+(If that package doesn't exist, use `npx @anthropic-ai/mcp-remote` or `npx mcp-remote` — the adapter ecosystem is evolving. Alternative: `@pyroprompts/mcp-stdio-to-streamable-http-adapter`.)
+
+### Step 2 — Edit Claude Desktop config
+
+Open the config file:
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+Add or update the `mcpServers` block:
+
+```json
+{
+  "mcpServers": {
+    "gymlogic": {
+      "command": "npx",
+      "args": [
+        "@anthropic-ai/mcp-remote",
+        "https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp"
+      ]
+    }
+  }
+}
+```
+
+If using Bearer auth instead of OAuth (simpler for testing):
+
+```json
+{
+  "mcpServers": {
+    "gymlogic": {
+      "command": "npx",
+      "args": [
+        "@pyroprompts/mcp-stdio-to-streamable-http-adapter"
+      ],
+      "env": {
+        "URI": "https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp",
+        "BEARER_TOKEN": "<YOUR_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+### Step 3 — Restart Claude Desktop
+
+Fully quit (Cmd+Q) and reopen. Look for the hammer icon in the chat input area — that means tools are loaded.
+
+### Step 4 — Verify tool discovery
+
+Ask: **"What tools do you have available?"**
+
+Expected: Claude lists the 5 gymlogic tools.
+
+### Step 5 — Run the coaching conversation
+
+This is the real thesis test. Run these prompts in sequence:
+
+1. "What did I train this week?"
+2. "How's my push/pull balance over the last month?"
+3. "What's programmed for tomorrow?"
+4. "Tell me about the Romanian deadlift"
+5. "Based on all this, what should I focus on next?"
+
+Expected: Claude chains multiple tool calls, reasons across the data, and gives a coaching-quality answer that's better than what in-app generate-workout produces.
+
+---
+
+## Checklist (per client)
+
+Copy this and check off as you go:
+
+- [ ] Connects without errors
+- [ ] Lists all 5 tools
+- [ ] `search_exercises` returns results
+- [ ] `get_exercise_details` returns full metadata (from a single-match search)
+- [ ] `exercise_catalog_schema` resource is readable
+- [ ] `get_workout_history` returns session data
+- [ ] `get_training_stats` returns volume + PRs
+- [ ] `get_upcoming_workouts` returns schedule (or graceful empty state)
+- [ ] Anti-spam: asking "details du bench press" does NOT trigger 20 calls
+- [ ] Coaching conversation feels better than in-app AI
+
+---
+
+## If things go wrong
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| "Authentication required" on all tools | Expired JWT | Get a fresh token from step 0.2 |
+| Only `search_exercises` shows in Cursor | Cursor cache | Close Cursor fully, reopen project |
+| Consent page 404 | Vercel hasn't deployed main yet | Wait for deploy or check Vercel dashboard |
+| Consent page shows error | Site URL mismatch in Supabase | Dashboard > Auth > URL Config > set to `https://gymlogic.me` |
+| Le Chat can't find OAuth endpoints | Discovery URL not configured | Check `/.well-known/oauth-authorization-server/auth/v1` returns JSON |
+| Claude Desktop shows no hammer icon | Adapter not installed or config wrong | Check `npx` works, check JSON syntax |
+| Tool responses are empty | User has no data for that query | Try broader filters (e.g. last 30 days instead of this week) |

--- a/docs/mcp-connect/claude-desktop.md
+++ b/docs/mcp-connect/claude-desktop.md
@@ -1,0 +1,88 @@
+# Connect GymLogic to Claude Desktop
+
+Use your training data and exercise catalog in Claude conversations via GymLogic's MCP server.
+
+## Prerequisites
+
+- A [GymLogic](https://gymlogic.me) account with at least one logged workout
+- [Claude Desktop](https://claude.ai/download) installed
+
+## Setup
+
+### 1. Add a Custom Connector
+
+1. Open Claude Desktop
+2. Click the **MCP plug icon** (bottom-left, below the conversation list) or go to **Settings** > **Connectors**
+3. Click **Add custom connector**
+4. Fill in:
+   - **Name**: `Gymlogic`
+   - **URL**: `https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp`
+   - Leave **OAuth Client ID** and **OAuth Client Secret** empty (GymLogic uses dynamic registration)
+5. Click **Add**
+
+### 2. Authenticate via OAuth
+
+After adding the connector, Claude Desktop will trigger the OAuth flow:
+
+1. Your browser opens to `www.gymlogic.me/oauth/consent`
+2. Sign in with your GymLogic account if prompted
+3. Review the permissions and click **Approve**
+4. Return to Claude Desktop — the connector now shows as connected
+
+### 3. Start chatting
+
+Look for the **hammer icon** in the chat input area — this confirms tools are loaded. Ask something and Claude will use the GymLogic tools when relevant.
+
+## Available tools
+
+| Tool | What it does |
+|---|---|
+| `search_exercises` | Search the exercise catalog by name (FR/EN), muscle group, equipment, or difficulty |
+| `get_exercise_details` | Full exercise info: instructions, muscles, equipment, media |
+| `get_workout_history` | Your past sessions with sets, weights, and PRs |
+| `get_training_stats` | Volume by muscle group, personal records, session frequency |
+| `get_upcoming_workouts` | Your programmed training days and exercises |
+
+## Example conversation
+
+Try this sequence to test the full coaching experience:
+
+1. **"What did I train this week?"** — pulls your recent sessions
+2. **"How's my push/pull balance over the last month?"** — analyzes volume distribution
+3. **"What's programmed for tomorrow?"** — checks your active program
+4. **"Tell me about the Romanian Deadlift"** — searches and fetches exercise details
+5. **"Based on all this, what should I focus on next?"** — Claude reasons across all the data
+
+## Alternative: config file with `mcp-remote`
+
+If the native connector UI doesn't work for your version, you can use the `mcp-remote` adapter instead. Requires Node.js 18+.
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "gymlogic": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp"
+      ]
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving. `mcp-remote` will open your browser for OAuth on first use.
+
+> **Node version matters**: Claude Desktop uses the first `npx` on your PATH. If you use nvm, make sure your default Node is 18+ (`nvm alias default 20`). Node 12/14 will crash `mcp-remote`.
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| Connector shows "Not connected" | Click the connector and re-authenticate — the OAuth token may have expired |
+| OAuth consent page doesn't load | Make sure you're signed in to GymLogic at `www.gymlogic.me` first |
+| "Authentication required" errors | Disconnect and reconnect the connector to trigger a fresh OAuth flow |
+| No hammer icon (config file method) | Check JSON syntax, verify Node.js 18+ is on your PATH (`node -v`) |
+| `mcp-remote` crashes with `SyntaxError` | Your Node.js is too old — run `nvm use 20` or use the full path `/opt/homebrew/opt/node@22/bin/npx` in the config |

--- a/docs/mcp-connect/cursor.md
+++ b/docs/mcp-connect/cursor.md
@@ -1,0 +1,72 @@
+# Connect GymLogic to Cursor
+
+Use your training data, exercise catalog, and workout stats directly from Cursor's AI agent via GymLogic's MCP server.
+
+## Prerequisites
+
+- A [GymLogic](https://gymlogic.me) account with at least one logged workout
+- [Cursor](https://cursor.com) installed
+
+## Setup
+
+### 1. Get your access token
+
+1. Go to [gymlogic.me](https://gymlogic.me) and sign in
+2. Open browser DevTools (`Cmd+Option+I` on macOS)
+3. Go to **Application** > **Local Storage** > find the key starting with `sb-`
+4. Expand the JSON value and copy the `access_token` field
+
+> The token expires after 1 hour. You'll need to refresh it when it expires.
+
+### 2. Add the MCP server
+
+Edit your global MCP config at `~/.cursor/mcp.json` (create it if it doesn't exist):
+
+```json
+{
+  "mcpServers": {
+    "gymlogic": {
+      "url": "https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_ACCESS_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+Replace `<YOUR_ACCESS_TOKEN>` with the token from step 1.
+
+### 3. Activate in Cursor
+
+1. Open **Cursor Settings** > **MCP**
+2. You should see `gymlogic` listed — click the refresh icon if needed
+3. Open a **new Agent chat** (existing chats won't pick up new tools)
+
+## Available tools
+
+| Tool | What it does |
+|---|---|
+| `search_exercises` | Search the exercise catalog by name (FR/EN), muscle group, equipment, or difficulty |
+| `get_exercise_details` | Full exercise info: instructions, muscles, equipment, media |
+| `get_workout_history` | Your past sessions with sets, weights, and PRs |
+| `get_training_stats` | Volume by muscle group, personal records, session frequency |
+| `get_upcoming_workouts` | Your programmed training days and exercises |
+
+There is also 1 MCP Resource (`exercise_catalog_schema`) that exposes the exercise taxonomy (muscle groups, equipment types, difficulty levels).
+
+## Example prompts
+
+- "Montre-moi mes 5 dernieres seances"
+- "Cherche les exercices pour les pectoraux"
+- "Analyse mon equilibre push/pull sur le dernier mois"
+- "C'est quoi mon prochain training ?"
+- "Donne-moi les details du Romanian Deadlift"
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| Only `search_exercises` shows up | Close Cursor entirely, reopen the project, start a new Agent chat |
+| "Authentication required" errors | Your token expired — get a fresh one from step 1 |
+| Tools not listed at all | Check `~/.cursor/mcp.json` syntax, restart MCP in Cursor Settings |

--- a/docs/mcp-connect/le-chat.md
+++ b/docs/mcp-connect/le-chat.md
@@ -1,0 +1,77 @@
+# Connect GymLogic to Le Chat (Mistral)
+
+Use your training data and exercise catalog in Le Chat conversations via GymLogic's MCP server.
+
+## Prerequisites
+
+- A [GymLogic](https://gymlogic.me) account with at least one logged workout
+- A [Le Chat](https://chat.mistral.ai) account (free tier works)
+
+## Setup
+
+### 1. Create a Connector
+
+1. Go to [chat.mistral.ai](https://chat.mistral.ai) and sign in
+2. Click **Intelligence** in the left sidebar, then select **Connectors**
+3. Click **Add Connector** (top-right)
+4. Switch to the **Custom MCP Connector** tab
+5. Fill in:
+   - **Connector Name**: `gymlogic`
+   - **Connector Server**: `https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp`
+   - **Authentication Method**: select **OAuth 2.1**
+6. Click **Connect**
+
+### 2. Authenticate via OAuth
+
+After clicking Connect, Le Chat opens the GymLogic consent screen:
+
+1. If you're not already signed in to GymLogic, you'll be redirected to the login page first — sign in with your Google account
+2. Review the permissions requested by Le Chat
+3. Click **Approve**
+4. You're redirected back to Le Chat — the connector now shows as connected
+
+### 3. Create an Agent with the Connector
+
+Connectors don't work in regular chats — you need an Agent:
+
+1. Go to **Intelligence** > **Agents**
+2. Click **Create Agent**
+3. Give it a name (e.g. "Coach GymLogic")
+4. In the **Connectors** section, toggle on the **gymlogic** connector you just created
+5. (Optional) Add system instructions like: *"You are a personal training coach. Use the gymlogic tools to answer questions about the user's training history, stats, and exercise catalog."*
+6. Click **Save**
+
+### 4. Start a conversation
+
+1. Go back to **Intelligence** > **Agents**
+2. Click your Agent, then **New Chat**
+3. Ask something — Le Chat will automatically discover and use the GymLogic tools
+
+## Available tools
+
+| Tool | What it does |
+|---|---|
+| `search_exercises` | Search the exercise catalog by name (FR/EN), muscle group, equipment, or difficulty |
+| `get_exercise_details` | Full exercise info: instructions, muscles, equipment, media |
+| `get_workout_history` | Your past sessions with sets, weights, and PRs |
+| `get_training_stats` | Volume by muscle group, personal records, session frequency |
+| `get_upcoming_workouts` | Your programmed training days and exercises |
+
+## Example prompts
+
+- "What did I train this week?"
+- "Search for chest exercises with dumbbells"
+- "How's my training volume this month?"
+- "What's my next workout?"
+- "Tell me about the Kroc Row"
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| OAuth 2.1 not selectable in dropdown | Make sure you entered the exact MCP URL above — Le Chat probes it for OAuth discovery |
+| OAuth consent page doesn't load | Make sure you're signed in to GymLogic at `www.gymlogic.me` first, then retry |
+| `unauthorized request origin` error | Your browser must be on `www.gymlogic.me` (not `gymlogic.me` without www). The Supabase Site URL must match. |
+| "Authentication required" errors | Token may have expired — disconnect the Connector and reconnect |
+| Tools not appearing in chat | You must chat via an **Agent** that has the gymlogic Connector enabled, not a regular chat |
+| Agent doesn't call tools | Make sure the Connector toggle is on in the Agent config. Try an explicit prompt like "Use gymlogic to show my last 5 workouts" |

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <title>GymLogic — Strength training, simplified</title>
     <meta
       name="description"
-      content="Free PWA for strength training: log sessions and PRs, 600+ exercises, offline sync, AI programs. Sign in with Google."
+      content="Free PWA for strength training: log sessions and PRs, 360+ exercises, offline sync, AI programs. Sign in with Google."
     />
 
     <meta property="og:type" content="website" />
@@ -24,7 +24,7 @@
     <meta property="og:title" content="GymLogic — Strength training, simplified" />
     <meta
       property="og:description"
-      content="Free strength-training app: log workouts and PRs, 600+ exercises, rest timers, offline sync, and AI-generated programs. Sign in with Google in seconds."
+      content="Free strength-training app: log workouts and PRs, 360+ exercises, rest timers, offline sync, and AI-generated programs. Sign in with Google in seconds."
     />
     <meta property="og:image" content="https://gymlogic.me/og-image.png" />
     <meta property="og:image:secure_url" content="https://gymlogic.me/og-image.png" />
@@ -42,7 +42,7 @@
     <meta name="twitter:title" content="GymLogic — Strength training, simplified" />
     <meta
       name="twitter:description"
-      content="Free strength-training app: log workouts and PRs, 600+ exercises, rest timers, offline sync, and AI-generated programs. Sign in with Google in seconds."
+      content="Free strength-training app: log workouts and PRs, 360+ exercises, rest timers, offline sync, and AI-generated programs. Sign in with Google in seconds."
     />
     <meta name="twitter:image" content="https://gymlogic.me/og-image.png" />
     <meta

--- a/src/locales/en/auth.json
+++ b/src/locales/en/auth.json
@@ -5,7 +5,7 @@
   "marketingHeadline": "Strength training, simplified",
   "marketingSub": "Log sessions, track PRs, and follow programs on your phone — huge exercise library, rest timers, offline sync, and AI-powered workout & program generation.",
   "feature1": "Progressive overload & session history",
-  "feature2": "600+ exercises with instructions & demos",
+  "feature2": "360+ curated exercises with instructions & demos",
   "feature3": "Works offline; syncs when you reconnect",
   "feature4": "AI-generated workouts & programs tailored to your profile",
   "cardEyebrow": "Get started",

--- a/src/locales/fr/auth.json
+++ b/src/locales/fr/auth.json
@@ -5,7 +5,7 @@
   "marketingHeadline": "La musculation, en toute clarté",
   "marketingSub": "Enregistrez vos séances, vos PR et vos programmes sur mobile — bibliothèque d'exercices, chronos de repos, synchro hors ligne, et génération par IA de programmes et de séances.",
   "feature1": "Progression et historique de séances",
-  "feature2": "600+ exercices avec consignes et démos",
+  "feature2": "360+ exercices sélectionnés avec consignes et démos",
   "feature3": "Hors ligne : synchro automatique au retour du réseau",
   "feature4": "Séances et programmes générés par IA selon votre profil",
   "cardEyebrow": "C'est parti",

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -106,7 +106,7 @@ async function handleWellKnown(url: URL): Promise<Response | null> {
       )
       const metadata = await upstream.json()
       return json(metadata)
-    } catch (_) {
+    } catch (_err) {
       return json({ error: "Failed to fetch authorization server metadata" }, 502)
     }
   }

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -10,6 +10,10 @@ const corsHeaders: Record<string, string> = {
   "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
 }
 
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!
+const MCP_URL = `${SUPABASE_URL}/functions/v1/mcp`
+const AUTH_ISSUER = `${SUPABASE_URL}/auth/v1`
+
 const SERVER_INFO = { name: "gymlogic", version: "0.1.0" }
 const PROTOCOL_VERSION = "2025-03-26"
 
@@ -51,11 +55,7 @@ async function handleRpc(
       const resource = resourceRegistry.get(uri)
       if (!resource) return fail(id, -32602, `Unknown resource: ${uri}`)
 
-      const supabase = authHeader.startsWith("Bearer ")
-        ? createUserClient(authHeader)
-        : null
-
-      const result = await resource.handler(supabase)
+      const result = await resource.handler(createUserClient(authHeader))
       return ok(id, result)
     }
 
@@ -65,11 +65,7 @@ async function handleRpc(
       const tool = toolRegistry.get(name)
       if (!tool) return fail(id, -32601, `Unknown tool: ${name}`)
 
-      const supabase = authHeader.startsWith("Bearer ")
-        ? createUserClient(authHeader)
-        : null
-
-      const result = await tool.handler(args, supabase)
+      const result = await tool.handler(args, createUserClient(authHeader))
       return ok(id, result)
     }
 
@@ -78,11 +74,44 @@ async function handleRpc(
   }
 }
 
-function json(body: unknown, status = 200) {
+function json(body: unknown, status = 200, extraHeaders?: Record<string, string>) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
+    headers: { ...corsHeaders, "Content-Type": "application/json", ...extraHeaders },
   })
+}
+
+const RESOURCE_METADATA_URL = `${MCP_URL}/.well-known/oauth-protected-resource`
+const WWW_AUTHENTICATE = `Bearer resource_metadata="${RESOURCE_METADATA_URL}"`
+
+async function handleWellKnown(url: URL): Promise<Response | null> {
+  const path = url.pathname
+
+  // RFC 9728 — Protected Resource Metadata
+  if (path.endsWith("/.well-known/oauth-protected-resource")) {
+    return json({
+      resource: MCP_URL,
+      authorization_servers: [AUTH_ISSUER],
+      scopes_supported: [],
+      bearer_methods_supported: ["header"],
+    })
+  }
+
+  // RFC 8414 fallback — proxy Supabase's OAuth AS metadata so clients
+  // that don't follow redirects (or probe the MCP URL directly) get a 200.
+  if (path.endsWith("/.well-known/oauth-authorization-server")) {
+    try {
+      const upstream = await fetch(
+        `${SUPABASE_URL}/.well-known/oauth-authorization-server/auth/v1`,
+      )
+      const metadata = await upstream.json()
+      return json(metadata)
+    } catch (_) {
+      return json({ error: "Failed to fetch authorization server metadata" }, 502)
+    }
+  }
+
+  return null
 }
 
 Deno.serve(async (req) => {
@@ -92,12 +121,27 @@ Deno.serve(async (req) => {
   if (req.method === "DELETE")
     return new Response(null, { status: 200, headers: corsHeaders })
 
+  if (req.method === "GET") {
+    const wellKnown = await handleWellKnown(new URL(req.url))
+    if (wellKnown) return wellKnown
+    return json(fail(null, -32600, "Only POST is supported"), 405)
+  }
+
   if (req.method !== "POST")
     return json(fail(null, -32600, "Only POST is supported"), 405)
 
+  const authHeader = req.headers.get("Authorization") ?? ""
+
+  if (!authHeader.startsWith("Bearer ")) {
+    return json(
+      fail(null, -32000, "Authentication required"),
+      401,
+      { "WWW-Authenticate": WWW_AUTHENTICATE },
+    )
+  }
+
   try {
     const body = await req.json()
-    const authHeader = req.headers.get("Authorization") ?? ""
 
     if (Array.isArray(body)) {
       const results = await Promise.all(

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -106,6 +106,7 @@ async function handleWellKnown(url: URL): Promise<Response | null> {
       )
       const metadata = await upstream.json()
       return json(metadata)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (_err) {
       return json({ error: "Failed to fetch authorization server metadata" }, 502)
     }


### PR DESCRIPTION
## Summary

- **OAuth 2.1 discovery for MCP clients**: Added RFC 9728 Protected Resource Metadata and RFC 8414 Authorization Server Metadata handlers to the MCP Edge Function, enabling Le Chat (Mistral) and Claude Desktop to auto-discover the Supabase OAuth server and authenticate via OAuth 2.1 consent flow.
- **Global auth gate**: All POST requests to the MCP server now return `401 + WWW-Authenticate` when no Bearer token is present (including `initialize`), signaling to clients that OAuth is required.
- **Connection guides**: Created per-provider setup docs for Le Chat, Claude Desktop, and Cursor (`docs/mcp-connect/`).
- **README overhaul**: Pitched MCP as a core feature, updated tech stack, linked connection guides.
- **Exercise count correction**: Updated "600+ exercises" → "360+ exercises" across README, index.html, locale files, and epic brief.
- **Manual testing guide** (T65): Step-by-step testing plan for all three MCP clients.

## Changes

| File | What |
|---|---|
| `supabase/functions/mcp/index.ts` | `GET /.well-known/oauth-protected-resource`, `GET /.well-known/oauth-authorization-server` (proxied), global 401 auth gate |
| `docs/mcp-connect/le-chat.md` | Full setup: connector + OAuth + agent creation |
| `docs/mcp-connect/claude-desktop.md` | Native connector UI + `mcp-remote` fallback |
| `docs/mcp-connect/cursor.md` | Bearer token config for Cursor |
| `docs/T65_—_Manual_Testing_Guide.md` | E2E testing checklist |
| `README.md` | MCP pitch, updated features & tech stack |
| `index.html`, `src/locales/*/auth.json`, epic brief | 600+ → 360+ exercises |

## Test plan

- [x] `curl` verified: `/.well-known/oauth-protected-resource` returns 200 JSON
- [x] `curl` verified: `/.well-known/oauth-authorization-server` returns 200 proxied metadata
- [x] `curl` verified: unauthenticated POST returns 401 + `WWW-Authenticate` header
- [x] Le Chat: full OAuth 2.1 flow tested end-to-end (discovery → consent → tools working)
- [x] Claude Desktop: native connector UI tested

Made with [Cursor](https://cursor.com)