### PR TITLE
perf(router): lazy-load non-critical routes (T67)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react"
 import { useSetAtom } from "jotai"
 import { Outlet, useLocation } from "react-router-dom"
 import { useTranslation } from "react-i18next"
@@ -7,6 +8,7 @@ import { SyncStatusChip } from "@/components/SyncStatusChip"
 import { SideDrawer } from "@/components/SideDrawer"
 import { InstallBanner } from "@/components/InstallBanner"
 import { RestTimerPill } from "@/components/RestTimerPill"
+import { RouteSkeleton } from "@/components/RouteSkeleton"
 import { AchievementRealtimeProvider } from "@/components/achievements/AchievementRealtimeProvider"
 import { AchievementUnlockOverlay } from "@/components/achievements/AchievementUnlockOverlay"
 
@@ -41,7 +43,12 @@ export function AppShell() {
         <AchievementUnlockOverlay />
 
         <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col">
-          <Outlet />
+          {/* Single Suspense boundary for all lazy routes nested under AppShell.
+              Keeps header + side drawer + chips stable while the next chunk
+              downloads (`RouteSkeleton` only swaps inside `<main>`). */}
+          <Suspense fallback={<RouteSkeleton />}>
+            <Outlet />
+          </Suspense>
         </main>
       </div>
     </AchievementRealtimeProvider>

--- a/src/components/RouteSkeleton.tsx
+++ b/src/components/RouteSkeleton.tsx
@@ -1,0 +1,21 @@
+import { Loader2 } from "lucide-react"
+
+/**
+ * Shared `<Suspense>` fallback for lazy-loaded routes.
+ *
+ * Kept intentionally minimal: most lazy routes are non-critical (admin,
+ * history, library, builder, account). The logged-in home (`/`), `/login`,
+ * `/onboarding`, and `/create-program` stay eager so the auth + LCP path
+ * never hits this fallback. Upgrade to a per-route skeleton only if a
+ * specific lazy surface suffers a visible flash.
+ */
+export function RouteSkeleton() {
+  return (
+    <div
+      className="flex flex-1 items-center justify-center"
+      aria-hidden="true"
+    >
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,3 +1,8 @@
+/* eslint-disable react-refresh/only-export-components --
+ * This file only exports `router` (config), not components. The local
+ * `lazy(...)` consts trip the rule, but there is no fast-refresh surface
+ * to break here. */
+import { lazy, Suspense } from "react"
 import { createBrowserRouter, Navigate } from "react-router-dom"
 import { AuthGuard } from "@/router/AuthGuard"
 import { OnboardingGuard } from "@/router/OnboardingGuard"
@@ -5,27 +10,95 @@ import { AdminGuard } from "@/router/AdminGuard"
 import { AppShell } from "@/components/AppShell"
 import { LoginPage } from "@/pages/LoginPage"
 import { WorkoutPage } from "@/pages/WorkoutPage"
-import { HistoryPage } from "@/pages/HistoryPage"
-import { BuilderPage } from "@/pages/BuilderPage"
-import { AboutPage } from "@/pages/AboutPage"
 import { OnboardingPage } from "@/pages/OnboardingPage"
-import { AdminExercisesPage } from "@/pages/AdminExercisesPage"
-import { AdminExerciseEditPage } from "@/pages/AdminExerciseEditPage"
 import { LibraryLayout } from "@/pages/library/LibraryLayout"
-import { LibraryProgramsPage } from "@/pages/library/LibraryProgramsPage"
-import { ExerciseLibraryPage } from "@/pages/library/ExerciseLibraryPage"
-import { ExerciseLibraryExercisePage } from "@/pages/library/ExerciseLibraryExercisePage"
 import { CreateProgramPage } from "@/pages/CreateProgramPage"
-import { AdminFeedbackPage } from "@/pages/AdminFeedbackPage"
-import { AdminHomePage } from "@/pages/AdminHomePage"
-import { AdminEnrichmentPage } from "@/pages/AdminEnrichmentPage"
-import { AdminReviewPage } from "@/pages/AdminReviewPage"
-import { CycleSummaryPage } from "@/pages/CycleSummaryPage"
-import { AccountPage } from "@/pages/AccountPage"
-import { AchievementsPage } from "@/pages/AchievementsPage"
-import { PrivacyPage } from "@/pages/PrivacyPage"
-import { OAuthConsentPage } from "@/pages/OAuthConsentPage"
 import { RouteErrorFallback } from "@/components/RouteErrorFallback"
+import { RouteSkeleton } from "@/components/RouteSkeleton"
+
+// Named-export → default-export adapter for `React.lazy`. All page files
+// in this repo use named exports, so every dynamic import is translated
+// into a `{ default: ... }` shape. Lazy routes nested under `AppShell`
+// share the Suspense boundary mounted in `AppShell`; the handful of
+// routes outside it (about, privacy, oauth consent) get an individual
+// wrapper via `standalone()` below.
+const HistoryPage = lazy(() =>
+  import("@/pages/HistoryPage").then((m) => ({ default: m.HistoryPage })),
+)
+const BuilderPage = lazy(() =>
+  import("@/pages/BuilderPage").then((m) => ({ default: m.BuilderPage })),
+)
+const AboutPage = lazy(() =>
+  import("@/pages/AboutPage").then((m) => ({ default: m.AboutPage })),
+)
+const AdminExercisesPage = lazy(() =>
+  import("@/pages/AdminExercisesPage").then((m) => ({
+    default: m.AdminExercisesPage,
+  })),
+)
+const AdminExerciseEditPage = lazy(() =>
+  import("@/pages/AdminExerciseEditPage").then((m) => ({
+    default: m.AdminExerciseEditPage,
+  })),
+)
+const LibraryProgramsPage = lazy(() =>
+  import("@/pages/library/LibraryProgramsPage").then((m) => ({
+    default: m.LibraryProgramsPage,
+  })),
+)
+const ExerciseLibraryPage = lazy(() =>
+  import("@/pages/library/ExerciseLibraryPage").then((m) => ({
+    default: m.ExerciseLibraryPage,
+  })),
+)
+const ExerciseLibraryExercisePage = lazy(() =>
+  import("@/pages/library/ExerciseLibraryExercisePage").then((m) => ({
+    default: m.ExerciseLibraryExercisePage,
+  })),
+)
+const AdminFeedbackPage = lazy(() =>
+  import("@/pages/AdminFeedbackPage").then((m) => ({
+    default: m.AdminFeedbackPage,
+  })),
+)
+const AdminHomePage = lazy(() =>
+  import("@/pages/AdminHomePage").then((m) => ({ default: m.AdminHomePage })),
+)
+const AdminEnrichmentPage = lazy(() =>
+  import("@/pages/AdminEnrichmentPage").then((m) => ({
+    default: m.AdminEnrichmentPage,
+  })),
+)
+const AdminReviewPage = lazy(() =>
+  import("@/pages/AdminReviewPage").then((m) => ({
+    default: m.AdminReviewPage,
+  })),
+)
+const CycleSummaryPage = lazy(() =>
+  import("@/pages/CycleSummaryPage").then((m) => ({
+    default: m.CycleSummaryPage,
+  })),
+)
+const AccountPage = lazy(() =>
+  import("@/pages/AccountPage").then((m) => ({ default: m.AccountPage })),
+)
+const AchievementsPage = lazy(() =>
+  import("@/pages/AchievementsPage").then((m) => ({
+    default: m.AchievementsPage,
+  })),
+)
+const PrivacyPage = lazy(() =>
+  import("@/pages/PrivacyPage").then((m) => ({ default: m.PrivacyPage })),
+)
+const OAuthConsentPage = lazy(() =>
+  import("@/pages/OAuthConsentPage").then((m) => ({
+    default: m.OAuthConsentPage,
+  })),
+)
+
+const standalone = (element: React.ReactNode) => (
+  <Suspense fallback={<RouteSkeleton />}>{element}</Suspense>
+)
 
 export const router = createBrowserRouter([
   {
@@ -35,17 +108,17 @@ export const router = createBrowserRouter([
   },
   {
     path: "/about",
-    element: <AboutPage />,
+    element: standalone(<AboutPage />),
     errorElement: <RouteErrorFallback />,
   },
   {
     path: "/privacy",
-    element: <PrivacyPage />,
+    element: standalone(<PrivacyPage />),
     errorElement: <RouteErrorFallback />,
   },
   {
     path: "/oauth/consent",
-    element: <OAuthConsentPage />,
+    element: standalone(<OAuthConsentPage />),
     errorElement: <RouteErrorFallback />,
   },
   {


### PR DESCRIPTION
## What

- Convert 17 non-critical pages to `React.lazy(() => import(...))` (history, builder, library pages, account, achievements, cycle summary, admin suite, about, privacy, oauth consent).
- Add shared `RouteSkeleton` fallback + mount a single `<Suspense>` boundary inside `AppShell` so the header/nav stay stable while lazy chunks load. Standalone lazy routes outside the shell (`/about`, `/privacy`, `/oauth/consent`) get their own wrappers.
- Keep `/`, `/login`, `/onboarding`, `/create-program`, all guards, and `AppShell` eager — the LCP + auth path must never hit a Suspense fallback.

## Why

Next step of the Lighthouse perf epic (#104) after T66. The monolithic bundle (~716 kB main chunk, 65 % unused on `/`) was the biggest LCP lever identified in the tech plan. Route-level code splitting is the cheapest way to stop shipping admin/history/builder JS to users who only open the workout page.

## How

- Named-export → default-export adapter in `React.lazy`: `lazy(() => import("@/pages/X").then((m) => ({ default: m.X })))` — every page in the repo uses named exports.
- `Suspense` boundary lives between `AppShell`'s outlet and the chrome, so transitions render the fallback inside `<main>` only.
- Blanket-disabled `react-refresh/only-export-components` on `router/index.tsx`: the rule fires on the local `lazy()` consts, but the file only exports `router` (config), so there's no fast-refresh surface to break.
- No Playwright changes — selectors still target `aria-label` / role from T66.

### Build impact (vs. pre-T67)

| Chunk | Before | After |
|---|---|---|
| Main `index-*.js` | ~716 kB | **548 kB** (168 kB gzip) |
| `HistoryPage` (recharts) | inlined | **495 kB**, loaded on `/history` |
| Admin suite | inlined | ~35 kB split across 6 chunks |
| Library pages | inlined | ~22 kB across 3 chunks |
| `BuilderPage` | inlined | 73 kB |
| `Account` / `Achievements` / `About` / `CycleSummary` / `Privacy` / `OAuthConsent` | inlined | individual chunks |

Remaining vendor weight in the main chunk (supabase 322 kB, schemas 97 kB, button 138 kB) is the **T68** target (vendor `manualChunks` + 3rd-party deferral).

### Verification

- `npx tsc --noEmit`: clean
- Lints: clean
- `npm run test`: 965/965 pass
- `npm run build`: clean, 17 new lazy chunks emitted as expected

Closes #239

Made with [Cursor](https://cursor.com)