### PR TITLE
perf(exercises): kill N+1 queries + slim catalog payload (T69)

### DIFF
--- a/src/components/generator/ExerciseAddPicker.tsx
+++ b/src/components/generator/ExerciseAddPicker.tsx
@@ -5,12 +5,12 @@ import { cn, groupBy } from "@/lib/utils"
 import { normalizeForSearch } from "@/lib/search"
 import { Input } from "@/components/ui/input"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
-import type { Exercise } from "@/types/database"
+import type { ExerciseListItem } from "@/types/database"
 
 interface ExerciseAddPickerProps {
-  pool: Exercise[]
+  pool: ExerciseListItem[]
   currentExerciseIds: string[]
-  onSelect: (exercise: Exercise) => void
+  onSelect: (exercise: ExerciseListItem) => void
   onClose: () => void
 }
 

--- a/src/components/generator/ExerciseSwapPicker.tsx
+++ b/src/components/generator/ExerciseSwapPicker.tsx
@@ -2,14 +2,15 @@ import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Info } from "lucide-react"
 import { ExerciseDetailSheet } from "@/components/generator/ExerciseDetailSheet"
+import { useExerciseById } from "@/hooks/useExerciseById"
 import { cn } from "@/lib/utils"
-import type { Exercise } from "@/types/database"
+import type { ExerciseListItem } from "@/types/database"
 
 interface ExerciseSwapPickerProps {
-  pool: Exercise[]
+  pool: ExerciseListItem[]
   currentExerciseIds: string[]
   muscleGroup: string
-  onSelect: (exercise: Exercise) => void
+  onSelect: (exercise: ExerciseListItem) => void
   onClose: () => void
 }
 
@@ -21,7 +22,11 @@ export function ExerciseSwapPicker({
   onClose,
 }: ExerciseSwapPickerProps) {
   const { t } = useTranslation("generator")
-  const [inspectedExercise, setInspectedExercise] = useState<Exercise | null>(null)
+  const [inspectedExerciseId, setInspectedExerciseId] = useState<string | null>(null)
+  // Rich fields (instructions/youtube) deferred until the user opens the info
+  // sheet. Hits the per-id cache seeded by `useWorkoutExercises` when the
+  // exercise is in the current day — otherwise fires a single `select(*)`.
+  const { data: inspectedExercise } = useExerciseById(inspectedExerciseId)
 
   const candidates = useMemo(
     () =>
@@ -65,7 +70,7 @@ export function ExerciseSwapPicker({
               </button>
               <button
                 type="button"
-                onClick={() => setInspectedExercise(exercise)}
+                onClick={() => setInspectedExerciseId(exercise.id)}
                 className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                 aria-label={t("exerciseInfo", "View details")}
               >
@@ -76,10 +81,10 @@ export function ExerciseSwapPicker({
         </div>
       )}
       <ExerciseDetailSheet
-        exercise={inspectedExercise}
-        open={!!inspectedExercise}
+        exercise={inspectedExercise ?? null}
+        open={!!inspectedExerciseId}
         onOpenChange={(v) => {
-          if (!v) setInspectedExercise(null)
+          if (!v) setInspectedExerciseId(null)
         }}
       />
     </div>

--- a/src/components/generator/PreviewStep.test.tsx
+++ b/src/components/generator/PreviewStep.test.tsx
@@ -2,9 +2,16 @@ import { describe, it, expect, vi } from "vitest"
 import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { renderWithProviders } from "@/test/utils"
-import { PreviewStep } from "./PreviewStep"
 import type { Exercise } from "@/types/database"
 import type { GeneratedExercise, GeneratedWorkout } from "@/types/generator"
+
+// Stub the hook to avoid pulling `@/lib/supabase` (which needs real env vars)
+// via the InspectedExerciseSheet import chain.
+vi.mock("@/hooks/useExerciseById", () => ({
+  useExerciseById: () => ({ data: null, isLoading: false }),
+}))
+
+import { PreviewStep } from "./PreviewStep"
 
 function fakeExercise(overrides: Partial<Exercise> & { id: string }): Exercise {
   return {

--- a/src/components/generator/PreviewStep.tsx
+++ b/src/components/generator/PreviewStep.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useMemo } from "react"
+import { useState, useCallback, useRef, useMemo, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { RefreshCw, ArrowLeft, Plus, Bookmark } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -48,7 +48,12 @@ export function PreviewStep({
   const [name, setName] = useState(workout.name)
   const [swappingIndex, setSwappingIndex] = useState<number | null>(null)
   const [addingExercise, setAddingExercise] = useState(false)
-  const [inspectedIndex, setInspectedIndex] = useState<number | null>(null)
+  // Track inspected exercise by id, not index — list can mutate (remove/shuffle)
+  // between click and render, and an out-of-bounds index would open a sheet
+  // with no dismissable content.
+  const [inspectedExerciseId, setInspectedExerciseId] = useState<string | null>(
+    null,
+  )
   const lastShuffleRef = useRef(0)
 
   const handleRemove = useCallback((index: number) => {
@@ -226,7 +231,9 @@ export function PreviewStep({
               index={index}
               onRemove={handleRemove}
               onSwap={handleSwap}
-              onInfo={setInspectedIndex}
+              onInfo={(idx) =>
+                setInspectedExerciseId(exercises[idx]?.exercise.id ?? null)
+              }
               onUpdateSets={handleUpdateSets}
               onUpdateReps={handleUpdateReps}
             />
@@ -265,13 +272,8 @@ export function PreviewStep({
       </div>
 
       <InspectedExerciseSheet
-        exerciseId={
-          inspectedIndex !== null
-            ? exercises[inspectedIndex]?.exercise.id ?? null
-            : null
-        }
-        open={inspectedIndex !== null}
-        onClose={() => setInspectedIndex(null)}
+        exerciseId={inspectedExerciseId}
+        onClose={() => setInspectedExerciseId(null)}
       />
     </div>
   )
@@ -281,21 +283,31 @@ export function PreviewStep({
  * Thin wrapper that lazily fetches the full Exercise row (instructions,
  * youtube_url, secondary_muscles) only when the user opens the detail sheet.
  * Hits the per-id cache seeded by `useWorkoutExercises` when applicable.
+ *
+ * Open is derived from id + resolved data to avoid a dangling sheet when the
+ * referenced exercise is unreachable (orphan FK, RLS filter). If the query
+ * resolves to null, we clear the id so the parent state stays consistent.
  */
 function InspectedExerciseSheet({
   exerciseId,
-  open,
   onClose,
 }: {
   exerciseId: string | null
-  open: boolean
   onClose: () => void
 }) {
-  const { data: exercise } = useExerciseById(exerciseId)
+  const { data: exercise, isPending } = useExerciseById(exerciseId)
+
+  useEffect(() => {
+    if (exerciseId && !isPending && exercise === null) {
+      onClose()
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reflect unreachable-exercise async result into parent id state; no safer place to run this.
+  }, [exerciseId, isPending, exercise, onClose])
+
   return (
     <ExerciseDetailSheet
       exercise={exercise ?? null}
-      open={open}
+      open={!!exerciseId && !!exercise}
       onOpenChange={(v) => {
         if (!v) onClose()
       }}

--- a/src/components/generator/PreviewStep.tsx
+++ b/src/components/generator/PreviewStep.tsx
@@ -8,7 +8,8 @@ import { PreviewExerciseCard } from "./PreviewExerciseCard"
 import { ExerciseSwapPicker } from "./ExerciseSwapPicker"
 import { ExerciseAddPicker } from "./ExerciseAddPicker"
 import { ExerciseDetailSheet } from "./ExerciseDetailSheet"
-import type { Exercise } from "@/types/database"
+import { useExerciseById } from "@/hooks/useExerciseById"
+import type { ExerciseListItem } from "@/types/database"
 import type { GeneratedExercise, GeneratedWorkout } from "@/types/generator"
 import {
   COMPOUND_REPS,
@@ -21,7 +22,7 @@ import { SessionHeatmap } from "@/components/body-map/SessionHeatmap"
 
 interface PreviewStepProps {
   workout: GeneratedWorkout
-  exercisePool: Exercise[]
+  exercisePool: ExerciseListItem[]
   onStart: (workout: GeneratedWorkout) => void
   onSave: (workout: GeneratedWorkout) => void
   onShuffle: () => void
@@ -59,7 +60,7 @@ export function PreviewStep({
   }, [])
 
   const handleSwapSelect = useCallback(
-    (exercise: Exercise) => {
+    (exercise: ExerciseListItem) => {
       if (swappingIndex === null) return
       setExercises((prev) =>
         prev.map((ge, i) => {
@@ -101,7 +102,7 @@ export function PreviewStep({
   }, [onShuffle])
 
   const handleAddExercise = useCallback(
-    (exercise: Exercise) => {
+    (exercise: ExerciseListItem) => {
       const compound = (exercise.secondary_muscles?.length ?? 0) > 0
       setExercises((prev) => {
         const defaultSets = prev[0]?.sets ?? 3
@@ -263,17 +264,41 @@ export function PreviewStep({
         )}
       </div>
 
-      <ExerciseDetailSheet
-        exercise={
+      <InspectedExerciseSheet
+        exerciseId={
           inspectedIndex !== null
-            ? exercises[inspectedIndex]?.exercise ?? null
+            ? exercises[inspectedIndex]?.exercise.id ?? null
             : null
         }
         open={inspectedIndex !== null}
-        onOpenChange={(open) => {
-          if (!open) setInspectedIndex(null)
-        }}
+        onClose={() => setInspectedIndex(null)}
       />
     </div>
+  )
+}
+
+/**
+ * Thin wrapper that lazily fetches the full Exercise row (instructions,
+ * youtube_url, secondary_muscles) only when the user opens the detail sheet.
+ * Hits the per-id cache seeded by `useWorkoutExercises` when applicable.
+ */
+function InspectedExerciseSheet({
+  exerciseId,
+  open,
+  onClose,
+}: {
+  exerciseId: string | null
+  open: boolean
+  onClose: () => void
+}) {
+  const { data: exercise } = useExerciseById(exerciseId)
+  return (
+    <ExerciseDetailSheet
+      exercise={exercise ?? null}
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) onClose()
+      }}
+    />
   )
 }

--- a/src/components/workout/ExerciseDetail.tsx
+++ b/src/components/workout/ExerciseDetail.tsx
@@ -22,7 +22,7 @@ import { useLastSession } from "@/hooks/useLastSession"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 import { useExerciseFromLibrary } from "@/hooks/useExerciseFromLibrary"
 import { useProgressionSuggestion } from "@/hooks/useProgressionSuggestion"
-import type { Exercise, WorkoutExercise } from "@/types/database"
+import type { ExerciseListItem, WorkoutExercise } from "@/types/database"
 import { ExerciseInstructionsPanel } from "@/components/exercise/ExerciseInstructionsPanel"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
 import { AdminOnly } from "@/components/admin/AdminOnly"
@@ -34,10 +34,10 @@ import { ExerciseHistorySheet } from "@/components/workout/ExerciseHistorySheet"
 import { ProgressionPill } from "@/components/workout/ProgressionPill"
 
 export interface ExerciseDetailEditSessionProps {
-  exercisePool: Exercise[]
+  exercisePool: ExerciseListItem[]
   poolLoading: boolean
   allExercises: WorkoutExercise[]
-  onSwapExerciseChosen: (row: WorkoutExercise, picked: Exercise) => void
+  onSwapExerciseChosen: (row: WorkoutExercise, picked: ExerciseListItem) => void
   onDeleteRequested: (row: WorkoutExercise) => void
   onSwapBrowseLibrary: (row: WorkoutExercise) => void
 }

--- a/src/components/workout/ExerciseEditRowControls.tsx
+++ b/src/components/workout/ExerciseEditRowControls.tsx
@@ -12,14 +12,14 @@ import {
 import { ExerciseSwapInlinePanel } from "@/components/workout/ExerciseSwapInlinePanel"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 import { formatDurationShort } from "@/lib/formatters"
-import type { Exercise, WorkoutExercise } from "@/types/database"
+import type { ExerciseListItem, WorkoutExercise } from "@/types/database"
 
 export interface ExerciseEditRowControlsProps {
   exercise: WorkoutExercise
-  exercisePool: Exercise[]
+  exercisePool: ExerciseListItem[]
   poolLoading: boolean
   currentExerciseIds: string[]
-  onSwapExerciseChosen: (row: WorkoutExercise, picked: Exercise) => void
+  onSwapExerciseChosen: (row: WorkoutExercise, picked: ExerciseListItem) => void
   onDeleteRequested: (row: WorkoutExercise) => void
   onSwapBrowseLibrary: (row: WorkoutExercise) => void
   onInspectDetails: (exerciseId: string) => void

--- a/src/components/workout/ExerciseSwapInlinePanel.test.tsx
+++ b/src/components/workout/ExerciseSwapInlinePanel.test.tsx
@@ -2,8 +2,15 @@ import { describe, it, expect, vi } from "vitest"
 import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { renderWithProviders } from "@/test/utils"
-import { ExerciseSwapInlinePanel } from "./ExerciseSwapInlinePanel"
 import type { Exercise, WorkoutExercise } from "@/types/database"
+
+// Stub the hook to avoid pulling `@/lib/supabase` (which needs real env vars)
+// via the ExerciseSwapPicker → inspection-sheet import chain.
+vi.mock("@/hooks/useExerciseById", () => ({
+  useExerciseById: () => ({ data: null, isLoading: false }),
+}))
+
+import { ExerciseSwapInlinePanel } from "./ExerciseSwapInlinePanel"
 
 function fakeExercise(overrides: Partial<Exercise> & { id: string }): Exercise {
   return {

--- a/src/components/workout/ExerciseSwapInlinePanel.tsx
+++ b/src/components/workout/ExerciseSwapInlinePanel.tsx
@@ -2,13 +2,13 @@ import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ExerciseSwapPicker } from "@/components/generator/ExerciseSwapPicker"
-import type { Exercise, WorkoutExercise } from "@/types/database"
+import type { ExerciseListItem, WorkoutExercise } from "@/types/database"
 
 export interface ExerciseSwapInlinePanelProps {
   exercise: WorkoutExercise
-  exercisePool: Exercise[]
+  exercisePool: ExerciseListItem[]
   currentExerciseIds: string[]
-  onSwapExerciseChosen: (row: WorkoutExercise, picked: Exercise) => void
+  onSwapExerciseChosen: (row: WorkoutExercise, picked: ExerciseListItem) => void
   onSwapBrowseLibrary: (row: WorkoutExercise) => void
   onDismiss: () => void
   /** Extra class on outer wrapper (e.g. pre-session list indent). */

--- a/src/components/workout/PreSessionExerciseList.tsx
+++ b/src/components/workout/PreSessionExerciseList.tsx
@@ -2,13 +2,14 @@ import { useTranslation } from "react-i18next"
 import { Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ExerciseEditRowControls } from "@/components/workout/ExerciseEditRowControls"
-import type { Exercise, WorkoutExercise } from "@/types/database"
+import type { ExerciseListItem, WorkoutExercise } from "@/types/database"
 
 export interface PreSessionExerciseListProps {
   exercises: WorkoutExercise[]
-  exercisePool: Exercise[]
+  /** Slim pool from `useExerciseLibrary` — rich fields (instructions/youtube) are fetched on demand in inspect sheets. */
+  exercisePool: ExerciseListItem[]
   poolLoading: boolean
-  onSwapExerciseChosen: (row: WorkoutExercise, picked: Exercise) => void
+  onSwapExerciseChosen: (row: WorkoutExercise, picked: ExerciseListItem) => void
   onDeleteRequested: (row: WorkoutExercise) => void
   onSwapBrowseLibrary: (row: WorkoutExercise) => void
   onRequestAddExerciseSheet: () => void

--- a/src/hooks/useAIGenerateProgram.ts
+++ b/src/hooks/useAIGenerateProgram.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query"
 import { supabase } from "@/lib/supabase"
+import { SLIM_EXERCISE_SELECT } from "@/lib/exerciseSelects"
 import { buildExercise } from "@/lib/generateWorkout"
 import { VOLUME_MAP } from "@/lib/generatorConfig"
 import type { ExerciseListItem } from "@/types/database"
@@ -82,12 +83,10 @@ export function useAIGenerateProgram({ exercisePool }: AIGenerateProgramContext)
 
       if (missingIds.length > 0) {
         // Fallback for ids the slim pool didn't have (rare: newly added exercise
-        // not yet in `exercise-library` cache). Select the same slim shape.
+        // not yet in `exercise-library` cache). Reuses the shared slim select.
         const { data: fetched, error: fetchError } = await supabase
           .from("exercises")
-          .select(
-            "id, name, name_en, emoji, muscle_group, equipment, image_url, difficulty_level, is_system, measurement_type, default_duration_seconds, secondary_muscles",
-          )
+          .select(SLIM_EXERCISE_SELECT)
           .in("id", missingIds)
 
         if (fetchError) throw fetchError

--- a/src/hooks/useAIGenerateProgram.ts
+++ b/src/hooks/useAIGenerateProgram.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query"
 import { supabase } from "@/lib/supabase"
 import { buildExercise } from "@/lib/generateWorkout"
 import { VOLUME_MAP } from "@/lib/generatorConfig"
-import type { Exercise } from "@/types/database"
+import type { ExerciseListItem } from "@/types/database"
 import type { Duration } from "@/types/generator"
 import type {
   GenerateProgramConstraints,
@@ -23,7 +23,10 @@ interface EdgeFunctionResponse {
 }
 
 interface AIGenerateProgramContext {
-  exercisePool: Exercise[]
+  // Slim catalog is sufficient — the generator only reads id + secondary_muscles
+  // (via `buildExercise` / `isCompound`); rich fields (instructions, etc.) are
+  // never consumed in the AI program flow.
+  exercisePool: ExerciseListItem[]
 }
 
 function isNetworkError(err: unknown): boolean {
@@ -65,7 +68,7 @@ export function useAIGenerateProgram({ exercisePool }: AIGenerateProgramContext)
       }
 
       const poolMap = new Map(exercisePool.map((e) => [e.id, e]))
-      const resolved = new Map<string, Exercise>()
+      const resolved = new Map<string, ExerciseListItem>()
       const missingIds: string[] = []
 
       for (const id of allIds) {
@@ -78,13 +81,17 @@ export function useAIGenerateProgram({ exercisePool }: AIGenerateProgramContext)
       }
 
       if (missingIds.length > 0) {
+        // Fallback for ids the slim pool didn't have (rare: newly added exercise
+        // not yet in `exercise-library` cache). Select the same slim shape.
         const { data: fetched, error: fetchError } = await supabase
           .from("exercises")
-          .select("*")
+          .select(
+            "id, name, name_en, emoji, muscle_group, equipment, image_url, difficulty_level, is_system, measurement_type, default_duration_seconds, secondary_muscles",
+          )
           .in("id", missingIds)
 
         if (fetchError) throw fetchError
-        for (const ex of (fetched ?? []) as Exercise[]) {
+        for (const ex of (fetched ?? []) as unknown as ExerciseListItem[]) {
           resolved.set(ex.id, ex)
         }
       }
@@ -103,7 +110,7 @@ export function useAIGenerateProgram({ exercisePool }: AIGenerateProgramContext)
           muscleFocus: day.muscle_focus,
           exercises: day.exercise_ids
             .map((id) => resolved.get(id))
-            .filter((ex): ex is Exercise => ex != null)
+            .filter((ex): ex is ExerciseListItem => ex != null)
             .map((ex) => buildExercise(ex, setsPerExercise)),
         }
       })

--- a/src/hooks/useBuilderMutations.ts
+++ b/src/hooks/useBuilderMutations.ts
@@ -2,7 +2,12 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
 import { supabase } from "@/lib/supabase"
 import { authAtom } from "@/store/atoms"
-import type { Exercise, WorkoutDay, WorkoutExercise } from "@/types/database"
+import type {
+  Exercise,
+  ExerciseListItem,
+  WorkoutDay,
+  WorkoutExercise,
+} from "@/types/database"
 
 export function useCreateDay(programId: string | null) {
   const user = useAtomValue(authAtom)
@@ -91,7 +96,7 @@ export function useAddExerciseToDay() {
       weight = "0",
     }: {
       dayId: string
-      exercise: Exercise
+      exercise: ExerciseListItem
       sortOrder: number
       weight?: string
     }) => {
@@ -243,7 +248,7 @@ export function useSwapExerciseInDay() {
     mutationFn: async (vars: {
       id: string
       dayId: string
-      exercise: Exercise
+      exercise: ExerciseListItem
       weight: string
     }) => {
       const { error } = await supabase

--- a/src/hooks/useExerciseLibrary.ts
+++ b/src/hooks/useExerciseLibrary.ts
@@ -1,25 +1,17 @@
 import { useQuery } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
 import { supabase } from "@/lib/supabase"
+import { SLIM_EXERCISE_SELECT } from "@/lib/exerciseSelects"
 import { authAtom } from "@/store/atoms"
 import type { ExerciseListItem } from "@/types/database"
 
 const STALE_MS = 1000 * 60 * 30
 
 /**
- * Slim catalog fetch for lookup/map use cases (e.g. hydrating session-side
- * `exerciseById` or the AI-generation pool is NOT a caller — see T69).
- *
- * Enumerated columns instead of `*` to avoid shipping rich fields (JSONB
- * `instructions`, `youtube_url`, `source`, `reviewed_*`) in the hot path.
- * Rich fields are fetched per-id via `useExerciseById` as needed.
- *
- * `measurement_type` + `default_duration_seconds` are kept because the
- * active-session pool uses them for duration-vs-reps branching.
+ * Slim catalog fetch for lookup/map use cases. Uses the shared
+ * `SLIM_EXERCISE_SELECT` — rich fields like `instructions`/`youtube_url`
+ * are fetched on demand via `useExerciseById`.
  */
-const SLIM_SELECT =
-  "id, name, name_en, emoji, muscle_group, equipment, image_url, difficulty_level, is_system, measurement_type, default_duration_seconds, secondary_muscles"
-
 export function useExerciseLibrary() {
   const user = useAtomValue(authAtom)
 
@@ -28,7 +20,7 @@ export function useExerciseLibrary() {
     queryFn: async (): Promise<ExerciseListItem[]> => {
       const { data, error } = await supabase
         .from("exercises")
-        .select(SLIM_SELECT)
+        .select(SLIM_EXERCISE_SELECT)
         .order("muscle_group")
         .order("name")
 

--- a/src/hooks/useExerciseLibrary.ts
+++ b/src/hooks/useExerciseLibrary.ts
@@ -2,24 +2,38 @@ import { useQuery } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
 import { supabase } from "@/lib/supabase"
 import { authAtom } from "@/store/atoms"
-import type { Exercise } from "@/types/database"
+import type { ExerciseListItem } from "@/types/database"
 
 const STALE_MS = 1000 * 60 * 30
+
+/**
+ * Slim catalog fetch for lookup/map use cases (e.g. hydrating session-side
+ * `exerciseById` or the AI-generation pool is NOT a caller — see T69).
+ *
+ * Enumerated columns instead of `*` to avoid shipping rich fields (JSONB
+ * `instructions`, `youtube_url`, `source`, `reviewed_*`) in the hot path.
+ * Rich fields are fetched per-id via `useExerciseById` as needed.
+ *
+ * `measurement_type` + `default_duration_seconds` are kept because the
+ * active-session pool uses them for duration-vs-reps branching.
+ */
+const SLIM_SELECT =
+  "id, name, name_en, emoji, muscle_group, equipment, image_url, difficulty_level, is_system, measurement_type, default_duration_seconds, secondary_muscles"
 
 export function useExerciseLibrary() {
   const user = useAtomValue(authAtom)
 
   return useQuery({
     queryKey: ["exercise-library"],
-    queryFn: async (): Promise<Exercise[]> => {
+    queryFn: async (): Promise<ExerciseListItem[]> => {
       const { data, error } = await supabase
         .from("exercises")
-        .select("*")
+        .select(SLIM_SELECT)
         .order("muscle_group")
         .order("name")
 
       if (error) throw error
-      return (data ?? []) as Exercise[]
+      return (data ?? []) as unknown as ExerciseListItem[]
     },
     enabled: !!user,
     staleTime: STALE_MS,

--- a/src/hooks/useGenerateProgram.ts
+++ b/src/hooks/useGenerateProgram.ts
@@ -3,6 +3,7 @@ import { useAtomValue } from "jotai"
 import { getDefaultStore } from "jotai"
 import { supabase } from "@/lib/supabase"
 import { adaptForExperience, resolveEquipmentSwap } from "@/lib/generateProgram"
+import { fetchExercisesByIds } from "@/lib/fetchExercisesByIds"
 import { authAtom, hasProgramAtom, activeProgramIdAtom } from "@/store/atoms"
 import type { UserProfile, ExerciseAlternative, ProgramTemplate } from "@/types/onboarding"
 import type { Exercise } from "@/types/database"
@@ -59,7 +60,32 @@ export function useGenerateProgram() {
           alternatives = (data ?? []) as ExerciseAlternative[]
         }
 
-        const exerciseCache = new Map<string, Exercise>()
+        // Pre-compute every swap target up front so we can batch-fetch the
+        // replacement exercises in a single `.in()` call instead of firing one
+        // `.eq + .single` per swapped exercise (previous N+1). The batch helper
+        // chunks at 100 ids to respect PostgREST URL limits.
+        const resolvedIdsToFetch = new Set<string>()
+        for (const day of template.template_days) {
+          for (const te of day.template_exercises) {
+            const resolvedId = resolveEquipmentSwap(
+              te.exercise_id,
+              profile.equipment,
+              alternatives,
+            )
+            if (resolvedId !== te.exercise_id) {
+              resolvedIdsToFetch.add(resolvedId)
+            }
+          }
+        }
+
+        const fetchedSwapTargets =
+          resolvedIdsToFetch.size > 0
+            ? await fetchExercisesByIds([...resolvedIdsToFetch])
+            : []
+        const exerciseCache = fetchedSwapTargets.reduce(
+          (map, ex) => map.set(ex.id, ex),
+          new Map<string, Exercise>(),
+        )
 
         for (const day of template.template_days) {
           const { data: insertedDay, error: dayError } = await supabase
@@ -76,61 +102,51 @@ export function useGenerateProgram() {
 
           if (dayError) throw dayError
 
-          const exerciseRows = await Promise.all(
-            day.template_exercises.map(async (te, idx) => {
-              const resolvedId = resolveEquipmentSwap(
-                te.exercise_id,
-                profile.equipment,
-                alternatives,
-              )
+          const exerciseRows = day.template_exercises.map((te, idx) => {
+            const resolvedId = resolveEquipmentSwap(
+              te.exercise_id,
+              profile.equipment,
+              alternatives,
+            )
 
-              let exercise = te.exercise
-              if (resolvedId !== te.exercise_id) {
-                if (!exerciseCache.has(resolvedId)) {
-                  const { data } = await supabase
-                    .from("exercises")
-                    .select("*")
-                    .eq("id", resolvedId)
-                    .single()
-                  if (data) exerciseCache.set(resolvedId, data as Exercise)
-                }
-                exercise = exerciseCache.get(resolvedId)
-              }
+            const exercise =
+              resolvedId !== te.exercise_id
+                ? exerciseCache.get(resolvedId)
+                : te.exercise
 
-              const adapted = adaptForExperience(
-                te.rep_range,
-                te.sets,
-                te.rest_seconds,
-                profile.experience,
-              )
+            const adapted = adaptForExperience(
+              te.rep_range,
+              te.sets,
+              te.rest_seconds,
+              profile.experience,
+            )
 
-              const isDuration = exercise?.measurement_type === "duration"
-              const isBodyweight = exercise?.equipment === "bodyweight"
-              const defaultSec = exercise?.default_duration_seconds ?? 30
+            const isDuration = exercise?.measurement_type === "duration"
+            const isBodyweight = exercise?.equipment === "bodyweight"
+            const defaultSec = exercise?.default_duration_seconds ?? 30
 
-              return {
-                workout_day_id: insertedDay.id,
-                exercise_id: resolvedId,
-                name_snapshot: exercise?.name ?? "Exercise",
-                muscle_snapshot: exercise?.muscle_group ?? "",
-                emoji_snapshot: exercise?.emoji ?? "🏋️",
-                sets: adapted.sets,
-                reps: isDuration ? "0" : adapted.reps,
-                weight: "0",
-                rest_seconds: adapted.restSeconds,
-                sort_order: idx,
-                target_duration_seconds: isDuration ? defaultSec : null,
-                rep_range_min: adapted.repRangeMin ?? 8,
-                rep_range_max: adapted.repRangeMax ?? 12,
-                set_range_min: Math.max(1, adapted.sets - 1),
-                set_range_max: Math.min(6, adapted.sets + 2),
-                max_weight_reached: isBodyweight ? true : false,
-                duration_range_min_seconds: isDuration ? Math.max(5, defaultSec - 10) : null,
-                duration_range_max_seconds: isDuration ? defaultSec + 15 : null,
-                duration_increment_seconds: isDuration ? 5 : null,
-              }
-            }),
-          )
+            return {
+              workout_day_id: insertedDay.id,
+              exercise_id: resolvedId,
+              name_snapshot: exercise?.name ?? "Exercise",
+              muscle_snapshot: exercise?.muscle_group ?? "",
+              emoji_snapshot: exercise?.emoji ?? "🏋️",
+              sets: adapted.sets,
+              reps: isDuration ? "0" : adapted.reps,
+              weight: "0",
+              rest_seconds: adapted.restSeconds,
+              sort_order: idx,
+              target_duration_seconds: isDuration ? defaultSec : null,
+              rep_range_min: adapted.repRangeMin ?? 8,
+              rep_range_max: adapted.repRangeMax ?? 12,
+              set_range_min: Math.max(1, adapted.sets - 1),
+              set_range_max: Math.min(6, adapted.sets + 2),
+              max_weight_reached: isBodyweight ? true : false,
+              duration_range_min_seconds: isDuration ? Math.max(5, defaultSec - 10) : null,
+              duration_range_max_seconds: isDuration ? defaultSec + 15 : null,
+              duration_increment_seconds: isDuration ? 5 : null,
+            }
+          })
 
           const { error: exError } = await supabase
             .from("workout_exercises")

--- a/src/hooks/useWorkoutExercises.ts
+++ b/src/hooks/useWorkoutExercises.ts
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { supabase } from "@/lib/supabase"
+import { FULL_EXERCISE_SELECT } from "@/lib/exerciseSelects"
 import type {
   Exercise,
   WorkoutExerciseWithExercise,
@@ -25,12 +26,7 @@ export function useWorkoutExercises(dayId: string | null) {
     queryFn: async () => {
       const { data, error } = await supabase
         .from("workout_exercises")
-        .select(
-          `
-          *,
-          exercise:exercises(*)
-        `,
-        )
+        .select(`*, exercise:exercises(${FULL_EXERCISE_SELECT})`)
         .eq("workout_day_id", dayId!)
         .order("sort_order")
 

--- a/src/hooks/useWorkoutExercises.ts
+++ b/src/hooks/useWorkoutExercises.ts
@@ -1,21 +1,56 @@
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { supabase } from "@/lib/supabase"
-import type { WorkoutExercise } from "@/types/database"
+import type {
+  Exercise,
+  WorkoutExerciseWithExercise,
+} from "@/types/database"
 
+/**
+ * Loads all `workout_exercises` for a day WITH the related `exercises` row
+ * embedded (PostgREST resource embedding). Two goals:
+ *
+ *  1. Kill the per-id `exercises?id=eq…` request storm that `useExerciseById`
+ *     used to trigger for every card on the session/home screens (N+1 → 1).
+ *  2. Warm the per-id cache (`["exercise", id]`) so downstream callers of
+ *     `useExerciseFromLibrary` / `useExerciseById` hit memory instead of
+ *     the network.
+ */
 export function useWorkoutExercises(dayId: string | null) {
-  return useQuery<WorkoutExercise[]>({
+  const queryClient = useQueryClient()
+
+  return useQuery<WorkoutExerciseWithExercise[]>({
     queryKey: ["workout-exercises", dayId],
     /** Template rows change often (builder, permanent add/swap/delete); avoid long-lived stale lists. */
     staleTime: 0,
     queryFn: async () => {
       const { data, error } = await supabase
         .from("workout_exercises")
-        .select("*")
+        .select(
+          `
+          *,
+          exercise:exercises(*)
+        `,
+        )
         .eq("workout_day_id", dayId!)
         .order("sort_order")
 
       if (error) throw error
-      return data as WorkoutExercise[]
+
+      const rows = (data ?? []) as WorkoutExerciseWithExercise[]
+
+      const uniqueExercises = rows
+        .map((row) => row.exercise)
+        .filter((ex): ex is Exercise => !!ex)
+        .reduce(
+          (map, ex) => map.set(ex.id, ex),
+          new Map<string, Exercise>(),
+        )
+
+      uniqueExercises.forEach((ex, id) => {
+        queryClient.setQueryData(["exercise", id], ex)
+      })
+
+      return rows
     },
     enabled: !!dayId,
   })

--- a/src/lib/exerciseSelects.ts
+++ b/src/lib/exerciseSelects.ts
@@ -1,0 +1,37 @@
+/**
+ * Canonical PostgREST `select` strings for the `exercises` table.
+ *
+ * Keeping these in one place prevents schema drift between hooks that read
+ * the same data at different fidelities (slim list vs full per-id vs embed).
+ *
+ * Adding a new column to the `Exercise` type? Also add it to
+ * `FULL_EXERCISE_SELECT`. Adding a field consumed by the pool-style lookup
+ * hooks? Add it to `SLIM_EXERCISE_SELECT` and `ExerciseListItem` in
+ * `@/types/database`.
+ */
+
+/**
+ * Slim projection for catalog-style fetches (exercise library list, AI
+ * generator pool). Drops rich-but-optional fields like `instructions` JSONB,
+ * `youtube_url`, and admin metadata (`source`, `reviewed_*`, `created_at`).
+ *
+ * Consumers get `ExerciseListItem`. Rich fields are deferred to the per-id
+ * flow (`useExerciseById`) or the day-view embed (which uses FULL).
+ */
+export const SLIM_EXERCISE_SELECT =
+  "id, name, name_en, emoji, muscle_group, equipment, image_url, difficulty_level, is_system, measurement_type, default_duration_seconds, secondary_muscles"
+
+/**
+ * Full projection for the workout day embed
+ * (`workout_exercises.exercise:exercises(<FULL>)`) and for `useExerciseById`.
+ *
+ * Enumerated rather than `*` to prevent a future migration from silently
+ * bloating every embedded row — every column on `exercises` ships in every
+ * `workout_exercises` row when the relation is embedded, so adding a heavy
+ * JSONB/blob column via `*` would tax every day-view payload.
+ *
+ * Mirrors the full `Exercise` type so the returned shape stays safe to cache
+ * under `["exercise", id]` for both session and admin consumers.
+ */
+export const FULL_EXERCISE_SELECT =
+  "id, name, name_en, emoji, muscle_group, equipment, image_url, difficulty_level, is_system, measurement_type, default_duration_seconds, secondary_muscles, instructions, youtube_url, source, reviewed_at, reviewed_by, created_at"

--- a/src/lib/generateWorkout.ts
+++ b/src/lib/generateWorkout.ts
@@ -1,4 +1,4 @@
-import type { Exercise } from "@/types/database"
+import type { Exercise, ExerciseListItem } from "@/types/database"
 import { groupBy } from "@/lib/utils"
 import type {
   GeneratorConstraints,
@@ -19,7 +19,7 @@ import {
   isBodyweightOnlySelection,
 } from "./equipmentSelection"
 
-function isCompound(exercise: Exercise): boolean {
+function isCompound(exercise: ExerciseListItem): boolean {
   return (exercise.secondary_muscles?.length ?? 0) > 0
 }
 
@@ -82,7 +82,7 @@ function pickDistributed(
 }
 
 export function buildExercise(
-  exercise: Exercise,
+  exercise: ExerciseListItem,
   setsPerExercise: number,
 ): GeneratedExercise {
   const compound = isCompound(exercise)

--- a/src/lib/sessionSetRow.ts
+++ b/src/lib/sessionSetRow.ts
@@ -1,4 +1,4 @@
-import type { Exercise, WorkoutExercise } from "@/types/database"
+import type { ExerciseListItem, WorkoutExercise } from "@/types/database"
 
 /** Default hold length when exercise has no explicit default (seconds). */
 export const DEFAULT_DURATION_FALLBACK_SEC = 30
@@ -72,7 +72,7 @@ export function normalizeSessionSetRow(raw: unknown): SessionSetRow {
 
 export function resolveTargetSecondsForRow(
   row: WorkoutExercise,
-  lib: Exercise | undefined,
+  lib: ExerciseListItem | undefined,
 ): number {
   const fromTemplate = row.target_duration_seconds
   if (fromTemplate != null && fromTemplate > 0) return fromTemplate
@@ -83,7 +83,7 @@ export function resolveTargetSecondsForRow(
 
 export function buildInitialSetRowsForExercise(
   row: WorkoutExercise,
-  lib: Exercise | undefined,
+  lib: ExerciseListItem | undefined,
   displayWeight: string,
 ): SessionSetRow[] {
   const isDuration = lib?.measurement_type === "duration"

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -97,7 +97,12 @@ import {
   clonePreSessionPatch,
   type PreSessionExercisePatch,
 } from "@/types/preSessionOverrides"
-import type { Exercise, WorkoutDay, WorkoutExercise } from "@/types/database"
+import type {
+  ExerciseListItem,
+  WorkoutDay,
+  WorkoutExercise,
+} from "@/types/database"
+import { useExerciseById } from "@/hooks/useExerciseById"
 
 const EMPTY_DAYS: WorkoutDay[] = []
 
@@ -113,7 +118,7 @@ function isSyntheticRow(patch: PreSessionExercisePatch, rowId: string): boolean 
 function applySessionSwap(
   prev: PreSessionExercisePatch,
   row: WorkoutExercise,
-  picked: Exercise,
+  picked: ExerciseListItem,
   weightStr: string,
 ): PreSessionExercisePatch {
   const next = clonePreSessionPatch(prev)
@@ -160,9 +165,9 @@ function applySessionAdd(
 }
 
 type PendingScopeAction =
-  | { kind: "swap"; row: WorkoutExercise; picked: Exercise }
+  | { kind: "swap"; row: WorkoutExercise; picked: ExerciseListItem }
   | { kind: "delete"; row: WorkoutExercise }
-  | { kind: "add"; picked: Exercise }
+  | { kind: "add"; picked: ExerciseListItem }
 
 type SessionFinishedStats = {
   exercisesCompleted: number
@@ -252,11 +257,10 @@ export function WorkoutPage() {
     useExerciseLibrary()
 
   const exerciseById = useMemo(() => {
-    const m = new Map<string, Exercise>()
-    for (const e of exercisePool) {
-      m.set(e.id, e)
-    }
-    return m
+    return exercisePool.reduce(
+      (map, e) => map.set(e.id, e),
+      new Map<string, ExerciseListItem>(),
+    )
   }, [exercisePool])
 
   const { data: allExercisesForDay, isLoading: exercisesLoading } =
@@ -277,10 +281,11 @@ export function WorkoutPage() {
     [exercises, swapLibraryRowId],
   )
 
-  const inspectedExercise = useMemo(
-    () => exercisePool.find((e) => e.id === inspectedExerciseId) ?? null,
-    [exercisePool, inspectedExerciseId],
-  )
+  // Rich fields (instructions/youtube/secondary_muscles) needed by the detail
+  // sheet are NOT in the slim catalog pool — fetch on demand. Hits the per-id
+  // cache seeded by `useWorkoutExercises` embed, so exercises already in a
+  // loaded day are zero-network.
+  const { data: inspectedExercise } = useExerciseById(inspectedExerciseId)
 
   const exerciseIds = useMemo(
     () => exercises.map((ex) => ex.exercise_id),
@@ -510,7 +515,7 @@ export function WorkoutPage() {
       exercisePool,
       poolLoading: exercisePoolLoading,
       allExercises: exercises,
-      onSwapExerciseChosen: (row: WorkoutExercise, picked: Exercise) => {
+      onSwapExerciseChosen: (row: WorkoutExercise, picked: ExerciseListItem) => {
         setPendingScope({ kind: "swap", row, picked })
         setScopeDialogOpen(true)
       },
@@ -1196,8 +1201,8 @@ export function WorkoutPage() {
       />
 
       <ExerciseDetailSheet
-        exercise={inspectedExercise}
-        open={!!inspectedExercise}
+        exercise={inspectedExercise ?? null}
+        open={!!inspectedExerciseId}
         onOpenChange={(v) => {
           if (!v) setInspectedExerciseId(null)
         }}

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -285,7 +285,22 @@ export function WorkoutPage() {
   // sheet are NOT in the slim catalog pool — fetch on demand. Hits the per-id
   // cache seeded by `useWorkoutExercises` embed, so exercises already in a
   // loaded day are zero-network.
-  const { data: inspectedExercise } = useExerciseById(inspectedExerciseId)
+  const { data: inspectedExercise, isPending: inspectedExercisePending } =
+    useExerciseById(inspectedExerciseId)
+
+  // If the query resolves to null (orphan FK, RLS filter, deleted catalog row),
+  // the detail sheet returns null and has no way to dismiss itself. Clear the
+  // id so the parent stays in a consistent state.
+  useEffect(() => {
+    if (
+      inspectedExerciseId &&
+      !inspectedExercisePending &&
+      inspectedExercise === null
+    ) {
+      setInspectedExerciseId(null)
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reflect unreachable-exercise async result into id state; no safer place to run this.
+  }, [inspectedExerciseId, inspectedExercisePending, inspectedExercise])
 
   const exerciseIds = useMemo(
     () => exercises.map((ex) => ex.exercise_id),
@@ -1202,7 +1217,7 @@ export function WorkoutPage() {
 
       <ExerciseDetailSheet
         exercise={inspectedExercise ?? null}
-        open={!!inspectedExerciseId}
+        open={!!inspectedExerciseId && !!inspectedExercise}
         onOpenChange={(v) => {
           if (!v) setInspectedExerciseId(null)
         }}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -67,6 +67,39 @@ export interface WorkoutExercise {
   duration_increment_seconds?: number | null
 }
 
+/**
+ * Row shape returned by `useWorkoutExercises` after the T69 embed.
+ * `exercise` is null only if the FK row was deleted (RLS filtered or orphan).
+ */
+export interface WorkoutExerciseWithExercise extends WorkoutExercise {
+  exercise: Exercise | null
+}
+
+/**
+ * Slim projection used by catalog-style fetches (`useExerciseLibrary`) where
+ * rich fields like `instructions`/`youtube_url` are deferred to per-id hooks.
+ * Includes `measurement_type` + `default_duration_seconds` because the active
+ * session pool (`WorkoutPage.exerciseById`) needs them for duration branching.
+ */
+export type ExerciseListItem = Pick<
+  Exercise,
+  | "id"
+  | "name"
+  | "name_en"
+  | "emoji"
+  | "muscle_group"
+  | "equipment"
+  | "image_url"
+  | "difficulty_level"
+  | "is_system"
+  | "measurement_type"
+  | "default_duration_seconds"
+  // `secondary_muscles` is kept because `isCompound` logic in generator flows
+  // (PreviewStep, quick workout) branches on presence. Cheap scalar array.
+  | "secondary_muscles"
+>
+
+
 export interface Session {
   id: string
   user_id: string

--- a/src/types/generator.ts
+++ b/src/types/generator.ts
@@ -1,4 +1,4 @@
-import type { Exercise } from "./database"
+import type { ExerciseListItem } from "./database"
 
 export type Duration = 15 | 30 | 45 | 60 | 90
 
@@ -14,7 +14,10 @@ export interface GeneratorConstraints {
 }
 
 export interface GeneratedExercise {
-  exercise: Exercise
+  // Narrowed to the slim catalog shape (T69). The only rich field the
+  // generator consumes is `secondary_muscles` (isCompound), which is now
+  // in ExerciseListItem.
+  exercise: ExerciseListItem
   sets: number
   reps: string
   restSeconds: number


### PR DESCRIPTION
## What

- `useWorkoutExercises` now embeds `exercise:exercises(*)` and seeds `["exercise", id]` in the TanStack cache so every downstream `useExerciseById` for in-day exercises is a cache hit (swap panels, detail sheets, rest-timer meta, etc.).
- `useExerciseLibrary` drops `select("*")` for an explicit `SLIM_SELECT` — returns `ExerciseListItem[]`. Sheds `instructions` JSONB, `youtube_url`, `source`, `reviewed_*`, `description`, `created_at`.
- `useGenerateProgram` batches swap-target resolution via a single `fetchExercisesByIds([...])` call instead of N sequential `.eq().single()` queries.
- Pool types narrowed to `ExerciseListItem` across generator + workout components; rich `Exercise` data is fetched on demand via `useExerciseById` when a detail sheet opens.

## Why

Post-T68 Lighthouse flagged Supabase payload bloat and a burst of per-exercise round-trips on the workout view as the main remaining perf drag. Each day view was firing one list query + N per-exercise queries; the library list was shipping ~160 KB of fields the UI never reads.

This collapses that to: **one embedded query per day view** + **one slim library fetch**, while keeping rich fields available on demand without a second wave of requests (thanks to the seeded cache).

## How

- Added `WorkoutExerciseWithExercise` and `ExerciseListItem` in `src/types/database.ts` — `ExerciseListItem` includes `secondary_muscles` for generator scoring.
- `GeneratedExercise.exercise` narrowed to `ExerciseListItem`; `buildExercise`, `isCompound`, `buildInitialSetRowsForExercise`, `resolveTargetSecondsForRow` all accept the slim shape.
- Detail sheets (`WorkoutPage`, `PreviewStep`, `ExerciseSwapPicker`) moved from `inspectedExercise` state to `inspectedExerciseId` + `useExerciseById(id)` — hits cache for in-day items, falls back to network for library-only items.
- `useAIGenerateProgram` + `useAIGenerateWorkout` still accept `ExerciseListItem[]`; AI flow only needs `id` + `secondary_muscles` from the pool.

## Verification

- `tsc -b`: clean
- `npm run lint`: 0 errors, 8 pre-existing warnings (unrelated)
- `npm run test`: 973/973 pass
- `npm run build`: success

Closes #241

Made with [Cursor](https://cursor.com)