### PR TITLE
docs(perf): tech plan + sub-tickets T66-T69 for Lighthouse epic (#104)

### DIFF
--- a/docs/T66_—_CLS_A11y_and_406_Dedup_Fixes.md
+++ b/docs/T66_—_CLS_A11y_and_406_Dedup_Fixes.md
@@ -1,0 +1,267 @@
+# T66 — CLS, A11y & 406/Dedup Fixes
+
+## Goal
+
+Eliminate layout shift on the logged-in home view (`/`), fix the non-composited animations flagged by Lighthouse, add accessible names and proper tap-target sizes to the workout-day carousel's pager dots, and stop the Supabase 406 + duplicate request pattern caused by imperative admin/program probes at login. This ticket is the P0 correctness + UX quick-win of Epic #104.
+
+## Dependencies
+
+None. Independent of T67/T68/T69.
+
+## Scope
+
+### CLS fix — `file:src/pages/WorkoutPage.tsx`
+
+Replace the page-level `<Loader2 />` spinner (around line 923, in the `daysLoading` branch) with a new `<WorkoutHomeSkeleton />` component that matches the final layout pixel-for-pixel.
+
+### CLS fix — `file:src/components/workout/WorkoutDayCarousel.tsx`
+
+- Add `min-h-[Xpx]` on the root `div.space-y-3` (the element Lighthouse flagged for the 0.82 shift). Measure `X` from a rendered `WorkoutDayCard` and bake it into a CSS custom property (`--workout-day-card-min-h`) for future tweaking.
+- Keep the existing Embla `Carousel` unchanged; the shift comes from the absence of a reserved height, not from the carousel itself.
+
+### Pager dots — `file:src/components/workout/WorkoutDayCarousel.tsx` (lines 104-116)
+
+Replace current pager dot markup:
+
+```tsx
+<button className="h-1.5 rounded-full transition-all w-1.5 (or w-4 when active)" />
+```
+
+With a composited, accessible version:
+
+```tsx
+<button
+  type="button"
+  onClick={() => api?.scrollTo(idx)}
+  aria-label={`Go to slide ${idx + 1}`}
+  aria-current={idx === activeSlide ? "true" : undefined}
+  className="flex min-h-6 min-w-6 items-center justify-center"
+>
+  <span
+    className={cn(
+      "h-1.5 w-4 rounded-full bg-muted-foreground/30 transition-transform",
+      idx === activeSlide && "bg-primary",
+    )}
+    style={{
+      transform: idx === activeSlide ? "scaleX(1)" : "scaleX(0.375)",
+      transformOrigin: "center",
+    }}
+  />
+</button>
+```
+
+This gives us: composited transform animation (no more "non-composited" Lighthouse flag), 24×24px tap target, and `aria-label` for screen readers.
+
+### Card shadow — `file:src/components/workout/WorkoutDayCard.tsx` (lines 45-52)
+
+Replace `transition-shadow` + conditional `shadow-lg`:
+
+```tsx
+<div className={cn(
+  "rounded-xl border bg-card p-5 transition-shadow",
+  isActive ? "border-primary/60 shadow-lg shadow-primary/10" : "border-border",
+)}>
+```
+
+With a pre-painted ring whose opacity animates (composited):
+
+```tsx
+<div className={cn(
+  "rounded-xl border bg-card p-5 ring-2 ring-primary/0 transition-[box-shadow,border-color] duration-200",
+  isActive ? "border-primary/60 ring-primary/30" : "border-border",
+)}>
+```
+
+Note: we still use `transition-[border-color]` because that's cheap and already animated today. The key win is removing the shadow animation.
+
+### BodyMap slot reservation — `file:src/components/workout/WorkoutDayCard.tsx` (lines 78-87)
+
+Wrap the `BodyMap` / pulse placeholder block in a container with fixed intrinsic size:
+
+```tsx
+<div className="flex min-h-[140px] items-center justify-center">
+  {exercises && exercises.length > 0 ? (
+    <BodyMap data={heatmapData} />
+  ) : exercises ? null : (
+    <div className="flex gap-3 py-6">
+      <div className="h-28 w-14 animate-pulse rounded bg-muted" />
+      <div className="h-28 w-14 animate-pulse rounded bg-muted" />
+    </div>
+  )}
+</div>
+```
+
+Measure the actual BodyMap height in the rendered app and adjust `min-h-[Xpx]` accordingly.
+
+### CycleProgressHeader — `file:src/components/workout/CycleProgressHeader.tsx` (lines 29-33)
+
+Replace `transition-all` + inline `width: ${pct}%` with `transform: scaleX(pct/100)`:
+
+```tsx
+<div className="h-1.5 overflow-hidden rounded-full bg-muted">
+  <div
+    className="h-full origin-left rounded-full bg-primary transition-transform duration-300"
+    style={{ transform: `scaleX(${pct / 100})` }}
+  />
+</div>
+```
+
+### Full skeleton — `file:src/components/workout/WorkoutHomeSkeleton.tsx` (new)
+
+Static Tailwind skeleton matching the real layout. No external dep. Rough structure:
+
+```tsx
+export function WorkoutHomeSkeleton() {
+  return (
+    <div className="flex-1 space-y-4 overflow-hidden pb-20">
+      {/* Cycle progress header */}
+      <div className="px-4 pt-4">
+        <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+        <div className="mt-2 h-1.5 w-full animate-pulse rounded-full bg-muted" />
+      </div>
+
+      {/* Carousel placeholder */}
+      <div className="space-y-3" style={{ minHeight: "var(--workout-day-card-min-h, 320px)" }}>
+        <div className="px-4">
+          <div className="h-[280px] animate-pulse rounded-xl bg-muted" />
+        </div>
+        <div className="flex items-center justify-center gap-1.5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-1.5 w-1.5 rounded-full bg-muted-foreground/30" />
+          ))}
+        </div>
+      </div>
+
+      {/* Exercise list placeholder */}
+      <div className="space-y-2 px-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-2 rounded-lg border border-border/60 bg-card px-3 py-2">
+            <div className="h-8 w-8 animate-pulse rounded bg-muted" />
+            <div className="h-4 flex-1 animate-pulse rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+### 406 + dedup — `file:src/lib/supabase.ts`
+
+**Delete** the following blocks (approximate lines — confirm during implementation):
+- `checkAdminStatus` function body (lines ~55-70)
+- `checkProgramStatus` function body (lines ~35-50)
+- The `getSession().then(...)` callback that calls both (lines ~72-80)
+- The `onAuthStateChange('SIGNED_IN', ...)` wiring that calls them (lines ~109-115)
+
+Keep:
+- Supabase client creation and export
+- Any session-state-forwarding to Jotai atoms that does NOT hit the DB
+
+### `useIsAdmin` rewrite — `file:src/hooks/useIsAdmin.ts`
+
+Rewrite as a TanStack Query hook:
+
+```typescript
+export function useIsAdmin() {
+  const { user } = useAuth()
+  return useQuery({
+    queryKey: ["is-admin", user?.id],
+    queryFn: async () => {
+      if (!user?.email) return false
+      const { data } = await supabase
+        .from("admin_users")
+        .select("email")
+        .eq("email", user.email)
+        .maybeSingle()
+      return !!data
+    },
+    enabled: !!user,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  })
+}
+```
+
+Return shape must stay compatible with existing callers (`file:src/components/admin/AdminOnly.tsx`, `file:src/router/AdminGuard.tsx`). Add a `.data` unwrap or wrapper to preserve the current boolean API.
+
+### `useActiveProgram` tweak — `file:src/hooks/useActiveProgram.ts`
+
+Swap `.single()` → `.maybeSingle()` and simplify the error branch:
+
+```typescript
+const { data, error } = await supabase
+  .from("programs")
+  .select("id, user_id, name, template_id, is_active, archived_at, created_at")
+  .eq("user_id", user!.id)
+  .eq("is_active", true)
+  .maybeSingle()
+
+if (error) throw error
+return data ?? null
+```
+
+Remove the `PGRST116` special-case branch (now unreachable).
+
+### Atom bridge — `file:src/components/AppShell.tsx`
+
+Add a small effect that mirrors query results into existing Jotai atoms:
+
+```typescript
+const isAdminQuery = useIsAdmin()
+const activeProgramQuery = useActiveProgram()
+const setIsAdmin = useSetAtom(isAdminAtom)
+const setActiveProgramId = useSetAtom(activeProgramIdAtom)
+
+useEffect(() => {
+  if (isAdminQuery.isSuccess) setIsAdmin(isAdminQuery.data)
+}, [isAdminQuery.isSuccess, isAdminQuery.data, setIsAdmin])
+
+useEffect(() => {
+  if (activeProgramQuery.isSuccess) setActiveProgramId(activeProgramQuery.data?.id ?? null)
+}, [activeProgramQuery.isSuccess, activeProgramQuery.data, setActiveProgramId])
+```
+
+Atoms stay. Full deletion deferred to follow-up.
+
+### Optional: content-visibility hints
+
+On `file:src/components/workout/ExerciseListPreview.tsx` and `file:src/components/workout/ExerciseEditRowControls.tsx` row containers, add:
+
+```tsx
+style={{ contentVisibility: "auto", containIntrinsicSize: "auto 56px" }}
+```
+
+Low risk, pure render perf improvement. Skip if it breaks any visual test.
+
+## Out of Scope
+
+- Route-level code splitting → **T67**
+- Vendor chunk splitting, bundle analyzer, third-party script deferral → **T68**
+- `useWorkoutExercises` embed / N+1 / library slim → **T69**
+- Full deletion of `isAdminAtom` and `activeProgramIdAtom` → follow-up after T66 ships
+- Deferring `react-day-picker/style.css` or i18n locales → future optimization
+- SEO `meta name="description"` addition (P2 in the issue) → can land in T69 or a follow-up
+
+## Acceptance Criteria
+
+- [ ] Lighthouse mobile (clean incognito profile) shows **CLS < 0.1** on `/` after login.
+- [ ] Lighthouse no longer flags pager dot animations as "non-composited" (transform-based).
+- [ ] Lighthouse no longer flags the `WorkoutDayCard` as having non-composited `box-shadow` animation.
+- [ ] Pager dot buttons have `aria-label="Go to slide N"` and `aria-current` on the active dot; axe audit passes on accessible name.
+- [ ] Pager dot tap target is ≥24×24px (axe tap-target passes).
+- [ ] No Supabase `406` errors in the browser console on cold load (new user, returning user, admin, non-admin all verified).
+- [ ] Network panel shows exactly **one** `admin_users?email=eq…` request on login and **one** `programs?…is_active=eq.true` request.
+- [ ] `useIsAdmin` consumers in `file:src/components/admin/AdminOnly.tsx` and `file:src/router/AdminGuard.tsx` still render correctly with no UI regression.
+- [ ] `WorkoutPage` renders the full skeleton (no raw spinner) during `daysLoading`.
+- [ ] `WorkoutDayCard` content height does not shift when `exercises` resolves (BodyMap slot reserved).
+- [ ] No TypeScript errors; `npx tsc --noEmit` passes.
+- [ ] No Vitest regressions on existing test suite.
+
+## References
+
+- Epic / issue: [#104 — Improve Lighthouse: CLS, LCP, Supabase payload & 406 errors](https://github.com/PierreTsia/workout-app/issues/104)
+- Tech Plan: `file:docs/Tech_Plan_—_Lighthouse_CLS_LCP_Supabase_#104.md`
+- Files touched: `WorkoutPage`, `WorkoutDayCarousel`, `WorkoutDayCard`, `CycleProgressHeader`, `WorkoutHomeSkeleton` (new), `supabase.ts`, `useIsAdmin`, `useActiveProgram`, `AppShell`

--- a/docs/T67_—_Route-Level_Code_Splitting.md
+++ b/docs/T67_—_Route-Level_Code_Splitting.md
@@ -1,0 +1,119 @@
+# T67 — Route-Level Code Splitting
+
+## Goal
+
+Split the monolithic JS bundle (~716 KB transferred, 65% unused) into per-route chunks so the logged-in home route (`/`) loads only what it needs. Keep the workout flow (`/`, `/login`, `/onboarding`, `/create-program`) in the main chunk; lazy-load everything else behind `React.lazy` with a shared `<Suspense>` fallback. This is the largest single LCP lever identified in Epic #104.
+
+## Dependencies
+
+- **T66** should ship first so the `AppShell` layout is stable and new `<Suspense>` boundaries don't introduce fresh CLS.
+
+## Scope
+
+### Router refactor — `file:src/router/index.tsx`
+
+Convert the following static imports to `React.lazy(() => import(...))`:
+
+**Lazy-load (non-critical-path):**
+- `HistoryPage`
+- `BuilderPage`
+- `LibraryProgramsPage`
+- `ExerciseLibraryPage`
+- `ExerciseLibraryExercisePage`
+- `AccountPage`
+- `AchievementsPage`
+- `CycleSummaryPage`
+- `AdminHomePage`
+- `AdminExercisesPage`
+- `AdminExerciseEditPage`
+- `AdminReviewPage`
+- `AdminEnrichmentPage`
+- `AdminFeedbackPage`
+- `OAuthConsentPage`
+- `PrivacyPage`
+- `AboutPage`
+
+**Keep eager (critical path or blocks auth flow):**
+- `WorkoutPage` (the `/` LCP surface)
+- `LoginPage`
+- `OnboardingPage`
+- `CreateProgramPage`
+- `AppShell`
+- `AuthGuard`, `OnboardingGuard`, `AdminGuard`
+
+### Suspense wrapping
+
+Each lazy route element needs a Suspense boundary. Two options — pick one:
+
+**Option A (recommended):** Wrap each lazy element inline:
+
+```tsx
+{
+  path: "history",
+  element: (
+    <Suspense fallback={<RouteSkeleton />}>
+      <HistoryPage />
+    </Suspense>
+  ),
+}
+```
+
+**Option B:** Single Suspense boundary inside `AppShell` between the outlet and the nav bar:
+
+```tsx
+<main className="mx-auto flex w-full max-w-5xl flex-1 flex-col">
+  <Suspense fallback={<RouteSkeleton />}>
+    <Outlet />
+  </Suspense>
+</main>
+```
+
+Option B is one line of code but means any lazy route triggers the same fallback. Option A is more code but allows per-route skeletons later (e.g. specialized history skeleton). **Use Option B unless a specific route needs a custom skeleton.**
+
+### New `RouteSkeleton` — `file:src/components/RouteSkeleton.tsx`
+
+Minimal component:
+
+```tsx
+export function RouteSkeleton() {
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+```
+
+If a specific lazy route suffers from visible flash (history with its charts, for instance), upgrade to a tailored skeleton in a follow-up.
+
+### Verify no critical-path regression
+
+- `npm run build` produces separate chunks for admin, history, library, builder.
+- Initial chunk for `/` does NOT contain: `recharts`, `@tanstack/react-table`, admin page components, `cmdk` (if still bundled, deferred to T68 via `manualChunks`).
+- `/` Lighthouse LCP improves by at least 1s on mobile simulated 3G.
+
+## Out of Scope
+
+- Manual vendor chunk splitting (`build.rollupOptions.output.manualChunks`) → **T68**
+- Bundle analyzer script → **T68**
+- Deferring Sentry / PostHog / SW initialization → **T68**
+- Prefetch on nav hover (optional future polish)
+- Converting `/login` or `/onboarding` to lazy (keep critical auth path eager)
+
+## Acceptance Criteria
+
+- [ ] `file:src/router/index.tsx` imports the listed routes via `React.lazy(() => import(...))`.
+- [ ] `/` loads without any admin/history/library/builder code in the initial chunk (verified via `npm run build` output or manual inspection of `dist/assets/*.js`).
+- [ ] First admin nav click successfully loads the admin chunk and renders correctly.
+- [ ] First `/history` nav click successfully loads the recharts-containing chunk.
+- [ ] `<Suspense>` fallback (`RouteSkeleton`) renders briefly between lazy route transitions on slow network.
+- [ ] Initial JS transfer on `/` mobile Lighthouse is **< 400 KB** (down from 716 KB baseline).
+- [ ] No TypeScript errors; `npx tsc --noEmit` passes.
+- [ ] No Playwright E2E regressions (login, workout session, builder flows).
+- [ ] Route transitions still work for guarded routes (`AdminGuard`, `OnboardingGuard`).
+
+## References
+
+- Epic / issue: [#104](https://github.com/PierreTsia/workout-app/issues/104)
+- Tech Plan: `file:docs/Tech_Plan_—_Lighthouse_CLS_LCP_Supabase_#104.md`
+- React Router v7 lazy docs: https://reactrouter.com/en/main/route/lazy

--- a/docs/T68_—_Vendor_Chunks_Analyzer_and_Third-party_Deferral.md
+++ b/docs/T68_—_Vendor_Chunks_Analyzer_and_Third-party_Deferral.md
@@ -1,0 +1,170 @@
+# T68 — Vendor Chunks, Analyzer & Third-party Deferral
+
+## Goal
+
+Configure Vite's `manualChunks` so that heavy vendor dependencies (Recharts, cmdk + vaul, @tanstack/react-table, Radix primitives, Supabase client) land in their own chunks — preventing duplication across the lazy route chunks introduced in T67 and keeping the cold cache shareable. Add a bundle analyzer script for before/after evidence. Defer Sentry, PostHog-invisible work, and PWA `registerSW` until after first render via `requestIdleCallback`. Together these changes target a sub-150ms TBT and sub-2.5s LCP on `/` mobile.
+
+## Dependencies
+
+- **T67** (Route-Level Code Splitting) must be merged so the `manualChunks` config groups vendors against real lazy boundaries.
+
+## Scope
+
+### Vite config — `file:vite.config.ts`
+
+Add a `manualChunks` function inside `build.rollupOptions.output`:
+
+```typescript
+build: {
+  sourcemap: true,
+  rollupOptions: {
+    output: {
+      manualChunks(id) {
+        if (id.includes("node_modules")) {
+          if (id.includes("recharts") || id.includes("d3-")) return "chart-vendor"
+          if (id.includes("cmdk") || id.includes("vaul")) return "picker-vendor"
+          if (id.includes("@tanstack/react-table") || id.includes("@tanstack/table-core")) return "table-vendor"
+          if (id.includes("@radix-ui")) return "radix-vendor"
+          if (id.includes("@supabase")) return "supabase-vendor"
+          if (id.includes("@sentry")) return "sentry-vendor"
+          if (id.includes("posthog")) return "posthog-vendor"
+          if (id.includes("embla-carousel")) return "embla-vendor"
+          if (id.includes("@dnd-kit")) return "dnd-vendor"
+          if (id.includes("react-day-picker") || id.includes("date-fns")) return "calendar-vendor"
+        }
+      },
+    },
+  },
+},
+```
+
+Notes:
+- `d3-*` is pulled in by recharts transitively; grouping keeps them together.
+- `@radix-ui` is large and shared by most routes → one vendor chunk cached across lazy routes.
+- `date-fns` goes with calendar because `react-day-picker` depends on it; if another module needs heavy `date-fns` usage, revisit.
+
+### Analyzer — `file:vite.config.ts` + `file:package.json`
+
+Conditionally load `rollup-plugin-visualizer`:
+
+```typescript
+import { visualizer } from "rollup-plugin-visualizer"
+
+// inside defineConfig:
+plugins: [
+  react(),
+  VitePWA({ ... }),
+  sentryAuthTokenPlugin,
+  process.env.ANALYZE === "true" && visualizer({
+    filename: "dist/stats.html",
+    gzipSize: true,
+    brotliSize: true,
+    open: true,
+  }),
+].filter(Boolean),
+```
+
+Add to `package.json`:
+
+```json
+{
+  "scripts": {
+    "build:analyze": "ANALYZE=true vite build"
+  },
+  "devDependencies": {
+    "rollup-plugin-visualizer": "^5.12.0"
+  }
+}
+```
+
+Run `npm install rollup-plugin-visualizer --save-dev` and use the latest version.
+
+### Sentry + SW deferral — `file:src/main.tsx`
+
+Current order (approximate, from exploration):
+
+```tsx
+initSentry()                  // sync, pre-render
+listenForSwUpdate()           // sync, pre-render
+await handleVersionUpgrade()  // async, gates render
+createRoot(el).render(<App />)
+```
+
+Target:
+
+```tsx
+await handleVersionUpgrade()
+createRoot(el).render(<App />)
+
+const idle = (cb: () => void) =>
+  "requestIdleCallback" in window
+    ? (window as any).requestIdleCallback(cb, { timeout: 2000 })
+    : setTimeout(cb, 500)
+
+idle(() => {
+  initSentry()
+  listenForSwUpdate()
+})
+```
+
+Move `import { initSentry }` and `import { listenForSwUpdate }` out of the module top if the functions rely on side effects at import time. Verify with a cold-load test: error thrown in the first 2 seconds should still reach Sentry once it initializes (Sentry will miss the very earliest errors — this is an acceptable trade-off documented in the plan).
+
+### PWA `registerSW` — `file:src/lib/swReloadOnUpdate.ts`
+
+Change:
+
+```typescript
+registerSW({
+  immediate: true,
+  onRegisteredSW(...) { ... },
+  onRegisterError(...) { ... },
+})
+```
+
+To:
+
+```typescript
+registerSW({
+  immediate: false,
+  onRegisteredSW(...) { ... },
+  onRegisterError(...) { ... },
+})
+```
+
+This means new SW versions install on next navigation instead of immediately. `handleVersionUpgrade` in `main.tsx` still forces a reload on version mismatch — unchanged behavior for users.
+
+### Optional: guard against future regressions
+
+Add a simple eslint rule or CI check that warns if `WorkoutPage` imports `@/components/ui/chart` (which would pull recharts into the main chunk via the transitive graph). Implementation detail: can be a custom eslint rule, a CODEOWNERS note, or an explicit PR-template checklist item. **Include as documentation only** unless it's a quick win during implementation.
+
+## Out of Scope
+
+- Route-level `React.lazy` boundaries → **T67** (prerequisite)
+- Supabase query optimizations → **T69**
+- Deferring i18n locale loading
+- Deferring `react-day-picker/style.css` import from `main.tsx`
+- PostHog session replay config changes (not currently enabled)
+- Replacing `recharts` with a lighter chart library
+
+## Acceptance Criteria
+
+- [ ] `npm run build:analyze` produces `dist/stats.html` and opens it.
+- [ ] Main chunk for `/` (excluding vendors) is < 100 KB gzipped.
+- [ ] Vendor chunks are named `chart-vendor`, `picker-vendor`, `table-vendor`, `radix-vendor`, `supabase-vendor`, `sentry-vendor`, `posthog-vendor`, `embla-vendor`, `calendar-vendor` (check with `ls dist/assets/`).
+- [ ] `/` initial load does NOT fetch `chart-vendor`, `table-vendor`, or `calendar-vendor`.
+- [ ] Lighthouse mobile shows **TBT < 150ms** on `/` (clean incognito profile).
+- [ ] Lighthouse mobile shows **LCP < 2.5s** on `/`.
+- [ ] Sentry `initSentry()` is called after first render (verified via `console.time` or source inspection).
+- [ ] `listenForSwUpdate()` is called after first render.
+- [ ] Service worker still registers and activates correctly on install and update (verified via DevTools → Application → Service Workers).
+- [ ] `handleVersionUpgrade` behavior unchanged (forced reload on version mismatch still works).
+- [ ] `npx tsc --noEmit` passes.
+- [ ] `npm run build` completes without the `Unexpected early exit` error (note: this ticket adds to build complexity; run with `required_permissions: ["all"]` per workspace rule).
+
+## References
+
+- Epic / issue: [#104](https://github.com/PierreTsia/workout-app/issues/104)
+- Tech Plan: `file:docs/Tech_Plan_—_Lighthouse_CLS_LCP_Supabase_#104.md`
+- T67 (prerequisite): `file:docs/T67_—_Route-Level_Code_Splitting.md`
+- Vite `manualChunks` docs: https://vitejs.dev/guide/build.html#chunking-strategy
+- `rollup-plugin-visualizer`: https://github.com/btd/rollup-plugin-visualizer

--- a/docs/T69_—_Supabase_N+1_and_Library_Slim.md
+++ b/docs/T69_—_Supabase_N+1_and_Library_Slim.md
@@ -1,0 +1,192 @@
+# T69 — Supabase N+1 Elimination & Library Slim
+
+## Goal
+
+Eliminate the `exercises?id=eq…` request storm triggered when a workout day loads (currently 5-15 parallel per-id calls via `useExerciseFromLibrary`) by embedding the full exercise row inside the `workout_exercises` query. Slim the catalog-level `useExerciseLibrary` fetch from `select('*')` (~161 KB) to enumerated columns (~60 KB) by deferring rich fields (`instructions` JSONB, `youtube_url`, etc.) to `useExerciseById`. Replace the per-id loop in `useGenerateProgram` with a single batched `.in()` call. This ticket is the last major Supabase/network optimization of Epic #104.
+
+## Dependencies
+
+None strictly. Can ship in parallel with T67/T68.
+
+## Scope
+
+### `useWorkoutExercises` embed — `file:src/hooks/useWorkoutExercises.ts`
+
+Current:
+
+```typescript
+const { data, error } = await supabase
+  .from("workout_exercises")
+  .select("*")
+  .eq("workout_day_id", dayId!)
+```
+
+Target:
+
+```typescript
+const { data, error } = await supabase
+  .from("workout_exercises")
+  .select(`
+    *,
+    exercise:exercises(
+      id, name, name_en, emoji, muscle_group, equipment,
+      image_url, instructions, secondary_muscles, difficulty_level
+    )
+  `)
+  .eq("workout_day_id", dayId!)
+```
+
+After fetching, seed the per-id cache so downstream `useExerciseById` calls hit memory:
+
+```typescript
+if (data) {
+  const uniqueExercises = new Map<string, Exercise>()
+  data.forEach((row) => {
+    if (row.exercise) uniqueExercises.set(row.exercise.id, row.exercise)
+  })
+  uniqueExercises.forEach((exercise, id) => {
+    queryClient.setQueryData(["exercise", id], exercise)
+  })
+}
+```
+
+Use the functional pattern from workspace rule — no mutable for-loops:
+
+```typescript
+const uniqueExercises = (data ?? [])
+  .map((row) => row.exercise)
+  .filter((ex): ex is Exercise => !!ex)
+  .reduce((map, ex) => map.set(ex.id, ex), new Map<string, Exercise>())
+
+uniqueExercises.forEach((ex, id) => queryClient.setQueryData(["exercise", id], ex))
+```
+
+Update the TypeScript return type to reflect the embed (e.g. `WorkoutExerciseWithExercise`).
+
+### `useExerciseLibrary` slim — `file:src/hooks/useExerciseLibrary.ts`
+
+Current:
+
+```typescript
+.from("exercises")
+.select("*")
+.order("muscle_group")
+.order("name")
+```
+
+Target:
+
+```typescript
+.from("exercises")
+.select("id, name, name_en, emoji, muscle_group, equipment, image_url, difficulty_level, is_system")
+.order("muscle_group")
+.order("name")
+```
+
+Change the return type:
+
+```typescript
+// file:src/types/exercise.ts (or wherever Exercise lives)
+export type ExerciseListItem = Pick<
+  Exercise,
+  "id" | "name" | "name_en" | "emoji" | "muscle_group" | "equipment" | "image_url" | "difficulty_level" | "is_system"
+>
+```
+
+`useExerciseLibrary` now returns `ExerciseListItem[]`. TypeScript will flag every caller that expects rich fields (`instructions`, `youtube_url`, `secondary_muscles`, `source`, `reviewed_*`) — those must switch to `useExerciseById(id)`.
+
+### `useExerciseFromLibrary` audit — `file:src/hooks/useExerciseFromLibrary.ts`
+
+Identify callers that now have the embedded exercise from `useWorkoutExercises`:
+
+- `file:src/components/workout/SetsTable.tsx`
+- `file:src/components/workout/ExerciseDetail.tsx`
+- `file:src/components/workout/SessionSummary.tsx`
+
+These should prefer the embedded `row.exercise` (passed as prop) rather than re-fetching via `useExerciseFromLibrary(exercise_id)`. **Minimum viable change:** rely on the per-id cache seeded by `useWorkoutExercises` (T69) — the hook still works but hits memory instead of network. Ideal future change: pass `exercise` via prop and drop the hook. Stay minimal here unless the change is trivial.
+
+**Keep `useExerciseFromLibrary` intact** for pages where per-id is legitimately needed:
+- `file:src/components/builder/ExerciseRow.tsx`
+- `file:src/components/builder/ExerciseDetailEditor.tsx`
+- `file:src/components/exercise/ExerciseInstructionsPanel.tsx`
+- `file:src/pages/library/ExerciseLibraryExercisePage.tsx`
+
+### `AIGeneratingStep` dedicated query — `file:src/components/create-program/AIGeneratingStep.tsx`
+
+If the generation prompt needs rich fields (confirm during implementation), DO NOT re-widen `useExerciseLibrary`. Instead add a dedicated query scoped to that step:
+
+```typescript
+function useExercisePoolForGeneration() {
+  return useQuery({
+    queryKey: ["exercise-pool-for-gen"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("exercises")
+        .select("id, name, muscle_group, equipment, instructions, secondary_muscles, difficulty_level")
+        .order("muscle_group")
+      if (error) throw error
+      return data
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}
+```
+
+If the step currently uses `useExerciseLibrary`, migrate to the new hook. If it only needs the narrow shape, no change needed.
+
+### `useGenerateProgram` batching — `file:src/hooks/useGenerateProgram.ts` (around line 89)
+
+Current (per-id fetches in a loop):
+
+```typescript
+const { data } = await supabase
+  .from("exercises")
+  .select("*")
+  .eq("id", resolvedId)
+  .single()
+```
+
+Target (single batch via existing helper):
+
+```typescript
+import { fetchExercisesByIds } from "@/lib/fetchExercisesByIds"
+
+// collect all resolvedIds upfront
+const resolvedIds = [...]  // build from the swap plan
+const batch = await fetchExercisesByIds(resolvedIds)
+const byId = new Map(batch.map((ex) => [ex.id, ex]))
+
+// then use byId.get(resolvedId) inside the mapping
+```
+
+Use the existing `fetchExercisesByIds` helper (chunked `.in('id', chunk)` with chunk size 100) from `file:src/lib/fetchExercisesByIds.ts`.
+
+## Out of Scope
+
+- Converting `workout_exercises` snapshot fields (`name_snapshot`, `emoji_snapshot`) into foreign-key-enforced data → existing architecture decision, unchanged
+- `useExerciseFromLibrary` deletion / hook consolidation → follow-up after confirming all callers are migrated
+- RPC-based pagination for `useExerciseLibrary` → rejected in plan (user said no regression, RPC changes the contract)
+- Deferring `useExerciseLibrary` until swap UI opens → rejected in plan (eager fetch + slim is cleaner)
+- Supabase 406 / duplicate fetches → **T66**
+- Route splitting / vendor chunks → **T67 / T68**
+
+## Acceptance Criteria
+
+- [ ] `useWorkoutExercises` returns `workout_exercises` rows each with an embedded `exercise` object.
+- [ ] Network panel on `/` load shows **at most one** `workout_exercises?…workout_day_id=eq…` request per visible day, AND **zero** follow-up `exercises?id=eq…` requests for those exercises.
+- [ ] `useExerciseLibrary` fires a single request with `select=id,name,name_en,emoji,muscle_group,equipment,image_url,difficulty_level,is_system` (verified via network panel).
+- [ ] Catalog fetch payload on `/` is reduced from ~161 KB to ~60 KB or less.
+- [ ] `useGenerateProgram` swap path uses a single batched `.in('id', ...)` call (verified via network panel during AI program generation).
+- [ ] No TypeScript errors after tightening `useExerciseLibrary`'s return type to `ExerciseListItem[]`.
+- [ ] All callers that needed rich fields (instructions, etc.) have been migrated to `useExerciseById` or a dedicated query — verified by running the app and visiting: session view → exercise detail, builder → exercise edit, library → exercise detail.
+- [ ] `ExerciseInstructionsPanel` still renders full instructions correctly.
+- [ ] AI program generation flow still produces the same prompt quality (manual spot check with a known input).
+- [ ] No Playwright E2E regressions.
+- [ ] `npx tsc --noEmit` passes.
+
+## References
+
+- Epic / issue: [#104](https://github.com/PierreTsia/workout-app/issues/104)
+- Tech Plan: `file:docs/Tech_Plan_—_Lighthouse_CLS_LCP_Supabase_#104.md`
+- Existing batch helper: `file:src/lib/fetchExercisesByIds.ts`
+- PostgREST embed docs: https://postgrest.org/en/stable/references/api/resource_embedding.html

--- a/docs/Tech_Plan_—_Lighthouse_CLS_LCP_Supabase_#104.md
+++ b/docs/Tech_Plan_—_Lighthouse_CLS_LCP_Supabase_#104.md
@@ -1,0 +1,257 @@
+# Tech Plan — Lighthouse: CLS, LCP, Supabase payload & 406 errors (#104)
+
+## Architectural Approach
+
+Systematically attack four independent bottlenecks revealed by Lighthouse (mobile, simulated 3G) on production (`workout-app-ypsilon.vercel.app`): **layout stability**, **first-load JS**, **Supabase network chatter**, and **auth-bootstrap correctness**. Four sequential sub-tickets, each one PR, each independently shippable and verifiable via a Lighthouse re-run.
+
+Baseline (from the issue): FCP ~3.5s, LCP ~5.4s, **CLS 0.84**, TBT ~160ms, Performance score ~0.46.
+Targets: **CLS < 0.1**, **LCP < 2.5s**, no console errors (including Supabase 406s), reduced first-load JS, reduced Supabase round-trips.
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Rollout structure | 4 sub-tickets (T66–T69), one PR each, priority order | Shipping the full scope as one PR is unreviewable; each ticket targets a different metric so verification is clean. |
+| Ordering | T66 CLS → T67 splitting → T68 vendor chunks + deferral → T69 Supabase N+1 | CLS first because it's the smallest, safest, most visible improvement. Route splitting next — it's the largest LCP lever. Vendor chunking after because it depends on lazy boundaries existing. |
+| CLS fix strategy | Full layout skeleton matching carousel + exercise list + cycle progress header; measured `min-h-*` on carousel root and card's BodyMap slot | Spinner-to-layout swap in `file:src/pages/WorkoutPage.tsx` is the primary shift source. Matching skeleton + reserved heights eliminates ~0.82 of the 0.84 CLS. |
+| Pager dots animation | Replace width animation with `transform: scaleX` indicator inside `min-w-6 min-h-6` tap target + `aria-label` | Non-composited → GPU-composited. Fixes a11y (tap target + accessible name) in one change. |
+| Card shadow animation | Replace `transition-shadow` on `box-shadow` with pre-painted `ring-2` + opacity transition | `box-shadow` is non-composited; `opacity` is. Zero visual regression. |
+| 406 / duplicate auth fix | Delete imperative `checkAdminStatus` + `checkProgramStatus` from `file:src/lib/supabase.ts`; use TanStack Query hooks (`useIsAdmin`, existing `useActiveProgram`) | React Query dedupes, retries, and respects `gcTime`. Eliminates the `getSession + SIGNED_IN` double-fire. `.maybeSingle()` removes 406s for zero-row cases. |
+| Atom migration approach | Bridge hooks → existing atoms (`isAdminAtom`, `activeProgramIdAtom`) via a small `AppShell` effect. Delete atoms in a follow-up pass | Minimum diff for T66; full atom deletion touches too many readers and belongs to its own refactor. |
+| Route-level code splitting | `React.lazy` for `/admin/*`, `/history`, `/library/*`, `/builder/*`, `/cycle-summary`, `/achievements`, `/account`, `/about`, `/privacy`, `/oauth/consent`. Keep eager: `/`, `/login`, `/onboarding`, `/create-program` + `AppShell` + guards | Preserves fast first paint on the logged-in home. Admin pays chunk cost on first nav (acceptable — single admin user). |
+| Vendor chunk splitting | Manual `rollupOptions.output.manualChunks` grouping: `recharts` → chart-vendor; `cmdk + vaul` → picker-vendor; `@tanstack/react-table` → table-vendor; `@radix-ui/*` → radix-vendor; `@supabase/*` → supabase-vendor | Prevents lazy chunks from duplicating vendor code; keeps cold cache shareable across routes. |
+| Bundle analyzer | Add `rollup-plugin-visualizer` gated behind `ANALYZE=true` env + `build:analyze` script | Zero cost in normal builds (plugin only loaded under the flag). Gives reviewers concrete before/after evidence. |
+| Third-party deferral | Move `initSentry()` and `listenForSwUpdate()` into `requestIdleCallback` (with `setTimeout(2000)` fallback for Safari) after `createRoot().render()` | Sentry + SW register currently block module-top pre-render. Moving to idle reclaims ~100–200ms TBT. |
+| Supabase N+1 | Add `exercise:exercises(...)` embed to `useWorkoutExercises`; seed per-id cache via `queryClient.setQueryData`; keep snapshot fields as fallback | One round-trip per day, RLS-safe (exercises is user-readable). Eliminates parallel `id=eq…` storm. |
+| `useExerciseLibrary` payload | Slim `select('*')` to enumerated columns (no `instructions`, `youtube_url`, `secondary_muscles`, `source`, `reviewed_*`). Rich fields land via `useExerciseById` on detail open | Cuts the 161 KB catalog fetch by ~60% with zero regression — callers needing rich fields already use `useExerciseById`. |
+| PWA `registerSW` | Change `immediate: true` → `immediate: false`; call inside `requestIdleCallback` | SW no longer blocks critical path; existing users keep offline shell from prior cache. `handleVersionUpgrade` keeps forced reload on version mismatch. |
+
+### Critical Constraints
+
+**`file:src/pages/WorkoutPage.tsx` is the LCP-defining surface and lives on the eager `/` route.** Nothing in T67's route-splitting work can introduce a `Suspense` boundary between `AppShell` and `WorkoutPage`, or first paint regresses. Splitting targets only non-root routes.
+
+**The `exercises` table is user-readable** (confirmed via current `useExerciseLibrary` and per-id hooks). Adding `exercise:exercises(*)` embed on `workout_exercises` relies on existing RLS — do not introduce new policies without verification. Fallback: `workout_exercises` rows already carry `name_snapshot` and `emoji_snapshot`.
+
+**`file:src/lib/supabase.ts` lines 38-43 and 59-64** imperatively populate `isAdminAtom` and `activeProgramIdAtom`. Deleting them means every atom reader must either (a) read from the new TanStack hooks directly or (b) keep atoms but hydrate from React Query via an `AppShell` effect. The plan picks (b) for T66 to minimize diff. Known readers: `file:src/components/admin/AdminOnly.tsx`, `file:src/router/AdminGuard.tsx`, `file:src/hooks/useIsAdmin.ts` (becomes the source of truth), `file:src/pages/WorkoutPage.tsx` (reads `activeProgramIdAtom`).
+
+**`WorkoutDayCarousel` content height is not stable today** because each `WorkoutDayCard` fetches its own exercises via `useWorkoutExercises(day.id)` and renders `BodyMap` only after data arrives (`file:src/components/workout/WorkoutDayCard.tsx` lines 78–87). A skeleton on the page-level spinner alone won't fix CLS — the carousel root AND each card's BodyMap slot must both reserve vertical space.
+
+**`file:src/main.tsx` globally imports `react-day-picker/style.css`.** Eligible for scoping to `calendar.tsx`, but non-trivial in Vite. Out of scope for this plan; noted as future optimization.
+
+**`file:src/lib/i18n.ts` bundles all locales at entry.** Deferred optimization; would require react-i18next lazy namespaces. Out of scope.
+
+**Lazy admin routes** change admin UX: first admin nav pays chunk fetch. User is the only admin → acceptable. No prefetch recommended.
+
+---
+
+## Data Model
+
+No schema changes. Query-shape changes only.
+
+### Query shape changes
+
+**Before** — `file:src/hooks/useWorkoutExercises.ts`:
+
+```sql
+SELECT * FROM workout_exercises WHERE workout_day_id = :dayId
+```
+
+Followed by N parallel `SELECT * FROM exercises WHERE id = :id` via `useExerciseFromLibrary` in each row component.
+
+**After**:
+
+```sql
+SELECT *, exercise:exercises(id, name, name_en, emoji, muscle_group, equipment, image_url, instructions, secondary_muscles, difficulty_level)
+FROM workout_exercises
+WHERE workout_day_id = :dayId
+```
+
+One round-trip, embedded join. `instructions` JSONB is kept on this embed because the in-session Instructions panel needs it.
+
+**Before** — `file:src/hooks/useExerciseLibrary.ts`:
+
+```sql
+SELECT * FROM exercises ORDER BY muscle_group, name  -- ~161 KB wire
+```
+
+**After**:
+
+```sql
+SELECT id, name, name_en, emoji, muscle_group, equipment, image_url, difficulty_level, is_system
+FROM exercises
+ORDER BY muscle_group, name  -- ~60 KB wire
+```
+
+Rich fields land via `useExerciseById` on detail open (already existing pattern).
+
+### Type model addition
+
+```typescript
+// src/types/exercise.ts (new or existing — confirm)
+export type ExerciseListItem = Pick<
+  Exercise,
+  "id" | "name" | "name_en" | "emoji" | "muscle_group" | "equipment" | "image_url" | "difficulty_level" | "is_system"
+>
+```
+
+`useExerciseLibrary` returns `ExerciseListItem[]`. Callers needing the rich shape must switch to `useExerciseById`. TypeScript enforces migration.
+
+### Jotai / LocalStorage
+
+No structural changes. `isAdminAtom` and `activeProgramIdAtom` continue to exist but are hydrated by React Query in an `AppShell` effect rather than imperative calls in `file:src/lib/supabase.ts`. Atom deletion deferred to a follow-up.
+
+---
+
+## Component Architecture
+
+### Ticket graph
+
+```mermaid
+graph TD
+    T66[T66 — CLS + A11y + 406/Dedup<br/>P0, ~1 day]
+    T67[T67 — Route code splitting<br/>P1, ~0.5 day]
+    T68[T68 — Vendor chunks + analyzer<br/>+ third-party deferral<br/>P1, ~1 day]
+    T69[T69 — Supabase N+1 + library slim<br/>P1, ~0.5 day]
+
+    T66 --> T67
+    T67 --> T68
+    T66 --> T69
+
+    T66 -.Lighthouse re-run.-> V1[CLS < 0.1]
+    T67 -.Lighthouse re-run.-> V2[Initial JS < 400 KB]
+    T68 -.Lighthouse re-run.-> V3[TBT < 150ms, LCP < 2.5s]
+    T69 -.Network panel.-> V4[1 exercises query per day]
+```
+
+T66 and T69 are independent; T67 unblocks T68's `manualChunks` config (which assumes lazy routes). T69 can ship parallel to T67/T68 since it only touches hooks.
+
+### Layer Overview (post-refactor)
+
+```mermaid
+graph TD
+    main[main.tsx<br/>i18n + CSS + render]
+    main --> router[router/index.tsx]
+
+    router -->|eager| appshell[AppShell]
+    router -.lazy chunks.-> history[history-chunk]
+    router -.lazy chunks.-> admin[admin-chunk]
+    router -.lazy chunks.-> library[library-chunk]
+    router -.lazy chunks.-> builder[builder-chunk]
+
+    main -.idleCallback.-> sentry[Sentry init]
+    main -.idleCallback.-> sw[registerSW]
+
+    appshell --> bridge[Atom bridge effect<br/>useIsAdmin → isAdminAtom<br/>useActiveProgram → activeProgramIdAtom]
+    appshell --> workoutpage[WorkoutPage /]
+
+    workoutpage --> skeleton[WorkoutHomeSkeleton<br/>while daysLoading]
+    workoutpage --> carousel[WorkoutDayCarousel<br/>min-h reserved]
+    workoutpage --> useWorkoutExercises[useWorkoutExercises<br/>with embed]
+
+    admin -.split.-> rechartsvendor[chart-vendor]
+    admin -.split.-> tablevendor[table-vendor]
+    builder -.split.-> pickervendor[picker-vendor]
+    library -.split.-> pickervendor
+
+    useWorkoutExercises -.setQueryData.-> exercisecache[exercise cache per id]
+```
+
+### New Files & Responsibilities
+
+| File | Purpose | Ticket |
+|---|---|---|
+| `file:src/components/workout/WorkoutHomeSkeleton.tsx` | Full-page skeleton matching `/` layout: cycle progress bar, carousel placeholders, exercise list rows. Replaces the page-level `Loader2` spinner. | T66 |
+| `file:src/components/RouteSkeleton.tsx` | Generic between-route suspense fallback. Minimal loader within `AppShell`'s `<main>`. | T67 |
+| `file:src/hooks/useIsAdmin.ts` (rewrite) | TanStack Query hook: `['is-admin', userId]`, `.maybeSingle()`, `staleTime: Infinity`, `refetchOnWindowFocus: false`. | T66 |
+| `file:src/types/exercise.ts` (extend) | Add `ExerciseListItem` narrow type. | T69 |
+
+### Modified Files
+
+**T66 — CLS + A11y + 406/Dedup**
+
+| File | Change |
+|---|---|
+| `file:src/components/workout/WorkoutDayCarousel.tsx` | Add `min-h-[Xpx]` on root `div.space-y-3` (measured from rendered card). Replace pager dots: `<button>` with `min-w-6 min-h-6` wrapper + inner `transform: scaleX` indicator. Add `aria-label="Go to slide {N}"`. |
+| `file:src/components/workout/WorkoutDayCard.tsx` | Replace `transition-shadow` + `shadow-lg` active with `ring-2 ring-primary/0` → `ring-primary/60` (opacity transition). Reserve BodyMap slot via fixed `min-h-*` or `aspect-ratio`. |
+| `file:src/components/workout/CycleProgressHeader.tsx` | Convert `transition-all` on width to `transform: scaleX` with `transform-origin: left`. |
+| `file:src/pages/WorkoutPage.tsx` (~line 923) | Replace spinner with `<WorkoutHomeSkeleton />`. Keep existing `daysLoading` gate. |
+| `file:src/lib/supabase.ts` (lines 30–80 region) | **Delete** imperative `checkAdminStatus` + `checkProgramStatus` + the `getSession`/`onAuthStateChange` wiring that calls them. Keep auth subscription that updates Supabase's own state. |
+| `file:src/hooks/useIsAdmin.ts` | Rewrite as TanStack Query hook (see above). |
+| `file:src/hooks/useActiveProgram.ts` | Swap `.single()` → `.maybeSingle()`; remove PGRST116 branch since `maybeSingle` returns `null`. |
+| `file:src/components/AppShell.tsx` | Add effect: `useEffect(() => { setIsAdmin(isAdminQuery.data ?? false); setActiveProgramId(activeProgramQuery.data?.id ?? null) }, [...])`. |
+| `file:src/components/workout/ExerciseListPreview.tsx`, `ExerciseEditRowControls.tsx` | Optional: add `content-visibility: auto` with intrinsic size hints (bonus, low risk). |
+
+**T67 — Route Code Splitting**
+
+| File | Change |
+|---|---|
+| `file:src/router/index.tsx` | Convert static imports → `React.lazy(() => import(...))` for: `HistoryPage`, `BuilderPage`, `LibraryProgramsPage`, `ExerciseLibraryPage`, `ExerciseLibraryExercisePage`, `AccountPage`, `AchievementsPage`, `CycleSummaryPage`, `AdminHomePage`, `AdminExercisesPage`, `AdminExerciseEditPage`, `AdminReviewPage`, `AdminEnrichmentPage`, `AdminFeedbackPage`, `OAuthConsentPage`, `PrivacyPage`, `AboutPage`. Keep eager: `WorkoutPage`, `LoginPage`, `OnboardingPage`, `CreateProgramPage`, `AppShell`, all guards. Wrap lazy routes with `<Suspense fallback={<RouteSkeleton />}>`. |
+| `file:src/components/RouteSkeleton.tsx` (new) | Minimal loader state. |
+
+**T68 — Vendor Chunks + Analyzer + Third-party Deferral**
+
+| File | Change |
+|---|---|
+| `file:vite.config.ts` | Add `build.rollupOptions.output.manualChunks` function grouping recharts, cmdk+vaul, react-table, radix, supabase. Conditionally load `rollup-plugin-visualizer` when `process.env.ANALYZE === 'true'`. |
+| `file:package.json` | Add `"build:analyze": "ANALYZE=true vite build"`. Add `rollup-plugin-visualizer` to `devDependencies`. |
+| `file:src/main.tsx` | Move `initSentry()` and `listenForSwUpdate()` out of module-top. Call them from a `requestIdleCallback` after `createRoot().render()` (with `setTimeout(2000)` fallback). |
+| `file:src/lib/swReloadOnUpdate.ts` | Change `registerSW({ immediate: true, ... })` → `registerSW({ immediate: false, ... })`. |
+
+**T69 — Supabase N+1 + Library Slim**
+
+| File | Change |
+|---|---|
+| `file:src/hooks/useWorkoutExercises.ts` | Change select to `"*, exercise:exercises(id, name, name_en, emoji, muscle_group, equipment, image_url, instructions, secondary_muscles, difficulty_level)"`. Update return type. After fetch, call `queryClient.setQueryData(['exercise', id], exercise)` for each row so downstream `useExerciseById` hits cache. |
+| `file:src/hooks/useExerciseLibrary.ts` | Slim `select('*')` to enumerated columns. Keep `staleTime: 30min` and `queryKey: ['exercise-library']`. Update return type to `ExerciseListItem[]`. |
+| `file:src/hooks/useExerciseFromLibrary.ts` | Audit callers. For session/day rows now carrying embedded `exercise`, stop using this hook. For admin/library detail pages (where per-id is legit), keep. |
+| `file:src/components/create-program/AIGeneratingStep.tsx` | If generation prompt needs `instructions` / `secondary_muscles`, switch to a dedicated query with the richer shape. Do NOT re-widen the shared library hook. |
+| `file:src/hooks/useGenerateProgram.ts` (line ~89) | Replace the loop's per-id `.single()` with a one-shot `.in('id', resolvedIds)` batch via existing `fetchExercisesByIds`. |
+
+### Failure Mode Analysis
+
+| Failure | Behavior | Mitigation |
+|---|---|---|
+| Skeleton renders but real data is faster than paint | Flash-of-skeleton | Gate skeleton behind 100ms `setTimeout` or accept the brief flash (UX team call) |
+| `exercise:exercises(*)` embed fails RLS for a user | Row returns `exercise: null` | Fallback to `name_snapshot`, `emoji_snapshot` already on `workout_exercises` |
+| Lazy admin chunk fetch fails (network error) | Route shows error boundary | Existing `ErrorBoundary` in `main.tsx` catches it; user can retry nav |
+| `useIsAdmin` re-fetches on window focus | Extra admin probe | Already mitigated: `refetchOnWindowFocus: false` in new hook |
+| `manualChunks` groups `recharts` into `chart-vendor` but `WorkoutPage` transitively imports `chart.tsx` | Recharts leaks into main chunk | Lint: `WorkoutPage` and imports must NOT reference `@/components/ui/chart`. Add ESLint rule if leak re-appears |
+| Deleting imperative admin/program checks breaks some atom reader | UI shows stale `false` | `AppShell` bridge effect covers the atoms; verify all readers get value from React Query-sourced atom |
+| `immediate: false` on SW means tab-for-hours users miss updates | Known existing behavior | `handleVersionUpgrade` in `main.tsx` forces reload on version mismatch — unchanged |
+| Third-party deferral skips Sentry init before an early error | Error not captured | Accept: errors in first ~2s are rare; optional `window.addEventListener('error', queueForSentry)` during the gap |
+| Slimmer `useExerciseLibrary` breaks a consumer expecting `instructions` | Runtime `undefined` access | TypeScript narrow type (`ExerciseListItem`) flags all offenders at compile time |
+| Session-view row loses `instructions` when `exercise` embed is null | Instructions panel empty | `ExerciseInstructionsPanel` already calls `useExerciseById` independently — unchanged |
+
+---
+
+## Stress-Test List
+
+1. **`WorkoutPage` renders before `useActiveProgram` resolves.** Post-T66, the atom is populated via React Query, so there's a first-paint window where `activeProgramId` is `undefined`. `WorkoutPage` must tolerate this — it already does, because program switching clears the atom. Verified in current code.
+2. **Wrong `min-h` measurement on `WorkoutDayCarousel`.** Too low → residual CLS; too high → visible gap. Mitigation: put measurement in a CSS custom property (`--card-min-h`) and re-measure after shipping a preview build. Acceptance requires Lighthouse CLS < 0.1.
+3. **`exercise:exercises(*)` embed increases per-row payload.** For a 10-exercise day, ~10 KB added to single query vs 10 parallel 1 KB requests. Net win on mobile where TCP setup dominates. Verify on throttled 3G in Lighthouse.
+4. **First `/history` visit pays recharts fetch on top of data fetch.** Consumer perception: "slow first time, fast after." Acceptable — history isn't critical path. Optional: hover-prefetch on nav icon if complaints.
+5. **Inconsistency with issue body:** issue lists both CLS and fat `select=*` as P0. The plan reorders: CLS → route splitting → vendor → Supabase. Rationale: route splitting is the biggest LCP lever and needs T66's stability work (skeletons) to not introduce new shifts. Called out explicitly.
+6. **`manualChunks` over-splitting on HTTP/2.** Too many parallel chunks can hurt on slow networks. Revert path: delete `manualChunks` function, keep analyzer. Two-line revert. Will verify via Lighthouse after T68.
+7. **PostHog session replay flag sneaks in later.** Instantly regresses TBT + bundle. Add a PR-reviewer note / CODEOWNERS line on `main.tsx` PostHog config. Out of scope for this plan but worth a follow-up task.
+8. **Atom bridge pattern could hide late hydration bugs.** Effect runs after hook resolves; readers observing `isAdmin === false` before hydration could flicker. Mitigation: `isAdminAtom` starts as `undefined` (loading state); readers must treat `undefined` as "not known yet" rather than "not admin". Follow-up deletion will remove the ambiguity.
+
+---
+
+## Acceptance Criteria (plan-level)
+
+- [ ] T66 ships with Lighthouse CLS < 0.1 on `/` mobile (clean profile / incognito).
+- [ ] T67 ships with initial JS transfer < 400 KB on `/` mobile.
+- [ ] T68 ships with TBT < 150ms and Lighthouse LCP < 2.5s on `/` mobile.
+- [ ] T69 ships with at most one `exercises?id=in.(...)` request per day load (verified in DevTools network panel).
+- [ ] No Supabase 406 errors in console on cold load after T66.
+- [ ] No duplicate `admin_users` or `programs?…is_active=eq.true` requests on login after T66.
+- [ ] Follow-up noted: delete `isAdminAtom` and `activeProgramIdAtom`, migrate readers to hooks directly.
+- [ ] Follow-up noted: defer i18n locale loading and `react-day-picker` CSS import.
+
+---
+
+## References
+
+- Issue: [#104 — Improve Lighthouse: CLS, LCP, Supabase payload & 406 errors](https://github.com/PierreTsia/workout-app/issues/104)
+- Baseline Lighthouse report: attached to issue (mobile, simulated 3G, production URL)
+- `file:docs/PRD.md` — tech stack and data model reference


### PR DESCRIPTION
## What

Planning deliverables for the Lighthouse performance epic. No code changes — this PR only lands the docs that drive the four implementation PRs.

| File | Purpose |
|---|---|
| `docs/Tech_Plan_—_Lighthouse_CLS_LCP_Supabase_#104.md` | Full plan: architectural approach, key decisions, data model, component architecture, failure-mode analysis, stress-test list |
| `docs/T66_—_CLS_A11y_and_406_Dedup_Fixes.md` | P0 ticket — CLS + a11y + 406/dedup |
| `docs/T67_—_Route-Level_Code_Splitting.md` | P1 ticket — `React.lazy` per non-critical route |
| `docs/T68_—_Vendor_Chunks_Analyzer_and_Third-party_Deferral.md` | P1 ticket — Vite `manualChunks` + analyzer + Sentry/SW deferral |
| `docs/T69_—_Supabase_N+1_and_Library_Slim.md` | P1 ticket — `exercise:exercises(*)` embed + library column slim |

## Why

Lighthouse mobile on production showed Performance ~0.46, driven by **CLS 0.84** and **LCP ~5.4s**. The issue body listed five workstreams but collapsing them into one PR is unreviewable, and codebase exploration revealed that the issue's framing is slightly off in places (the real 406 sources are `admin_users` + `programs` in `lib/supabase.ts`, not `sessions`). This plan reorders and re-scopes the work into four independent PRs so each change ships with its own Lighthouse verification.

## Plan summary

Priority ordering:

1. **T66 (P0)** — smallest blast radius, biggest UX visibility. Home skeleton, carousel `min-h`, pager dots via `transform` (not width), `transition-shadow` → `ring`/opacity, TanStack hooks replace the imperative admin/program probes.
2. **T67 (P1)** — biggest LCP lever. `React.lazy` for admin/history/library/builder/cycle-summary/achievements. Workout flow stays eager.
3. **T68 (P1)** — compounds with T67. Vite `manualChunks`, `rollup-plugin-visualizer` gated behind `ANALYZE=true`, Sentry + `registerSW` moved to `requestIdleCallback`.
4. **T69 (P1)** — kills the `exercises?id=eq…` storm. `exercise:exercises(*)` embed in `useWorkoutExercises`, `useExerciseLibrary` slimmed to `ExerciseListItem`, `useGenerateProgram` per-id loop replaced with batched `.in()`.

Targets: **CLS < 0.1**, **LCP < 2.5s**, zero Supabase 406s, initial JS < 400 KB on `/`.

## Sub-issues (already linked under #104)

- #238 — T66 — CLS, A11y & 406/Dedup Fixes
- #239 — T67 — Route-Level Code Splitting
- #240 — T68 — Vendor Chunks, Analyzer & Third-party Deferral
- #241 — T69 — Supabase N+1 Elimination & Library Slim

## Test plan

- [x] Tech plan follows `docs-format.mdc` template
- [x] Each ticket follows the ticket template (Goal / Dependencies / Scope / Out of Scope / Acceptance / References)
- [x] Four sub-issues created on GitHub and attached to #104 via the sub-issues API
- [x] Branch `perf/104/lighthouse-cls-lcp-supabase` cut from latest `main`
- [ ] Reviewer sanity-check: is the priority reordering (CLS first, then route-splitting) reasonable given the codebase findings?

Refs #104

Made with [Cursor](https://cursor.com)