### PR TITLE
docs: ship MCP agent SKILL.md and OpenClaw setup guide (#261, #264)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ GymLogic exposes your training data as an [MCP (Model Context Protocol)](https:/
 - [Le Chat (Mistral)](docs/mcp-connect/le-chat.md)
 - [Claude Desktop](docs/mcp-connect/claude-desktop.md)
 
+**Building an agent / runtime?** The [`skills/gymlogic-mcp/SKILL.md`](skills/gymlogic-mcp/SKILL.md) drop-in prompt context covers tool intent mapping, the **per-side weight convention for unilateral equipment**, and edge cases — load it into your agent's system prompt or skill registry alongside the connector.
+
 **Available tools:**
 
 | Tool | What it does |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ GymLogic exposes your training data as an [MCP (Model Context Protocol)](https:/
 - [Cursor](docs/mcp-connect/cursor.md)
 - [Le Chat (Mistral)](docs/mcp-connect/le-chat.md)
 - [Claude Desktop](docs/mcp-connect/claude-desktop.md)
+- [OpenClaw](docs/mcp-connect/openclaw.md)
 
 **Building an agent / runtime?** The [`skills/gymlogic-mcp/SKILL.md`](skills/gymlogic-mcp/SKILL.md) drop-in prompt context covers tool intent mapping, the **per-side weight convention for unilateral equipment**, and edge cases — load it into your agent's system prompt or skill registry alongside the connector.
 

--- a/docs/mcp-connect/openclaw.md
+++ b/docs/mcp-connect/openclaw.md
@@ -1,0 +1,154 @@
+# Connect GymLogic to OpenClaw
+
+Wire GymLogic's MCP server into [OpenClaw](https://docs.openclaw.ai) so any agent running on the OpenClaw runtime (e.g. [Iris / sudo-ceo](https://github.com/PierreTsia/sudo-ceo)) can read your training data and create or replace your active program with `create_program`.
+
+> ⚠️ **Pending [#266](https://github.com/PierreTsia/workout-app/issues/266)** — OpenClaw's strict Streamable-HTTP MCP transport opens an SSE stream that our edge function currently rejects with `405`. The wiring below is **valid for the day #266 ships**; until then you'll see `[bundle-mcp] failed to start server "gymlogic": Error: SSE error: Non-200 status code (405)` in the gateway logs. Cursor, Le Chat, and Claude Desktop all work today because they fall back to plain POST.
+
+## Prerequisites
+
+- A [GymLogic](https://gymlogic.me) account with at least one logged workout
+- [OpenClaw](https://docs.openclaw.ai) installed (verified against `openclaw 2026.4.21` and later)
+
+## Setup
+
+### 1. Create a Personal Access Token (PAT)
+
+1. Sign in at [gymlogic.me](https://gymlogic.me)
+2. Open **Account** > **Security & access** > **Manage API tokens** (or go directly to [gymlogic.me/account/api-tokens](https://gymlogic.me/account/api-tokens))
+3. Click **Create token**
+4. Give it a clear name (e.g. `OpenClaw / Iris`) and pick a lifetime (30 / 90 / 365 days, or never)
+5. **Copy the token now** — it starts with `glp_` and is shown only once. Treat it like a password.
+
+> Tokens are scoped to your account (full read + program write). Lost a token? Revoke it from the same page; the next request from that token will return 401.
+
+### 2. Add the MCP server
+
+Edit `~/.openclaw/openclaw.json` (overridable via `OPENCLAW_CONFIG_PATH`):
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "gymlogic": {
+        "url": "https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp",
+        "headers": {
+          "Authorization": "Bearer <YOUR_PAT>"
+        }
+      }
+    }
+  }
+}
+```
+
+> **Schema gotcha** — the top-level key is **`mcp.servers`**, NOT `mcpServers` (the Cursor / Claude Desktop convention). OpenClaw rejects `mcpServers` with `Unrecognized key: mcpServers` and the gateway crash-loops on startup. Confirmed via `openclaw config schema`.
+
+### 2bis. CLI alternative
+
+If you'd rather not edit JSON by hand:
+
+```bash
+openclaw mcp set gymlogic '{"url":"https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp","headers":{"Authorization":"Bearer <YOUR_PAT>"}}'
+openclaw mcp list                # confirms "gymlogic" is registered
+openclaw mcp show gymlogic       # prints the stored config
+openclaw mcp unset gymlogic      # remove
+```
+
+### 3. Validate, restart, verify
+
+```bash
+openclaw config validate
+# or against a candidate file:
+OPENCLAW_CONFIG_PATH=/tmp/candidate.json openclaw config validate
+```
+
+Strongly recommended in deploy scripts — catches schema drift before the gateway tries to boot.
+
+OpenClaw hot-reloads (`[reload] config hot reload applied`), but for first-time wiring a clean restart is more reliable:
+
+```bash
+systemctl --user restart openclaw-gateway.service   # systemd-managed installs (sudo-ceo, prod)
+openclaw gateway --force                             # manual / dev mode
+```
+
+Verify:
+
+```bash
+openclaw mcp list
+journalctl --user -u openclaw-gateway.service -n 30 --no-pager
+```
+
+You're looking for `[bundle-mcp] starting server "gymlogic"` with no SSE errors. (Today, this is where you'll hit the [#266](https://github.com/PierreTsia/workout-app/issues/266) blocker.)
+
+## Available tools
+
+| Tool | What it does |
+|---|---|
+| `search_exercises` | Search the exercise catalog by name (FR/EN), muscle group, equipment, or difficulty |
+| `get_exercise_details` | Full exercise info: instructions, muscles, equipment, media |
+| `get_workout_history` | Your past sessions with sets, weights, and PRs |
+| `get_training_stats` | Volume by muscle group, personal records, session frequency |
+| `get_upcoming_workouts` | Your programmed training days and exercises |
+| `create_program` | **Create / replace your active program** from structured days + exercise UUIDs. Default **`dry_run: true`** returns the insert plan only; **`dry_run: false`** writes to Supabase (deactivates other active programs). Use after `search_exercises` / `get_exercise_details` to resolve IDs. |
+
+There is also one **MCP Resource** (`exercise_catalog_schema`) exposing the exercise taxonomy (muscle groups, equipment types, difficulty levels).
+
+**Six tools** total — five for reads/analysis, one for persisting a full program.
+
+> **Building agent-side context?** [`skills/gymlogic-mcp/SKILL.md`](../../skills/gymlogic-mcp/SKILL.md) is a drop-in prompt context covering tool intent, weight conventions for unilateral equipment, and edge cases. Load it into your agent's system prompt or skill registry.
+
+## Example prompts
+
+In French:
+
+- "Montre-moi mes 5 dernières séances"
+- "C'est quoi mon prochain training ?"
+- "Analyse mon équilibre push/pull sur le dernier mois"
+- "Voici ma semaine type en 4 jours — sauvegarde ça comme programme actif (dry run puis apply avec create_program)"
+
+In English:
+
+- "What did I train this week?"
+- "Search for chest exercises with dumbbells"
+- "Tell me about the Romanian Deadlift"
+- "Propose a 3-day full-body refresh and save it with create_program (dry run first)"
+
+## Pro tip: env-var indirection for templated configs
+
+In CI/CD or a templated repo (like sudo-ceo), don't paste the PAT directly into `openclaw.json`. Use OpenClaw's env-var reference:
+
+```bash
+openclaw config set mcp.servers.gymlogic.headers.Authorization \
+  --ref-source env --ref-id GYMLOGIC_PAT
+```
+
+Or template the file with `envsubst` and run `openclaw config validate` as a pre-flight in your deploy script — see [`scripts/apply-config.sh`](https://github.com/PierreTsia/sudo-ceo/blob/main/scripts/apply-config.sh) for a working example.
+
+## Rotating or revoking a token
+
+- **Rotate**: create a new token, swap it into `~/.openclaw/openclaw.json` (or update the env var if you used the indirection trick), restart the gateway, then revoke the old one from `/account/api-tokens`.
+- **Revoke**: hit **Revoke** next to the token. Revocation is immediate and irreversible — the next request returns 401.
+- **Lost server / leaked token**: revoke the corresponding PAT. Any other tokens you created keep working.
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| Gateway crash-loops after a config edit | Run `openclaw config validate` (or `OPENCLAW_CONFIG_PATH=/path/to/file openclaw config validate`) — almost always schema drift caught here. |
+| `Unrecognized key: mcpServers` | The schema is `mcp.servers`, NOT `mcpServers`. Different from Cursor / Claude Desktop. |
+| `SSE error: Non-200 status code (405)` | Blocked on [#266](https://github.com/PierreTsia/workout-app/issues/266) — server-side SSE support not shipped yet. No client-side workaround. |
+| `401 Authentication required` | Token revoked, expired, or mistyped. Create a fresh one at [/account/api-tokens](https://gymlogic.me/account/api-tokens) and swap it in. |
+| `gymlogic` not appearing in `openclaw mcp list` | Re-check the JSON path — top-level key must be `mcp.servers.gymlogic`, not `mcpServers.gymlogic`. Then restart the gateway. |
+| Tools missing in agent chats but `mcp mcp list` shows the server | Restart the agent process — connector lists are cached at agent boot. |
+
+## Headless / scripted access (outside OpenClaw)
+
+The same PAT works as a Bearer token for direct HTTP calls — handy for CI jobs or `curl`-based debugging:
+
+```bash
+curl -X POST https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp \
+  -H "Authorization: Bearer <YOUR_PAT>" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+You can use the same token in OpenClaw and in scripts simultaneously, or create separate tokens per use-case for cleaner audit and revocation.

--- a/skills/gymlogic-mcp/SKILL.md
+++ b/skills/gymlogic-mcp/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: gymlogic-mcp
+description: >
+  Use the GymLogic MCP server to read a user's workout history, training stats,
+  exercise catalog, upcoming programmed days, and to create or replace their active
+  multi-day training program. Trigger when the user mentions sport, training,
+  workouts, sets, reps, weights, exercises, programmes, séances, musculation, gym,
+  or asks for coaching, volume analysis, or program design.
+---
+
+# GymLogic MCP Skill
+
+This skill teaches an LLM how to be a competent training coach on top of the [GymLogic](https://gymlogic.me) MCP server. It covers when to invoke each of the **six tools**, how to format their parameters, and the non-obvious quirks that bite zero-shot agents — most importantly the **per-side weight convention for unilateral equipment** (issue [#263](https://github.com/PierreTsia/workout-app/issues/263)).
+
+GymLogic is a French/English workout tracker. The user logs sessions, weights, reps; you read this data and either analyze it or design a new program with `create_program`.
+
+---
+
+## When to invoke this skill
+
+Trigger on any sport / training / fitness intent, in **French or English**:
+
+- "C'est quoi mon prochain training ?", "Montre mes 5 dernières séances", "Mon volume push/pull du mois ?"
+- "What did I train this week?", "Search for chest exercises with dumbbells", "How's my training volume?"
+- "Donne-moi un programme 4 jours full body" → design + `create_program`
+- "Remplace mon programme actuel par X" → `create_program` (replaces active program)
+- Ambiguous coaching prompts ("je stagne au bench") → start with `get_workout_history` + `get_training_stats`, then advise
+
+Do **not** invoke for:
+
+- Pure exercise-form questions answerable from general knowledge (unless the user asks for *their* version, then use `get_exercise_details`).
+- Nutrition / sleep / non-training topics — out of scope.
+
+---
+
+## Authentication
+
+Two paths; **PAT is recommended**.
+
+### Personal Access Token (PAT) — recommended
+
+Long-lived bearer token, created by the user at [gymlogic.me/account/api-tokens](https://gymlogic.me/account/api-tokens). Format: `glp_…`. The runtime injects it as:
+
+```http
+Authorization: Bearer glp_<token>
+```
+
+Stable, no refresh dance. Revocation is immediate (next call returns `401`).
+
+### OAuth 2.1 — alternative
+
+Dynamic client registration, browser consent at `www.gymlogic.me/oauth/consent`. Use only if the user explicitly requests it or PAT setup is impossible. See per-client guides in [`docs/mcp-connect/`](../../docs/mcp-connect/) for setup.
+
+### Server endpoint
+
+```
+https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp
+```
+
+All six tools 401 if no auth context. The tool response will be `Authentication required — please provide a valid Bearer token.` — surface that to the user and ask them to (re)connect.
+
+---
+
+## Tool reference (intent → tool)
+
+Six tools total — five reads, one write.
+
+| User intent | Tool | Notes |
+|---|---|---|
+| "Show me my recent workouts / sessions / training history" | `get_workout_history` | Defaults to last 10 sessions. Filter by `from_date` / `to_date` (ISO 8601) or `exercise_name` (fuzzy). |
+| "How am I doing / volume / PRs / muscle group balance / push-pull split" | `get_training_stats` | Defaults to last 30 days. Filter by `muscle_group` (FR name, e.g. `Pectoraux`, `Dos`). |
+| "What's my next workout / what's programmed for tomorrow" | `get_upcoming_workouts` | Default 3 days, max 7. Returns `No active program found` if user has none. |
+| "Find / search exercises for X muscle / with Y equipment" | `search_exercises` | FR + EN names. Use **before** `get_exercise_details` to resolve a UUID. Aliases: `chest`/`pecs` → `Pectoraux`, body regions like `push`/`pull`/`legs`/`core`/`upper_body`/`lower_body` work too. |
+| "Tell me more about exercise X / how to do X" | `get_exercise_details` | Requires a UUID (`exercise_id`). **Always run `search_exercises` first** to resolve it; if multiple matches come back, ask the user to pick. |
+| "Design / save / replace my program" | `create_program` | Multi-day. **`dry_run` defaults to `true`** — preview first, then re-call with `dry_run: false` to persist. Deactivates other active programs. |
+
+There's also one **MCP resource** (`exercise_catalog_schema`) exposing the muscle-group / equipment / difficulty taxonomy. Read it once at the start of a session if the runtime supports resources, otherwise rely on `search_exercises`'s built-in aliasing.
+
+---
+
+## Weight conventions per equipment — READ THIS BEFORE COMPUTING ANY VOLUME
+
+Volume math depends on **equipment type**. The `weight_logged` field on a set log does NOT always represent total load. Get this wrong and your push-pull / leg-arm volume analysis will be off by 2x for half the sets.
+
+| Equipment | What `weight_logged` means | How to compute total volume |
+|---|---|---|
+| `dumbbell` (unilateral, both hands at once: curls, presses, rows…) | **Per hand** | `total_load = weight_logged * 2` then `volume = total_load * reps` |
+| `kettlebell` (single-hand) | **Per hand** | Same: multiply by 2 if both hands working in alternation, else use as-is for single-hand sets |
+| `barbell` | Total bar load | Use `weight_logged` directly |
+| `machine` (stack-loaded) | Stack value (total) | Use `weight_logged` directly |
+| `plate-loaded machine` (Hammer Strength etc.) | Total plate load | Use `weight_logged` directly |
+| `cable` / poulie | Stack value (total) | Use `weight_logged` directly |
+| `ez_bar` | Total bar load | Use `weight_logged` directly |
+| `bodyweight` | `0` | Exclude from volume; still count the set |
+
+### How to know which equipment
+
+- `get_exercise_details` returns `equipment` explicitly — call it whenever you're not sure.
+- Exercise names hint: "Curl haltères" / "Dumbbell Curl" → `dumbbell` (per hand). "Développé couché" / "Bench Press" → `barbell` (total).
+- When in doubt, lean conservative and tell the user the assumption you made.
+
+### Worked example
+
+User logs 4 sets of 10 reps at `25 kg` for "Curl haltères" (dumbbell):
+
+- ❌ Naive: `volume = 4 * 10 * 25 = 1000 kg`
+- ✅ Correct: `25 kg per hand × 2 hands × 10 reps × 4 sets = 2000 kg`
+
+When you report volume, **always say which interpretation you used** ("Volume bilatéral, haltères comptés à deux mains") so the user can call out a mistake.
+
+---
+
+## Conversation patterns
+
+### Pattern 1 — Recent training summary
+
+User: *"Qu'est-ce que j'ai fait cette semaine ?"*
+
+```jsonc
+get_workout_history({ from_date: "<monday-iso>", to_date: "<today-iso>" })
+```
+
+Then summarize: session count, top exercises, total tonnage (with the weight-convention caveat above).
+
+### Pattern 2 — Volume balance over a month
+
+User: *"How's my push/pull balance?"*
+
+```jsonc
+get_training_stats({ days: 30 })
+```
+
+Read the per-muscle-group volume. Group `Pectoraux + Épaules + Triceps` as push, `Dos + Biceps + Trapèzes + Deltoïdes post.` as pull, and tell the user the ratio.
+
+### Pattern 3 — Exercise lookup → details
+
+User: *"How do I do a Romanian deadlift?"*
+
+```jsonc
+// 1. Find it
+search_exercises({ query: "romanian deadlift" })
+// → returns { id: "<uuid>", ... } if single match, list otherwise
+
+// 2. Pull full details (only on single match — otherwise ask user to pick)
+get_exercise_details({ exercise_id: "<uuid>" })
+```
+
+### Pattern 4 — Design + persist a new program
+
+User: *"Propose-moi un 4 jours full-body et active-le."*
+
+1. Read context: `get_training_stats`, optionally `get_upcoming_workouts` to see the current program.
+2. Search exercises to resolve UUIDs (one `search_exercises` call per movement, narrow to single matches).
+3. Dry-run preview:
+
+```jsonc
+create_program({
+  name: "Full Body 4d",
+  days: [
+    { label: "Lundi — Lower", exercise_ids: ["<uuid>", "<uuid>", ...] },
+    { label: "Mardi — Upper push", exercise_ids: [...] },
+    { label: "Jeudi — Lower", exercise_ids: [...] },
+    { label: "Vendredi — Upper pull", exercise_ids: [...] }
+  ],
+  dry_run: true
+})
+```
+
+4. Show the preview to the user, get explicit consent.
+5. Apply: same call with `dry_run: false`. Confirm: *"Program created and set active."*
+
+**Defaults applied by the server**: 3 sets × 10 reps × 90s rest per exercise (or duration mode for time-based exercises). The user can fine-tune in-app afterwards.
+
+---
+
+## Edge cases
+
+| Situation | What to do |
+|---|---|
+| `No workout sessions found for this period.` | Tell the user; don't fabricate data. Suggest they log a session in the app first. |
+| `No active program found.` (from `get_upcoming_workouts`) | Tell the user, offer to design one with `create_program`. |
+| `No active training cycle for "X".` | A program exists but no cycle is started. Tell the user to start a cycle in-app. |
+| `search_exercises` returns multiple matches | **Do not pick blindly.** List them and ask the user. Only call `get_exercise_details` once a single match is selected. |
+| `Invalid UUID(s) in days[i].exercise_ids` | You passed a non-UUID string (e.g. an exercise name). Resolve via `search_exercises` first. |
+| `Unknown or inaccessible exercise_id(s):` | The UUID is valid format but the exercise doesn't exist or isn't visible to this user. Re-search. |
+| `Authentication required` / `401` | Token expired or revoked. Tell the user to create a fresh PAT at `/account/api-tokens`. |
+| Ambiguous muscle group (`"chest"` vs `"Pectoraux"`) | `search_exercises` accepts both — pass the user's term as-is. For `get_training_stats` the filter must be the FR name (`Pectoraux`). |
+| User asks to *modify* one day of an existing program | Out of scope for MCP — `create_program` replaces the whole program. Tell the user single-day tweaks happen in-app (Workout Builder). |
+
+---
+
+## Parameter format conventions
+
+- **Dates**: ISO 8601, date-only (`2026-04-27`) for `from_date` / `to_date`. Server appends `T00:00:00Z` / `T23:59:59Z` automatically.
+- **Exercise IDs**: UUID v4 (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`). Always obtained from `search_exercises`. Never invent or transcribe from memory.
+- **Muscle groups (FR canonical)**: `Abdos`, `Biceps`, `Deltoïdes post.`, `Dos`, `Épaules`, `Fessiers`, `Ischios`, `Ischios / Bas du dos`, `Lombaires`, `Mollets`, `Pectoraux`, `Quadriceps`, `Trapèzes`, `Triceps`.
+- **Equipment values**: `barbell`, `dumbbell`, `cable`, `machine`, `ez_bar`, `bodyweight`.
+- **Body region aliases** (for `search_exercises` only): `upper_body`, `lower_body`, `push`, `pull`, `arms`, `legs`, `core`.
+- **Difficulty**: `beginner`, `intermediate`, `advanced`.
+- **`create_program` limits**: max **14 days**, max **40 exercises per day**.
+- **`create_program.dry_run`**: defaults to `true`. **Always preview first.** Only set `false` after explicit user consent. The apply path deactivates other active programs and sets the new one active — there is no undo in-app beyond reverting via another `create_program` call.
+
+---
+
+## References
+
+- Per-client setup guides: [Cursor](../../docs/mcp-connect/cursor.md), [Le Chat](../../docs/mcp-connect/le-chat.md), [Claude Desktop](../../docs/mcp-connect/claude-desktop.md), [OpenClaw](../../docs/mcp-connect/openclaw.md)
+- Project README: [README.md](../../README.md)
+- Issue [#261](https://github.com/PierreTsia/workout-app/issues/261) (this skill), [#263](https://github.com/PierreTsia/workout-app/issues/263) (per-side weight ambiguity), [#259](https://github.com/PierreTsia/workout-app/issues/259) (PAT epic).

--- a/supabase/functions/mcp/tools/getTrainingStats.ts
+++ b/supabase/functions/mcp/tools/getTrainingStats.ts
@@ -5,7 +5,11 @@ export const getTrainingStats: ToolDefinition = {
   name: "get_training_stats",
   description:
     "Get training statistics for a period. Returns session count, training frequency, " +
-    "volume breakdown by muscle group, and personal records. Defaults to the last 30 days.",
+    "volume breakdown by muscle group, and personal records. Defaults to the last 30 days. " +
+    "WEIGHT CONVENTION: per-set weight_logged is per-hand for unilateral equipment (dumbbells, " +
+    "kettlebells) and total for barbells, machines, plate-loaded, and cables. The volume figures " +
+    "returned here use the raw weight_logged value — when interpreting or reporting them, double the " +
+    "contribution of unilateral-equipment sets (check `equipment` via get_exercise_details when unsure).",
   inputSchema: {
     type: "object",
     properties: {

--- a/supabase/functions/mcp/tools/getWorkoutHistory.ts
+++ b/supabase/functions/mcp/tools/getWorkoutHistory.ts
@@ -5,7 +5,11 @@ export const getWorkoutHistory: ToolDefinition = {
   name: "get_workout_history",
   description:
     "Get the user's workout session history. Returns sessions with exercises, sets, reps, weights, " +
-    "and PR flags. Filter by date range or exercise name. Defaults to the last 10 sessions.",
+    "and PR flags. Filter by date range or exercise name. Defaults to the last 10 sessions. " +
+    "WEIGHT CONVENTION: weight_logged is per-hand for unilateral equipment (dumbbells, kettlebells); " +
+    "multiply by 2 for total load and volume. Barbells, machines, plate-loaded, and cables are total. " +
+    "Bodyweight is 0 (exclude from volume). Always check `equipment` via get_exercise_details before " +
+    "computing volume.",
   inputSchema: {
     type: "object",
     properties: {


### PR DESCRIPTION
## What

Ships two batched documentation tickets (the in-app help page from #262 stays out — different scope, separate branch later).

- **#261** — new `skills/gymlogic-mcp/SKILL.md` drop-in prompt context for any LLM consuming the GymLogic MCP server (OpenClaw / Iris / custom agents). Tool intent mapping, auth flows, conversation patterns, edge cases, parameter conventions.
- **#261 belt-and-suspenders** — extend the `description` field on `get_workout_history` and `get_training_stats` so distant LLMs that don't load SKILL.md still see the per-side weight warning when listing tools.
- **#264** — new `docs/mcp-connect/openclaw.md` mirroring the structure of `cursor.md` / `le-chat.md` / `claude-desktop.md`.
- **README** updated: OpenClaw added to the Setup guides list, plus a pointer to the SKILL.md for agent-runtime authors.
- **Side ticket #266** opened for the missing SSE support in the MCP edge function (referenced as "Pending" in the OpenClaw doc).

## Why

**#261** — agents using the GymLogic MCP today have to guess. Worst symptom: zero-shot LLMs silently halve volume on every dumbbell / kettlebell set because they don't know `weight_logged` is per-hand for unilateral equipment (issue #263, fixed by surfacing the convention here). Surfacing it both in a structured SKILL.md *and* in the tool descriptions covers both runtimes that load skills (OpenClaw, Iris) and ones that just enumerate `tools/list` (Cursor, Le Chat).

**#264** — the `docs/mcp-connect/` symmetry was missing OpenClaw, and we just learned the hard way wiring GymLogic into the sudo-ceo deployment that the schema gotcha (`mcp.servers` vs `mcpServers`) and the SSE 405 are non-obvious. Captured both so the next deployer doesn't burn the same hour debugging.

**Out of #262** — the in-app React help page is a 5-10x scope (route, components, copy-config button, screenshots, i18n). It deserves its own branch and PR. Left open for a future session.

## How

Three commits for clean review:

1. `docs(skills): add gymlogic-mcp SKILL.md for agent runtimes` — new file + README pointer.
2. `feat(mcp): document per-side weight convention in tool descriptions` — pure description-string change in `getWorkoutHistory.ts` and `getTrainingStats.ts`. No behavior change. Verified the volume RPC (`get_volume_by_muscle_group`) returns raw `weight_logged * reps_logged`, so the "double for unilateral" caveat is accurate as written.
3. `docs(mcp-connect): add OpenClaw setup guide` — new file + README setup-guides list entry. Includes a `> ⚠️ Pending #266` callout on the SSE-dependent steps.

End-to-end verification of the OpenClaw doc on a fresh install is **blocked on #266** (server-side SSE support). The doc ships with the Pending callout so it's discoverable and SEO-symmetric with the other guides today; the callout comes off when #266 lands.

Closes #261.
Closes #264.

Made with [Cursor](https://cursor.com)