### PR TITLE
perf(build): revert manualChunks, fix useActiveCycle 406

### DIFF
--- a/src/hooks/useCycle.ts
+++ b/src/hooks/useCycle.ts
@@ -12,9 +12,8 @@ export function useActiveCycle(programId: string | null) {
         .select("*")
         .eq("program_id", programId!)
         .is("finished_at", null)
-        .single()
+        .maybeSingle()
 
-      if (error?.code === "PGRST116") return null
       if (error) throw error
       return data
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -112,35 +112,6 @@ export default defineConfig(({ mode }) => {
 
     build: {
       sourcemap: true,
-      rollupOptions: {
-        output: {
-          // Split heavy third-party libs into stable vendor chunks so they
-          // cache independently of app code and don't duplicate across the
-          // lazy route chunks introduced in T67. Anything not matched falls
-          // through to Rollup's default splitting (shared async deps get
-          // their own chunk, the rest stays in the entry).
-          manualChunks(id) {
-            if (!id.includes("node_modules")) return
-            if (id.includes("recharts") || id.includes("/d3-"))
-              return "chart-vendor"
-            if (id.includes("cmdk") || id.includes("vaul"))
-              return "picker-vendor"
-            if (
-              id.includes("@tanstack/react-table") ||
-              id.includes("@tanstack/table-core")
-            )
-              return "table-vendor"
-            if (id.includes("@radix-ui")) return "radix-vendor"
-            if (id.includes("@supabase")) return "supabase-vendor"
-            if (id.includes("@sentry")) return "sentry-vendor"
-            if (id.includes("posthog")) return "posthog-vendor"
-            if (id.includes("embla-carousel")) return "embla-vendor"
-            if (id.includes("@dnd-kit")) return "dnd-vendor"
-            if (id.includes("react-day-picker") || id.includes("date-fns"))
-              return "calendar-vendor"
-          },
-        },
-      },
     },
   }
 })


### PR DESCRIPTION
## What

- Remove the `build.rollupOptions.output.manualChunks` block introduced in T68 (#246). Kept the bundle analyzer wiring and the deferred Sentry + service-worker init — those are net-positive.
- Switch `useActiveCycle` from `.single()` to `.maybeSingle()` and drop the `PGRST116` dance.

## Why

After T68 merged, the simulated Lighthouse perf score regressed from 0.66 → 0.59. The manual vendor splits fanned out 10+ `<link rel="modulepreload">` tags on the initial HTML, which inflated the simulated critical path under Lighthouse's throttling even though real-world numbers were fine. Rolling back `manualChunks` and letting Rollup/Rolldown handle chunking restores the previous preload footprint.

The 406 on `/cycles?...&finished_at=is.null` was a lingering bug from T66 — `.single()` throws `PGRST116` when no row exists, which Supabase surfaces as a 406. `.maybeSingle()` returns `null` cleanly for that case.

## How

- `vite.config.ts`: drop the `manualChunks(id)` function; rest of the T68 config (analyzer + `build:analyze` script + deferred init) stays.
- `src/hooks/useCycle.ts`: `.single()` → `.maybeSingle()`, remove the `error?.code === "PGRST116"` branch.

Verified with `tsc --noEmit`, `eslint`, `vitest` (965/965), and a full `vite build`.

Relates to #240

Made with [Cursor](https://cursor.com)