### PR TITLE
perf(boot): defer Sentry SDK and PostHog off the critical path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
         "@huggingface/inference": "^4.13.15",
-        "@posthog/react": "^1.9.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
@@ -3520,22 +3519,6 @@
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.25.2.tgz",
       "integrity": "sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==",
       "license": "MIT"
-    },
-    "node_modules/@posthog/react": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@posthog/react/-/react-1.9.0.tgz",
-      "integrity": "sha512-lVdTsWT5+PtHBu44gSQ7QohbLjAYqHkFAIGAQ+HV8Eh9yj+OcnQ7mXCmyhaMlTBD3z7D0H1eWMp4vQaFnsIyWQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": ">=16.8.0",
-        "posthog-js": ">=1.257.2",
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@posthog/types": {
       "version": "1.369.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@huggingface/inference": "^4.13.15",
-    "@posthog/react": "^1.9.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/src/components/AppErrorBoundary.tsx
+++ b/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,57 @@
+import { Component, type ErrorInfo, type ReactNode } from "react"
+
+interface AppErrorBoundaryProps {
+  children: ReactNode
+  fallback: (ctx: { error: Error; resetError: () => void }) => ReactNode
+}
+
+interface AppErrorBoundaryState {
+  error: Error | null
+}
+
+/**
+ * Tiny error boundary that keeps `@sentry/react` out of the main bundle.
+ * The Sentry SDK is only imported on the error path, so in the happy path
+ * we ship zero Sentry bytes here. Error reporting still flows through the
+ * SDK once an error occurs (it initializes via `initSentry()` on idle, so
+ * early-boot errors that fire before idle won't be captured — acceptable
+ * trade for LCP/TBT).
+ */
+export class AppErrorBoundary extends Component<
+  AppErrorBoundaryProps,
+  AppErrorBoundaryState
+> {
+  state: AppErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    void import("@sentry/react")
+      .then(({ captureException }) => {
+        captureException(error, {
+          contexts: {
+            react: { componentStack: info.componentStack ?? undefined },
+          },
+        })
+      })
+      .catch(() => {
+        // Sentry unavailable (network/offline) — swallow to avoid loops.
+      })
+  }
+
+  private resetError = (): void => {
+    this.setState({ error: null })
+  }
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return this.props.fallback({
+        error: this.state.error,
+        resetError: this.resetError,
+      })
+    }
+    return this.props.children
+  }
+}

--- a/src/components/admin/PostHogTestCaptureButton.tsx
+++ b/src/components/admin/PostHogTestCaptureButton.tsx
@@ -1,4 +1,4 @@
-import { usePostHog } from "@posthog/react"
+import posthog from "posthog-js"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -6,7 +6,6 @@ import { Button } from "@/components/ui/button"
 /** Sends a test capture — for verifying PostHog from the admin-only /admin page. */
 export function PostHogTestCaptureButton() {
   const { t } = useTranslation("admin")
-  const posthog = usePostHog()
 
   return (
     <Button

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,23 +8,21 @@ import { createRoot } from "react-dom/client"
 import { ThemeProvider } from "next-themes"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { RouterProvider } from "react-router-dom"
-import { ErrorBoundary } from "@sentry/react"
 import { router } from "@/router"
 import { queryClient } from "@/lib/queryClient"
 import { initSyncListeners } from "@/lib/syncService"
 import { Toaster } from "@/components/ui/sonner"
 import { ErrorFallback } from "@/components/ErrorFallback"
+import { AppErrorBoundary } from "@/components/AppErrorBoundary"
 import { prepareThemeLocalStorage, THEME_STORAGE_KEY } from "@/lib/themeStorage"
 import { handleVersionUpgrade } from "@/lib/versionManager"
-import { listenForSwUpdate } from "@/lib/swReloadOnUpdate"
 import { Analytics } from "@vercel/analytics/react"
-import { PostHogProvider } from "@posthog/react"
-import { initSentry } from "@/lib/sentry"
 
-// Defer work that doesn't need to run before first paint (Sentry init,
-// PWA service-worker registration). We trade off catching errors thrown
-// in the very first ~2s of boot — acceptable for a TBT/LCP win. Runs
-// after `createRoot().render()` schedules the mount below.
+// Defer work that doesn't need to run before first paint:
+//   - Sentry SDK init (dynamic import keeps it out of the main bundle)
+//   - PostHog SDK init + autocapture
+//   - PWA service-worker registration
+// Trade-off: errors/events fired in the first ~2s of boot may be missed.
 const runWhenIdle = (cb: () => void) => {
   if (typeof window === "undefined") return
   const w = window as Window & {
@@ -40,7 +38,6 @@ const runWhenIdle = (cb: () => void) => {
   }
 }
 
-// Purge stale caches/localStorage before React mounts so Jotai atoms read clean values.
 handleVersionUpgrade()
   .catch((error) => {
     console.error("Version upgrade failed; continuing app boot.", error)
@@ -48,9 +45,6 @@ handleVersionUpgrade()
   .finally(() => {
     initSyncListeners()
     prepareThemeLocalStorage(localStorage)
-
-    const posthogApiKey = import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN
-    const posthogHost = import.meta.env.VITE_PUBLIC_POSTHOG_HOST
 
     const app = (
       <ThemeProvider
@@ -61,22 +55,17 @@ handleVersionUpgrade()
         themes={["light", "dark", "system"]}
       >
         <QueryClientProvider client={queryClient}>
-          <ErrorBoundary
+          <AppErrorBoundary
             fallback={({ error, resetError }) => (
               <ErrorFallback
-                error={
-                  error instanceof Error
-                    ? error
-                    : new Error(String(error))
-                }
+                error={error}
                 resetErrorBoundary={resetError}
                 variant="page"
               />
             )}
-            showDialog={false}
           >
             <RouterProvider router={router} />
-          </ErrorBoundary>
+          </AppErrorBoundary>
           <Toaster />
           <Analytics />
         </QueryClientProvider>
@@ -84,25 +73,29 @@ handleVersionUpgrade()
     )
 
     createRoot(document.getElementById("root")!).render(
-      <StrictMode>
-        {posthogApiKey && posthogHost ? (
-          <PostHogProvider
-            apiKey={posthogApiKey}
-            options={{
-              api_host: posthogHost,
-              defaults: "2026-01-30",
-            }}
-          >
-            {app}
-          </PostHogProvider>
-        ) : (
-          app
-        )}
-      </StrictMode>,
+      <StrictMode>{app}</StrictMode>,
     )
 
     runWhenIdle(() => {
-      initSentry()
-      listenForSwUpdate()
+      void import("@/lib/sentry")
+        .then(({ initSentry }) => initSentry())
+        .catch(() => {})
+
+      const posthogApiKey = import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN
+      const posthogHost = import.meta.env.VITE_PUBLIC_POSTHOG_HOST
+      if (posthogApiKey && posthogHost) {
+        void import("posthog-js")
+          .then(({ default: posthog }) => {
+            posthog.init(posthogApiKey, {
+              api_host: posthogHost,
+              defaults: "2026-01-30",
+            })
+          })
+          .catch(() => {})
+      }
+
+      void import("@/lib/swReloadOnUpdate")
+        .then(({ listenForSwUpdate }) => listenForSwUpdate())
+        .catch(() => {})
     })
   })


### PR DESCRIPTION
## What

- New `AppErrorBoundary` component that dynamically imports `@sentry/react` **only on the error path** — happy path ships zero Sentry bytes.
- `initSentry()` is now a dynamic `import()` inside `runWhenIdle` (previously a static import, which pulled the whole SDK into the main chunk).
- `PostHogProvider` is gone from the root tree. `posthog-js` is initialized directly via a dynamic import in `runWhenIdle`, so autocapture + pageview tracking still work — just off the critical path.
- Admin `PostHogTestCaptureButton` now uses `posthog-js` directly instead of `usePostHog()`.
- Removed `@posthog/react` from dependencies (no longer used anywhere).

## Why

Continuing the perf work from #240 / T68. Post-merge Lighthouse bundle analysis showed two chunks still sitting on the cold-start critical path:

- `@sentry/core` + `@sentry/browser` + `@sentry/react` — ~110 KB raw / ~45 KB gzipped, with ~58 KB unused on first load.
- `posthog-js` — ~178 KB raw / ~62 KB gzipped, eagerly loaded via the React provider.

Neither of these needs to block first paint. Deferring them lifts **~75 KB gzipped** off the critical path, which should translate into a TBT/LCP improvement on throttled simulations.

## How

**Sentry — custom tiny error boundary** (`src/components/AppErrorBoundary.tsx`): 58-line class component. On `componentDidCatch`, it dynamically imports `@sentry/react` and calls `captureException(error, { contexts: { react: { componentStack } } })`. No Sentry code in the main bundle.

**Sentry — idle init**: `src/main.tsx` no longer statically imports `@/lib/sentry`. It's now `void import("@/lib/sentry").then(({ initSentry }) => initSentry())` inside `runWhenIdle`.

**PostHog — drop the React wrapper**: Only one component used `usePostHog()` (the admin test button). Swapped it to a direct `import posthog from "posthog-js"`. In `main.tsx`, after idle we do `import("posthog-js").then(({ default: posthog }) => posthog.init(apiKey, options))`. Autocapture + pageviews still flow because `posthog-js` installs its global hooks on `init()`.

**Build verification** (via `npm run build:analyze`):

- Main entry `index-*.js`: no `@sentry/*` or `posthog-js` code; only the dynamic `import()` call-sites.
- New chunks appear only after idle: `sentry-*.js` (~15 KB gz), `esm-*.js` Sentry core (~32 KB gz), `posthog-js` module (~60 KB gz).
- `tsc --noEmit`, `npm run lint`, `npm test` (965 passed), `npm run build` all green.

**Trade-off**: errors thrown during the first ~500 ms – 2 s of boot (before `requestIdleCallback` fires) will not reach Sentry. The boundary still renders the fallback UI, but the capture call lands on a not-yet-initialized SDK. This is the same trade-off already accepted for `initSentry` in the previous iteration — now extended to the boundary itself.

Refs #104, #240.

Made with [Cursor](https://cursor.com)