### PR TITLE
fix(cycle): self-heal orphan cycles on session start

### DIFF
--- a/src/lib/cycle.resolve.test.ts
+++ b/src/lib/cycle.resolve.test.ts
@@ -135,7 +135,8 @@ describe("resolveOrCreateActiveCycle", () => {
     })
   })
 
-  it("returns unavailable when genuinely offline (insert throws AND no orphan exists)", async () => {
+  it("returns unavailable with the thrown error's message when offline (insert throws AND no orphan)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
     mockSupabaseCycleCalls({
       selectResponses: [
         { data: null, error: null },
@@ -146,10 +147,16 @@ describe("resolveOrCreateActiveCycle", () => {
 
     const result = await resolveOrCreateActiveCycle("prog-1", "user-1")
 
-    expect(result).toEqual({ kind: "unavailable" })
+    expect(result).toEqual({ kind: "unavailable", reason: "Failed to fetch" })
+    expect(warn).toHaveBeenCalledWith(
+      "[cycle:insert] threw",
+      expect.any(Error),
+    )
+    warn.mockRestore()
   })
 
-  it("returns unavailable when insert fails with non-race error and no cycle appears on recheck", async () => {
+  it("returns unavailable with the supabase error message for non-race insert failures (e.g. RLS)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
     mockSupabaseCycleCalls({
       selectResponses: [
         { data: null, error: null },
@@ -157,16 +164,25 @@ describe("resolveOrCreateActiveCycle", () => {
       ],
       insertResult: {
         data: null,
-        error: { message: "RLS violation", code: "42501" },
+        error: { message: "new row violates row-level security policy", code: "42501" },
       },
     })
 
     const result = await resolveOrCreateActiveCycle("prog-1", "user-1")
 
-    expect(result).toEqual({ kind: "unavailable" })
+    expect(result).toEqual({
+      kind: "unavailable",
+      reason: "new row violates row-level security policy",
+    })
+    expect(warn).toHaveBeenCalledWith(
+      "[cycle:insert] failed",
+      expect.objectContaining({ code: "42501" }),
+    )
+    warn.mockRestore()
   })
 
   it("swallows a throw during the initial lookup and still creates a cycle", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
     mockSupabaseCycleCalls({
       selectResponses: [
         async () => {
@@ -183,6 +199,30 @@ describe("resolveOrCreateActiveCycle", () => {
       kind: "ok",
       cycleId: "new-after-read-fail",
       source: "created",
+    })
+    expect(warn).toHaveBeenCalledWith(
+      "[cycle:lookup] select threw",
+      expect.any(Error),
+    )
+    warn.mockRestore()
+  })
+
+  it("falls back to lookup-stage error message when insert didn't run (no insertError recorded)", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {})
+    mockSupabaseCycleCalls({
+      selectResponses: [
+        { data: null, error: { message: "initial lookup soft-failed" } },
+        { data: null, error: { message: "recheck also soft-failed" } },
+      ],
+      insertResult: new Error("insert blew up too"),
+    })
+
+    const result = await resolveOrCreateActiveCycle("prog-1", "user-1")
+
+    // insertError takes priority over lookup/recheck errors when present
+    expect(result).toEqual({
+      kind: "unavailable",
+      reason: "insert blew up too",
     })
   })
 })

--- a/src/lib/cycle.resolve.test.ts
+++ b/src/lib/cycle.resolve.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { resolveOrCreateActiveCycle } from "./cycle"
+import { supabase } from "@/lib/supabase"
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: vi.fn() },
+}))
+
+type SelectResult = { data: { id: string } | null; error: null | { message: string; code?: string } }
+type InsertResult = { data: { id: string } | null; error: null | { message: string; code?: string } }
+
+/**
+ * Builds a mock supabase client that services:
+ *  - `.from("cycles").select("id").eq(...).eq(...).is(...).maybeSingle()` (lookup)
+ *  - `.from("cycles").insert(...).select("id").single()` (create)
+ *
+ * `selectResponses` is a queue — each call pops the next one. Lets us assert
+ * behavior across the pre-insert lookup and the post-failure adoption re-query.
+ */
+function mockSupabaseCycleCalls(opts: {
+  selectResponses: Array<SelectResult | (() => Promise<SelectResult>) | (() => SelectResult)>
+  insertResult?: InsertResult | (() => Promise<InsertResult>) | (() => InsertResult) | Error
+}) {
+  const selectQueue = [...opts.selectResponses]
+
+  const selectChain = () => ({
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          is: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => {
+              const next = selectQueue.shift()
+              if (!next) throw new Error("No more mocked select responses")
+              return typeof next === "function" ? await next() : next
+            }),
+          })),
+        })),
+      })),
+    })),
+  })
+
+  const insertChain = () => ({
+    insert: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(async () => {
+          const r = opts.insertResult
+          if (r instanceof Error) throw r
+          if (typeof r === "function") return await r()
+          return r ?? { data: null, error: { message: "no insert configured" } }
+        }),
+      })),
+    })),
+  })
+
+  vi.mocked(supabase.from).mockImplementation(
+    () =>
+      ({
+        ...selectChain(),
+        ...insertChain(),
+      }) as never,
+  )
+}
+
+describe("resolveOrCreateActiveCycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns existing cycle without inserting when one is already open", async () => {
+    mockSupabaseCycleCalls({
+      selectResponses: [{ data: { id: "existing-cycle-1" }, error: null }],
+      insertResult: { data: null, error: { message: "should not be called" } },
+    })
+
+    const result = await resolveOrCreateActiveCycle("prog-1", "user-1")
+
+    expect(result).toEqual({
+      kind: "ok",
+      cycleId: "existing-cycle-1",
+      source: "existing",
+    })
+  })
+
+  it("creates a new cycle when none exists", async () => {
+    mockSupabaseCycleCalls({
+      selectResponses: [{ data: null, error: null }],
+      insertResult: { data: { id: "new-cycle-1" }, error: null },
+    })
+
+    const result = await resolveOrCreateActiveCycle("prog-1", "user-1")
+
+    expect(result).toEqual({
+      kind: "ok",
+      cycleId: "new-cycle-1",
+      source: "created",
+    })
+  })
+
+  it("adopts an orphan cycle when insert fails with 23505 (unique constraint race)", async () => {
+    mockSupabaseCycleCalls({
+      selectResponses: [
+        { data: null, error: null },
+        { data: { id: "orphan-cycle-1" }, error: null },
+      ],
+      insertResult: {
+        data: null,
+        error: { message: "duplicate key", code: "23505" },
+      },
+    })
+
+    const result = await resolveOrCreateActiveCycle("prog-1", "user-1")
+
+    expect(result).toEqual({
+      kind: "ok",
+      cycleId: "orphan-cycle-1",
+      source: "adopted",
+    })
+  })
+
+  it("adopts an orphan cycle when insert throws mid-flight (request committed, response dropped)", async () => {
+    mockSupabaseCycleCalls({
+      selectResponses: [
+        { data: null, error: null },
+        { data: { id: "orphan-cycle-2" }, error: null },
+      ],
+      insertResult: new Error("NetworkError when attempting to fetch resource"),
+    })
+
+    const result = await resolveOrCreateActiveCycle("prog-1", "user-1")
+
+    expect(result).toEqual({
+      kind: "ok",
+      cycleId: "orphan-cycle-2",
+      source: "adopted",
+    })
+  })
+
+  it("returns unavailable when genuinely offline (insert throws AND no orphan exists)", async () => {
+    mockSupabaseCycleCalls({
+      selectResponses: [
+        { data: null, error: null },
+        { data: null, error: null },
+      ],
+      insertResult: new Error("Failed to fetch"),
+    })
+
+    const result = await resolveOrCreateActiveCycle("prog-1", "user-1")
+
+    expect(result).toEqual({ kind: "unavailable" })
+  })
+
+  it("returns unavailable when insert fails with non-race error and no cycle appears on recheck", async () => {
+    mockSupabaseCycleCalls({
+      selectResponses: [
+        { data: null, error: null },
+        { data: null, error: null },
+      ],
+      insertResult: {
+        data: null,
+        error: { message: "RLS violation", code: "42501" },
+      },
+    })
+
+    const result = await resolveOrCreateActiveCycle("prog-1", "user-1")
+
+    expect(result).toEqual({ kind: "unavailable" })
+  })
+
+  it("swallows a throw during the initial lookup and still creates a cycle", async () => {
+    mockSupabaseCycleCalls({
+      selectResponses: [
+        async () => {
+          throw new Error("transient read failure")
+        },
+        { data: null, error: null },
+      ],
+      insertResult: { data: { id: "new-after-read-fail" }, error: null },
+    })
+
+    const result = await resolveOrCreateActiveCycle("prog-1", "user-1")
+
+    expect(result).toEqual({
+      kind: "ok",
+      cycleId: "new-after-read-fail",
+      source: "created",
+    })
+  })
+})

--- a/src/lib/cycle.ts
+++ b/src/lib/cycle.ts
@@ -1,3 +1,5 @@
+import { supabase } from "@/lib/supabase"
+
 /**
  * Derives the cycle ID to attach to a new session.
  * Quick workouts (skipCycle) must never be linked to an active cycle.
@@ -7,4 +9,62 @@ export function deriveCycleIdForSession(
   activeCycleId: string | null,
 ): string | null {
   return skipCycle ? null : (activeCycleId ?? null)
+}
+
+export type ResolveCycleResult =
+  | { kind: "ok"; cycleId: string; source: "existing" | "created" | "adopted" }
+  | { kind: "unavailable" }
+
+async function findOpenCycleId(
+  programId: string,
+  userId: string,
+): Promise<string | null> {
+  try {
+    const { data } = await supabase
+      .from("cycles")
+      .select("id")
+      .eq("program_id", programId)
+      .eq("user_id", userId)
+      .is("finished_at", null)
+      .maybeSingle()
+    return data?.id ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolves the active cycle for a program, creating one if needed.
+ *
+ * Why not just `insert`? The insert+select is not idempotent under flaky
+ * networks: if the request reaches the DB but the response never comes back,
+ * we get an orphan cycle (exists in DB, client doesn't know its id). The
+ * unique partial index `one_active_cycle_per_program` then blocks all future
+ * inserts with 23505. This helper self-heals by always re-querying for an
+ * open cycle before giving up, so orphans are adopted on the next call.
+ */
+export async function resolveOrCreateActiveCycle(
+  programId: string,
+  userId: string,
+): Promise<ResolveCycleResult> {
+  const existing = await findOpenCycleId(programId, userId)
+  if (existing) return { kind: "ok", cycleId: existing, source: "existing" }
+
+  try {
+    const { data, error } = await supabase
+      .from("cycles")
+      .insert({ program_id: programId, user_id: userId })
+      .select("id")
+      .single()
+    if (!error && data?.id) {
+      return { kind: "ok", cycleId: data.id, source: "created" }
+    }
+  } catch {
+    // Network blip or aborted request — fall through to self-heal.
+  }
+
+  const adopted = await findOpenCycleId(programId, userId)
+  if (adopted) return { kind: "ok", cycleId: adopted, source: "adopted" }
+
+  return { kind: "unavailable" }
 }

--- a/src/lib/cycle.ts
+++ b/src/lib/cycle.ts
@@ -13,24 +13,40 @@ export function deriveCycleIdForSession(
 
 export type ResolveCycleResult =
   | { kind: "ok"; cycleId: string; source: "existing" | "created" | "adopted" }
-  | { kind: "unavailable" }
+  | { kind: "unavailable"; reason: string }
 
 async function findOpenCycleId(
   programId: string,
   userId: string,
-): Promise<string | null> {
+  stage: "lookup" | "recheck",
+): Promise<{ id: string | null; error?: unknown }> {
   try {
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from("cycles")
       .select("id")
       .eq("program_id", programId)
       .eq("user_id", userId)
       .is("finished_at", null)
       .maybeSingle()
-    return data?.id ?? null
-  } catch {
-    return null
+    if (error) {
+      console.warn(`[cycle:${stage}] select failed`, error)
+      return { id: null, error }
+    }
+    return { id: data?.id ?? null }
+  } catch (e) {
+    console.warn(`[cycle:${stage}] select threw`, e)
+    return { id: null, error: e }
   }
+}
+
+function describeError(e: unknown): string {
+  if (!e) return "unknown"
+  if (typeof e === "string") return e
+  if (e instanceof Error) return e.message
+  if (typeof e === "object" && "message" in e) {
+    return String((e as { message: unknown }).message)
+  }
+  return "unknown"
 }
 
 /**
@@ -42,14 +58,21 @@ async function findOpenCycleId(
  * unique partial index `one_active_cycle_per_program` then blocks all future
  * inserts with 23505. This helper self-heals by always re-querying for an
  * open cycle before giving up, so orphans are adopted on the next call.
+ *
+ * On `unavailable`, `reason` carries the last error message seen (select or
+ * insert) so callers can surface it for diagnostics. All failures are also
+ * logged here with their full error object so RLS/5xx/etc. are debuggable.
  */
 export async function resolveOrCreateActiveCycle(
   programId: string,
   userId: string,
 ): Promise<ResolveCycleResult> {
-  const existing = await findOpenCycleId(programId, userId)
-  if (existing) return { kind: "ok", cycleId: existing, source: "existing" }
+  const existing = await findOpenCycleId(programId, userId, "lookup")
+  if (existing.id) {
+    return { kind: "ok", cycleId: existing.id, source: "existing" }
+  }
 
+  let insertError: unknown = undefined
   try {
     const { data, error } = await supabase
       .from("cycles")
@@ -59,12 +82,18 @@ export async function resolveOrCreateActiveCycle(
     if (!error && data?.id) {
       return { kind: "ok", cycleId: data.id, source: "created" }
     }
-  } catch {
-    // Network blip or aborted request — fall through to self-heal.
+    if (error) {
+      insertError = error
+      console.warn("[cycle:insert] failed", error)
+    }
+  } catch (e) {
+    insertError = e
+    console.warn("[cycle:insert] threw", e)
   }
 
-  const adopted = await findOpenCycleId(programId, userId)
-  if (adopted) return { kind: "ok", cycleId: adopted, source: "adopted" }
+  const adopted = await findOpenCycleId(programId, userId, "recheck")
+  if (adopted.id) return { kind: "ok", cycleId: adopted.id, source: "adopted" }
 
-  return { kind: "unavailable" }
+  const reason = describeError(insertError ?? adopted.error ?? existing.error)
+  return { kind: "unavailable", reason }
 }

--- a/src/lib/session.cycle.test.ts
+++ b/src/lib/session.cycle.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { deriveCycleIdForSession } from "./cycle"
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: vi.fn() },
+}))
 
 describe("deriveCycleIdForSession", () => {
   it("returns the active cycle id for normal sessions", () => {

--- a/src/locales/en/workout.json
+++ b/src/locales/en/workout.json
@@ -166,7 +166,7 @@
   "progression.tryGenerator": "Try the AI program generator for a new cycle",
   "autoDetectLoading": "{{name}}: you logged weight — unlock weight progression?",
   "autoDetectLoadingAction": "Unlock",
-  "cycleUnavailable": "Couldn't start the cycle — flaky network. Your session is starting anyway.",
+  "cycleUnavailable": "Couldn't start the cycle right now — your session will still be saved.",
   "historySheet.trendHintBodyweight": "Log this exercise on more days to see your best reps trend.",
   "historySheet.chartCaptionReps": "Best reps per session",
   "historySheet.chartAriaReps": "Reps trend from {{min}} to {{max}} across recent sessions",

--- a/src/locales/en/workout.json
+++ b/src/locales/en/workout.json
@@ -166,6 +166,7 @@
   "progression.tryGenerator": "Try the AI program generator for a new cycle",
   "autoDetectLoading": "{{name}}: you logged weight — unlock weight progression?",
   "autoDetectLoadingAction": "Unlock",
+  "cycleUnavailable": "Couldn't start the cycle — flaky network. Your session is starting anyway.",
   "historySheet.trendHintBodyweight": "Log this exercise on more days to see your best reps trend.",
   "historySheet.chartCaptionReps": "Best reps per session",
   "historySheet.chartAriaReps": "Reps trend from {{min}} to {{max}} across recent sessions",

--- a/src/locales/fr/workout.json
+++ b/src/locales/fr/workout.json
@@ -170,7 +170,7 @@
   "historySheet.repsInfoBody": "Cette courbe montre votre meilleur nombre de répétitions par séance — le plus grand nombre de reps enregistré sur une série lors de cette séance.\n\nPour les exercices au poids du corps, suivre les reps max est un indicateur de progrès plus pertinent que le 1RM estimé.",
   "autoDetectLoading": "{{name}} : poids ajouté — débloquer la progression de charge ?",
   "autoDetectLoadingAction": "Débloquer",
-  "cycleUnavailable": "Impossible de démarrer le cycle — réseau instable. Votre séance démarre quand même.",
+  "cycleUnavailable": "Impossible de démarrer le cycle — la séance sera quand même enregistrée.",
   "historySheet.epleyInfoLabel": "Qu’est-ce que le 1RM estimé ?",
   "historySheet.epleyInfoTitle": "1RM estimé (formule d’Epley)",
   "historySheet.epleyInfoBody": "Cette courbe montre votre meilleur 1RM estimé par séance — la charge que vous pourriez probablement soulever une seule fois, déduite de ce que vous avez réellement enregistré (poids × répétitions).\n\nNous utilisons la formule d’Epley, très répandue en musculation. Ce n’est pas une mesure de laboratoire, mais ça aide à comparer les séances quand vous chargez plus lourd ou faites moins de répétitions."

--- a/src/locales/fr/workout.json
+++ b/src/locales/fr/workout.json
@@ -170,6 +170,7 @@
   "historySheet.repsInfoBody": "Cette courbe montre votre meilleur nombre de répétitions par séance — le plus grand nombre de reps enregistré sur une série lors de cette séance.\n\nPour les exercices au poids du corps, suivre les reps max est un indicateur de progrès plus pertinent que le 1RM estimé.",
   "autoDetectLoading": "{{name}} : poids ajouté — débloquer la progression de charge ?",
   "autoDetectLoadingAction": "Débloquer",
+  "cycleUnavailable": "Impossible de démarrer le cycle — réseau instable. Votre séance démarre quand même.",
   "historySheet.epleyInfoLabel": "Qu’est-ce que le 1RM estimé ?",
   "historySheet.epleyInfoTitle": "1RM estimé (formule d’Epley)",
   "historySheet.epleyInfoBody": "Cette courbe montre votre meilleur 1RM estimé par séance — la charge que vous pourriez probablement soulever une seule fois, déduite de ce que vous avez réellement enregistré (poids × répétitions).\n\nNous utilisons la formule d’Epley, très répandue en musculation. Ce n’est pas une mesure de laboratoire, mais ça aide à comparer les séances quand vous chargez plus lourd ou faites moins de répétitions."

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -862,13 +862,17 @@ export function WorkoutPage() {
       const result = await resolveOrCreateActiveCycle(activeProgramId, user.id)
       if (result.kind === "ok") {
         cycleId = result.cycleId
-        if (result.source !== "existing") {
-          queryClient.invalidateQueries({
-            queryKey: ["active-cycle", activeProgramId],
-          })
-        }
+        // Always invalidate: the React Query cache may be stale (e.g. another
+        // tab created the cycle after our last fetch) even when source is
+        // "existing". Without this, useActiveCycle can stay stuck on null.
+        queryClient.invalidateQueries({
+          queryKey: ["active-cycle", activeProgramId],
+        })
       } else {
-        console.warn("[WorkoutPage] Could not resolve/create active cycle")
+        console.warn(
+          "[WorkoutPage] Could not resolve/create active cycle:",
+          result.reason,
+        )
         toast.warning(t("cycleUnavailable"))
       }
     }

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -37,7 +37,7 @@ import { enqueueSessionFinish, scheduleImmediateDrain, type ProgressionTarget } 
 import { computeNextSessionTarget, resolveWeightIncrement, type ProgressionPrescription, type SetPerformance, type VolumePrescription } from "@/lib/progression"
 import { getEffectiveElapsed } from "@/lib/session"
 import { supabase } from "@/lib/supabase"
-import { deriveCycleIdForSession } from "@/lib/cycle"
+import { deriveCycleIdForSession, resolveOrCreateActiveCycle } from "@/lib/cycle"
 import { prefetchBestPerformance } from "@/hooks/useBestPerformance"
 import { useExerciseBatch } from "@/hooks/useExerciseBatch"
 import { useLastSessionForDay } from "@/hooks/useLastSessionForDay"
@@ -859,26 +859,17 @@ export function WorkoutPage() {
     let cycleId = deriveCycleIdForSession(skipCycle, activeCycle?.id ?? null)
 
     if (!cycleId && activeProgramId && user && !skipCycle) {
-      try {
-        const { data, error } = await supabase
-          .from("cycles")
-          .insert({ program_id: activeProgramId, user_id: user.id })
-          .select()
-          .single()
-
-        if (error?.code === "23505") {
-          // Unique constraint race — another tab created one; refetch
-          await queryClient.invalidateQueries({ queryKey: ["active-cycle", activeProgramId] })
-          const refetched = queryClient.getQueryData<{ id: string } | null>(["active-cycle", activeProgramId])
-          cycleId = refetched?.id ?? null
-        } else if (error) {
-          console.warn("[WorkoutPage] Could not create cycle:", error.message)
-        } else {
-          cycleId = data.id
-          queryClient.invalidateQueries({ queryKey: ["active-cycle", activeProgramId] })
+      const result = await resolveOrCreateActiveCycle(activeProgramId, user.id)
+      if (result.kind === "ok") {
+        cycleId = result.cycleId
+        if (result.source !== "existing") {
+          queryClient.invalidateQueries({
+            queryKey: ["active-cycle", activeProgramId],
+          })
         }
-      } catch {
-        // Offline — start without cycle
+      } else {
+        console.warn("[WorkoutPage] Could not resolve/create active cycle")
+        toast.warning(t("cycleUnavailable"))
       }
     }
 


### PR DESCRIPTION
## What

- New `resolveOrCreateActiveCycle(programId, userId)` helper in `src/lib/cycle.ts` that looks up an existing open cycle first, inserts only if none exists, and re-queries on any insert failure to adopt whatever landed.
- `WorkoutPage.startSession` now uses the helper and surfaces a toast (`workout.cycleUnavailable`) when it genuinely can't link a cycle, instead of silently starting with `cycle_id = null`.
- 7 new unit tests covering: existing reuse, fresh create, 23505 race adoption, mid-flight throw adoption, truly-offline fallback, non-race supabase error, transient read-failure recovery.

## Why

If the cycle insert request committed on the server but the response never reached the client (flaky mobile, dropped fetch, aborted tab), we ended up with:

- an orphan cycle row (`finished_at = null`) in the DB,
- a session persisted with `cycle_id = null`,
- the unique partial index `one_active_cycle_per_program` blocking every future `startSession` with 23505.

Net effect for the user: header stuck at `0/N` after a completed session, no way forward.

The previous code made this worse: the `catch {}` silently absorbed thrown fetches (`// Offline — start without cycle`), and the 23505 recovery used `getQueryData` right after `invalidateQueries`, which returns the stale cached value when the query isn't foreground-refetching.

## How

`resolveOrCreateActiveCycle` turns the operation into idempotent "find or create":

1. `SELECT … WHERE finished_at IS NULL` first — if a cycle is already open, adopt it. No insert attempt.
2. Otherwise `INSERT`.
3. On any insert failure (23505 race, thrown fetch, other supabase error) re-`SELECT` and adopt whatever exists now. This swallows orphans on the next call.
4. Only return `{ kind: \"unavailable\" }` when we've confirmed nothing exists and truly can't create — the toast fires, session still starts so offline PWA behavior is preserved.

Nested `try/catch` is intentional: a transient failure on the initial read falls through to the create path instead of killing the whole flow.

### Data patch for the currently-affected user

\`\`\`sql
UPDATE sessions
SET cycle_id = '791eefbe-f121-469b-9bdc-1c19a5ccaaea'
WHERE id = 'dc78d9b1-e0d8-4ebd-b283-bee92226ea2a';
\`\`\`

Closes #249

Made with [Cursor](https://cursor.com)