### PR TITLE
perf(#238): home CLS fixes, Supabase 406 dedup, pager a11y

### DIFF
--- a/e2e/progression.spec.ts
+++ b/e2e/progression.spec.ts
@@ -118,8 +118,9 @@ test.describe("Progression — cross-session suggestion", () => {
     // Back on the carousel — wait for it to load
     await expect(lundiCard).toBeVisible({ timeout: 15_000 })
 
-    // Navigate to the Mercredi day card via dot indicators
-    const dots = page.locator("div.flex.items-center.justify-center button.rounded-full")
+    // Navigate to the Mercredi day card via dot indicators — by aria-label
+    // so the selector is locale-agnostic and survives CSS refactors.
+    const dots = page.getByRole("button", { name: /^(aller à|go to)\s/i })
     await expect(dots).toHaveCount(3, { timeout: 5_000 })
     await dots.nth(1).click()
     await page.waitForTimeout(500)

--- a/e2e/workout-session.spec.ts
+++ b/e2e/workout-session.spec.ts
@@ -132,8 +132,9 @@ test.describe("Workout session — full flow", () => {
     const dayCards = page.locator("h3").filter({ hasText: /Lundi|Mercredi|Vendredi/ })
     await expect(dayCards.first()).toBeVisible({ timeout: 30_000 })
 
-    // Dot indicators — small round buttons below the carousel
-    const dots = page.locator("div.flex.items-center.justify-center button.rounded-full")
+    // Dot indicators — target by accessible name (aria-label) so the selector
+    // survives CSS refactors; matches both en ("Go to …") and fr ("Aller à …").
+    const dots = page.getByRole("button", { name: /^(aller à|go to)\s/i })
     await expect(dots).toHaveCount(3, { timeout: 5_000 })
 
     // Click the second dot to navigate to the second day

--- a/src/components/workout/CycleProgressHeader.tsx
+++ b/src/components/workout/CycleProgressHeader.tsx
@@ -28,8 +28,8 @@ export function CycleProgressHeader({
         </div>
         <div className="h-1.5 overflow-hidden rounded-full bg-muted">
           <div
-            className="h-full rounded-full bg-primary transition-all"
-            style={{ width: `${pct}%` }}
+            className="h-full w-full origin-left rounded-full bg-primary transition-transform duration-300"
+            style={{ transform: `scaleX(${pct / 100})` }}
           />
         </div>
       </div>

--- a/src/components/workout/WorkoutDayCard.tsx
+++ b/src/components/workout/WorkoutDayCard.tsx
@@ -45,10 +45,8 @@ export function WorkoutDayCard({
   return (
     <div
       className={cn(
-        "rounded-xl border bg-card p-5 transition-shadow",
-        isActive
-          ? "border-primary/60 shadow-lg shadow-primary/10"
-          : "border-border",
+        "rounded-xl border bg-card p-5",
+        isActive ? "border-primary/60" : "border-border",
       )}
     >
       {/* Header: date badge + cycle done */}
@@ -75,8 +73,8 @@ export function WorkoutDayCard({
         <h3 className="text-xl font-bold text-foreground">{day.label}</h3>
       </div>
 
-      {/* Body map (centered hero) */}
-      <div className="flex items-center justify-center">
+      {/* Body map (centered hero) — min-h reserves space so the fetch → map swap doesn't trigger CLS */}
+      <div className="flex min-h-[280px] items-center justify-center">
         {exercises && exercises.length > 0 ? (
           <BodyMap data={heatmapData} />
         ) : exercises ? null : (

--- a/src/components/workout/WorkoutDayCarousel.tsx
+++ b/src/components/workout/WorkoutDayCarousel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useAtom } from "jotai"
+import { useTranslation } from "react-i18next"
 import { sessionAtom } from "@/store/atoms"
 import type { WorkoutDay } from "@/types/database"
 import {
@@ -20,6 +21,7 @@ export function WorkoutDayCarousel({
   days,
   completedDayIds,
 }: WorkoutDayCarouselProps) {
+  const { t } = useTranslation("workout")
   const [session, setSession] = useAtom(sessionAtom)
   const [api, setApi] = useState<CarouselApi>()
   const [activeSlide, setActiveSlide] = useState(0)
@@ -81,7 +83,7 @@ export function WorkoutDayCarousel({
   }, [api, onSelect])
 
   return (
-    <div className="space-y-3">
+    <div className="min-h-[360px] space-y-3">
       <Carousel
         setApi={setApi}
         opts={carouselOpts}
@@ -103,17 +105,28 @@ export function WorkoutDayCarousel({
 
       <div className="flex items-center justify-center px-4">
         <div className="flex gap-1.5">
-          {days.map((day, idx) => (
-            <button
-              key={day.id}
-              type="button"
-              onClick={() => api?.scrollTo(idx)}
-              className={cn(
-                "h-1.5 rounded-full transition-all",
-                idx === activeSlide ? "w-4 bg-primary" : "w-1.5 bg-muted-foreground/30",
-              )}
-            />
-          ))}
+          {days.map((day, idx) => {
+            const isActive = idx === activeSlide
+            return (
+              <button
+                key={day.id}
+                type="button"
+                onClick={() => api?.scrollTo(idx)}
+                aria-label={t("goToDay", { day: day.label })}
+                aria-current={isActive ? "true" : undefined}
+                className="group flex h-6 w-6 items-center justify-center"
+              >
+                <span
+                  className={cn(
+                    "h-1.5 w-4 origin-left rounded-full transition-transform duration-200",
+                    isActive
+                      ? "scale-x-100 bg-primary"
+                      : "scale-x-[0.375] bg-muted-foreground/30",
+                  )}
+                />
+              </button>
+            )
+          })}
         </div>
       </div>
     </div>

--- a/src/components/workout/WorkoutHomeSkeleton.tsx
+++ b/src/components/workout/WorkoutHomeSkeleton.tsx
@@ -1,0 +1,47 @@
+/**
+ * Layout-matching skeleton for the logged-in home route while `daysLoading` is true.
+ * Heights are tuned to the real `CycleProgressHeader`, `WorkoutDayCarousel` + `WorkoutDayCard`,
+ * and pre-session exercise list so the spinner → data swap does not cause CLS.
+ */
+export function WorkoutHomeSkeleton() {
+  return (
+    <div className="flex-1 space-y-4 overflow-hidden pb-20" aria-hidden="true">
+      <div className="mx-4 flex items-center gap-3 pt-4">
+        <div className="h-4 w-4 shrink-0 animate-pulse rounded-full bg-muted" />
+        <div className="flex-1">
+          <div className="mb-1 flex items-baseline justify-between">
+            <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+            <div className="h-3 w-8 animate-pulse rounded bg-muted" />
+          </div>
+          <div className="h-1.5 w-full animate-pulse rounded-full bg-muted" />
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="px-4">
+          <div className="h-[340px] animate-pulse rounded-xl border border-border bg-card" />
+        </div>
+        <div className="flex items-center justify-center gap-1.5">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-1.5 w-1.5 rounded-full bg-muted-foreground/30"
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2 px-4">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            className="flex items-center gap-2 rounded-lg border border-border/60 bg-card px-3 py-2"
+          >
+            <div className="h-8 w-8 animate-pulse rounded bg-muted" />
+            <div className="h-4 flex-1 animate-pulse rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useActiveProgram.ts
+++ b/src/hooks/useActiveProgram.ts
@@ -1,13 +1,33 @@
+import { useEffect } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { useAtomValue } from "jotai"
+import { useAtomValue, useSetAtom } from "jotai"
 import { supabase } from "@/lib/supabase"
-import { authAtom } from "@/store/atoms"
+import {
+  authAtom,
+  hasProgramAtom,
+  hasProgramLoadingAtom,
+  activeProgramIdAtom,
+} from "@/store/atoms"
 import type { Program } from "@/types/onboarding"
 
+/**
+ * Fetches the current user's active program.
+ *
+ * `.maybeSingle()` avoids the PGRST116 / 406 response PostgREST emits when
+ * `.single()` sees zero rows. Result mirrors into `hasProgramAtom` /
+ * `hasProgramLoadingAtom` / `activeProgramIdAtom` so existing readers
+ * (`OnboardingGuard`, `WorkoutPage`, `syncService`) keep working unchanged.
+ * Mutation hooks (`useCreateProgram`, `useActivateProgram`,
+ * `useGenerateProgram`) still write those atoms imperatively for instant UI
+ * feedback; this effect is a non-destructive downstream sync.
+ */
 export function useActiveProgram() {
   const user = useAtomValue(authAtom)
+  const setHasProgram = useSetAtom(hasProgramAtom)
+  const setHasProgramLoading = useSetAtom(hasProgramLoadingAtom)
+  const setActiveProgramId = useSetAtom(activeProgramIdAtom)
 
-  return useQuery<Program | null>({
+  const query = useQuery<Program | null>({
     queryKey: ["active-program", user?.id],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -15,12 +35,39 @@ export function useActiveProgram() {
         .select("id, user_id, name, template_id, is_active, archived_at, created_at")
         .eq("user_id", user!.id)
         .eq("is_active", true)
-        .single()
+        .maybeSingle()
 
-      if (error && error.code === "PGRST116") return null
       if (error) throw error
-      return data as Program
+      return (data as Program) ?? null
     },
     enabled: !!user,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
   })
+
+  const { data, isLoading, isFetched } = query
+
+  useEffect(() => {
+    if (!user) {
+      setHasProgram(false)
+      setActiveProgramId(null)
+      setHasProgramLoading(false)
+      return
+    }
+    setHasProgram(!!data)
+    setActiveProgramId(data?.id ?? null)
+    setHasProgramLoading(isLoading && !isFetched)
+  }, [
+    user,
+    data,
+    isLoading,
+    isFetched,
+    setHasProgram,
+    setActiveProgramId,
+    setHasProgramLoading,
+  ])
+
+  return query
 }

--- a/src/hooks/useCycle.ts
+++ b/src/hooks/useCycle.ts
@@ -27,13 +27,15 @@ interface CycleProgress {
   totalDays: number
   nextDayId: string | null
   isComplete: boolean
+  /** True while the inner `cycle-sessions` query is in its first fetch. False when no cycle (query idle). */
+  isLoading: boolean
 }
 
 export function useCycleProgress(
   cycleId: string | null,
   days: WorkoutDay[],
 ): CycleProgress {
-  const { data: cycleSessions } = useQuery<
+  const { data: cycleSessions, isLoading } = useQuery<
     Pick<Session, "workout_day_id">[]
   >({
     queryKey: ["cycle-sessions", cycleId],
@@ -63,6 +65,7 @@ export function useCycleProgress(
       totalDays,
       nextDayId,
       isComplete: totalDays > 0 && completedSet.size >= totalDays,
+      isLoading,
     }
-  }, [cycleSessions, days])
+  }, [cycleSessions, days, isLoading])
 }

--- a/src/hooks/useIsAdmin.ts
+++ b/src/hooks/useIsAdmin.ts
@@ -1,8 +1,56 @@
-import { useAtomValue } from "jotai"
-import { isAdminAtom, isAdminLoadingAtom } from "@/store/atoms"
+import { useEffect } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { useAtomValue, useSetAtom } from "jotai"
+import { supabase } from "@/lib/supabase"
+import { authAtom, isAdminAtom, isAdminLoadingAtom } from "@/store/atoms"
 
+/**
+ * Checks whether the current user's email is in `admin_users`.
+ *
+ * React Query dedupes across the tree, replaces the old imperative
+ * `checkAdminStatus` call in `lib/supabase.ts` (single source of truth),
+ * and uses `.maybeSingle()` so a missing row returns `null` without the
+ * PGRST116 / 406 noise. Result is mirrored into `isAdminAtom` /
+ * `isAdminLoadingAtom` so existing readers (`AdminGuard`, `AdminOnly`) keep
+ * working unchanged.
+ */
 export function useIsAdmin() {
-  const isAdmin = useAtomValue(isAdminAtom)
-  const isLoading = useAtomValue(isAdminLoadingAtom)
+  const user = useAtomValue(authAtom)
+  const setIsAdmin = useSetAtom(isAdminAtom)
+  const setIsAdminLoading = useSetAtom(isAdminLoadingAtom)
+
+  const email = user?.email
+
+  const { data, isLoading, isFetched } = useQuery({
+    queryKey: ["is-admin", email],
+    queryFn: async () => {
+      if (!email) return false
+      const { data, error } = await supabase
+        .from("admin_users")
+        .select("email")
+        .eq("email", email)
+        .maybeSingle()
+      if (error) throw error
+      return !!data
+    },
+    enabled: !!user,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  })
+
+  const isAdmin = data ?? false
+
+  useEffect(() => {
+    if (!user) {
+      setIsAdmin(false)
+      setIsAdminLoading(false)
+      return
+    }
+    setIsAdmin(isAdmin)
+    setIsAdminLoading(isLoading && !isFetched)
+  }, [user, isAdmin, isLoading, isFetched, setIsAdmin, setIsAdminLoading])
+
   return { isAdmin, isLoading }
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -33,52 +33,16 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
 const store = getDefaultStore()
 
-async function checkProgramStatus(userId: string) {
-  try {
-    const { data } = await supabase
-      .from("programs")
-      .select("id")
-      .eq("user_id", userId)
-      .eq("is_active", true)
-      .single()
-    store.set(hasProgramAtom, !!data)
-    store.set(activeProgramIdAtom, data?.id ?? null)
-  } catch {
-    store.set(hasProgramAtom, false)
-    store.set(activeProgramIdAtom, null)
-  }
-  store.set(hasProgramLoadingAtom, false)
-}
-
-async function checkAdminStatus(email: string | undefined) {
-  if (!email) {
-    store.set(isAdminAtom, false)
-    store.set(isAdminLoadingAtom, false)
-    return
-  }
-  try {
-    const { data } = await supabase
-      .from("admin_users")
-      .select("email")
-      .eq("email", email)
-      .single()
-    store.set(isAdminAtom, !!data)
-  } catch {
-    store.set(isAdminAtom, false)
-  }
-  store.set(isAdminLoadingAtom, false)
-}
-
+// Admin + active-program status are now owned by React Query hooks
+// (`useIsAdmin`, `useActiveProgram`) mounted by `AuthDataBridge`. Those hooks
+// sync their results to the existing atoms so guards + other readers keep
+// working, without the double-fetch (getSession + SIGNED_IN) and 406 noise
+// the previous imperative `.single()` calls produced.
 supabase.auth.getSession().then(({ data: { session } }) => {
   store.set(authAtom, session?.user ?? null)
   store.set(authLoadingAtom, false)
   if (session?.user) {
     drainQueue(session.user.id)
-    checkAdminStatus(session.user.email)
-    checkProgramStatus(session.user.id)
-  } else {
-    store.set(isAdminLoadingAtom, false)
-    store.set(hasProgramLoadingAtom, false)
   }
 })
 
@@ -110,8 +74,6 @@ supabase.auth.onAuthStateChange((event, session) => {
   store.set(authAtom, session?.user ?? null)
   if (event === "SIGNED_IN" && session?.user) {
     drainQueue(session.user.id)
-    checkAdminStatus(session.user.email)
-    checkProgramStatus(session.user.id)
   }
   if (event === "SIGNED_OUT") {
     clearUserState()

--- a/src/locales/en/workout.json
+++ b/src/locales/en/workout.json
@@ -68,6 +68,7 @@
   "rir.setInfo": "#{{setNumber}} set: {{reps}} × {{weight}} {{unit}}",
   "rir.infoLabel": "Info",
   "muscleMap": "Muscle map",
+  "goToDay": "Go to {{day}}",
   "cycleProgress": "Cycle {{current}}/{{total}}",
   "cycleComplete": "Cycle complete!",
   "startNewCycle": "Start new cycle",

--- a/src/locales/fr/workout.json
+++ b/src/locales/fr/workout.json
@@ -68,6 +68,7 @@
   "rir.setInfo": "#{{setNumber}} série : {{reps}} × {{weight}} {{unit}}",
   "rir.infoLabel": "Info",
   "muscleMap": "Carte musculaire",
+  "goToDay": "Aller à {{day}}",
   "cycleProgress": "Cycle {{current}}/{{total}}",
   "cycleComplete": "Cycle terminé !",
   "startNewCycle": "Nouveau cycle",

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -183,9 +183,11 @@ export function WorkoutPage() {
   const user = useAtomValue(authAtom)
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { data: activeCycle } = useActiveCycle(activeProgramId)
+  const { data: activeCycle, isLoading: activeCycleLoading } = useActiveCycle(activeProgramId)
   const { data: days, isLoading: daysLoading } = useWorkoutDays(activeProgramId)
   const cycleProgress = useCycleProgress(activeCycle?.id ?? null, days ?? EMPTY_DAYS)
+  // Hold the skeleton until the progress bar can render its final value — otherwise the `CycleProgressHeader` gate (`!isComplete && activeCycle`) briefly flips true with stale zero data, flashes a 0% bar, then disappears when sessions arrive.
+  const homeLoading = daysLoading || activeCycleLoading || cycleProgress.isLoading
   useAdvanceWorkoutDayOnDateRollover({
     isSessionActive: session.isActive,
     currentDayId: session.currentDayId,
@@ -921,7 +923,7 @@ export function WorkoutPage() {
     }
   }
 
-  if (daysLoading) {
+  if (homeLoading) {
     return <WorkoutHomeSkeleton />
   }
 

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -63,6 +63,7 @@ import { canStartPreSession } from "@/lib/canStartPreSession"
 import { fetchLastWeightsForExerciseIds } from "@/lib/lastWeightsFromSetLogs"
 import { WorkoutDayCarousel } from "@/components/workout/WorkoutDayCarousel"
 import { CycleProgressHeader } from "@/components/workout/CycleProgressHeader"
+import { WorkoutHomeSkeleton } from "@/components/workout/WorkoutHomeSkeleton"
 import { useAdvanceWorkoutDayOnDateRollover } from "@/hooks/useAdvanceWorkoutDayOnDateRollover"
 import { usePruneSessionSetsToExerciseList } from "@/hooks/usePruneSessionSetsToExerciseList"
 import { useCycleProgress } from "@/hooks/useCycle"
@@ -921,11 +922,7 @@ export function WorkoutPage() {
   }
 
   if (daysLoading) {
-    return (
-      <div className="flex flex-1 flex-col items-center justify-center gap-3">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    )
+    return <WorkoutHomeSkeleton />
   }
 
   if (!days || days.length === 0) {

--- a/src/router/AuthDataBridge.tsx
+++ b/src/router/AuthDataBridge.tsx
@@ -1,0 +1,17 @@
+import { useIsAdmin } from "@/hooks/useIsAdmin"
+import { useActiveProgram } from "@/hooks/useActiveProgram"
+
+/**
+ * Mounts the admin + active-program React Query hooks so their results mirror
+ * into the shared Jotai atoms read by `AdminGuard`, `OnboardingGuard`,
+ * `AdminOnly`, `WorkoutPage`, and `syncService`.
+ *
+ * Rendered inside `AuthGuard` (which already bails on `authLoading` / missing
+ * user) so both queries only fire for authenticated sessions and dedupe via
+ * React Query regardless of who consumes them downstream.
+ */
+export function AuthDataBridge() {
+  useIsAdmin()
+  useActiveProgram()
+  return null
+}

--- a/src/router/AuthGuard.tsx
+++ b/src/router/AuthGuard.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import { Navigate, Outlet } from "react-router-dom"
 import type { User } from "@/types/auth"
 import { authAtom, authLoadingAtom } from "@/store/atoms"
+import { AuthDataBridge } from "@/router/AuthDataBridge"
 import { useNotificationPermission } from "@/hooks/useNotificationPermission"
 import {
   Dialog,
@@ -72,6 +73,7 @@ export function AuthGuard() {
 
   return (
     <>
+      <AuthDataBridge />
       <Outlet />
       <Dialog open={showDialog} onOpenChange={setShowDialog}>
         <DialogContent onInteractOutside={(e) => e.preventDefault()}>


### PR DESCRIPTION
## What

- **CLS / paint**: replace the `daysLoading` spinner with a layout-matching `WorkoutHomeSkeleton`; reserve `min-h` on the carousel root + `WorkoutDayCard`'s `BodyMap` slot; swap `width`/`shadow` animations on `CycleProgressHeader` + carousel pager for `transform: scaleX` (composited); drop `transition-shadow` on `WorkoutDayCard`.
- **A11y**: pager dots now render a `24×24` tap target wrapping the pill, with `aria-label` (`goToDay` key, en + fr) and `aria-current`.
- **Supabase 406 / dedup**: `useIsAdmin` + `useActiveProgram` rewritten as TanStack Query hooks using `.maybeSingle()` (no more PGRST116 / 406 on missing rows), `staleTime: Infinity`, no refetch on focus/mount. Deleted imperative `checkAdminStatus` + `checkProgramStatus` and both call sites from `lib/supabase.ts`. New `<AuthDataBridge />` mounted inside `AuthGuard` fires both hooks once per authenticated session and syncs results into the existing Jotai atoms (`isAdminAtom`, `hasProgramAtom`, `activeProgramIdAtom`, etc.) so `AdminGuard`, `OnboardingGuard`, `AdminOnly`, `WorkoutPage`, and `syncService` keep working unchanged.

## Why

First ticket of the Lighthouse perf epic (#104). Targets the three worst offenders on the logged-in home route:

- A full-viewport spinner during `daysLoading` caused a huge CLS jump when data arrived.
- Non-composited `width` / `box-shadow` animations on the carousel pager, progress bar, and day cards triggered paint on every swipe frame.
- Two `.single()` calls in `lib/supabase.ts` ran on every `getSession` **and** `SIGNED_IN`, producing 406 responses for new users (no `admin_users` row, no `programs` row) and double-fetching the same rows for existing users.
- The pager buttons were below the WCAG tap-target minimum and had no accessible name.

## How

- Skeleton heights (`min-h-[360px]` carousel, `min-h-[280px]` BodyMap slot) tuned against the real components so the spinner → data swap is visually invisible.
- Bridge-from-hook strategy for atoms: picked deliberately over migrating each guard to call the hook directly, because it ships the same perf/correctness win with a smaller diff + zero test churn. Full deletion of the admin/program atoms is a clean follow-up (mentioned in the tech plan, not required for the T66 acceptance metrics).
- Query caches: `staleTime: Infinity`, `gcTime: Infinity`, `refetchOnWindowFocus: false`, `refetchOnMount: false`. Existing mutation hooks (`useCreateProgram`, `useActivateProgram`, `useGenerateProgram`) still write atoms imperatively for instant UI feedback — the effect sync is non-destructive downstream.
- Verification: `npx tsc --noEmit` clean, `npm run lint` clean (8 pre-existing warnings untouched), `npm run test` → **110 files / 965 tests pass**.

Closes #238

Made with [Cursor](https://cursor.com)