### PR TITLE
feat(mcp): GET-SSE listener for Streamable HTTP transport

### DIFF
--- a/docs/mcp-connect/openclaw.md
+++ b/docs/mcp-connect/openclaw.md
@@ -2,7 +2,7 @@
 
 Wire GymLogic's MCP server into [OpenClaw](https://docs.openclaw.ai) so any agent running on the OpenClaw runtime (e.g. [Iris / sudo-ceo](https://github.com/PierreTsia/sudo-ceo)) can read your training data and create or replace your active program with `create_program`.
 
-> ⚠️ **Pending [#266](https://github.com/PierreTsia/workout-app/issues/266)** — OpenClaw's strict Streamable-HTTP MCP transport opens an SSE stream that our edge function currently rejects with `405`. The wiring below is **valid for the day #266 ships**; until then you'll see `[bundle-mcp] failed to start server "gymlogic": Error: SSE error: Non-200 status code (405)` in the gateway logs. Cursor, Le Chat, and Claude Desktop all work today because they fall back to plain POST.
+> ⚠️ **Native `bundle-mcp` integration is not supported today.** OpenClaw 2026.3–2026.4 ships a `bundle-mcp` client that probes our endpoint with the legacy **HTTP+SSE transport (MCP protocol 2024-11-05)** — it expects every JSON-RPC response to be relayed back over a server-pushed SSE stream, which requires session-correlated stateful routing. Our MCP server runs on a stateless Supabase Edge Function and only implements the new **Streamable HTTP transport (2025-03-26)**, so registering `gymlogic` in `openclaw.json` will fail with `MCP server connection timed out after 30000ms`. **Use the [agent-driven `curl` pattern](#recommended-pattern-today--agent-driven-curl) below instead** — that's what [Iris (sudo-ceo)](https://github.com/PierreTsia/sudo-ceo) does in production. This page documents the eventual native config (which becomes correct the day OpenClaw upgrades to Streamable HTTP) but the verification step will time out today.
 
 ## Prerequisites
 
@@ -77,7 +77,7 @@ openclaw mcp list
 journalctl --user -u openclaw-gateway.service -n 30 --no-pager
 ```
 
-You're looking for `[bundle-mcp] starting server "gymlogic"` with no SSE errors. (Today, this is where you'll hit the [#266](https://github.com/PierreTsia/workout-app/issues/266) blocker.)
+You're looking for `[bundle-mcp] starting server "gymlogic"` with no SSE errors. **Today**, this is where you'll hit the legacy-transport timeout — expect `[bundle-mcp] failed to start server "gymlogic": Error: MCP server connection timed out after 30000ms` ~30s after boot. The PAT is correct, the URL is correct, the schema is correct — it's the transport mismatch described in the callout above. Skip native registration entirely and jump to [agent-driven `curl`](#recommended-pattern-today--agent-driven-curl).
 
 ## Available tools
 
@@ -129,16 +129,57 @@ Or template the file with `envsubst` and run `openclaw config validate` as a pre
 - **Revoke**: hit **Revoke** next to the token. Revocation is immediate and irreversible — the next request returns 401.
 - **Lost server / leaked token**: revoke the corresponding PAT. Any other tokens you created keep working.
 
+## Recommended pattern today — agent-driven `curl`
+
+While native `bundle-mcp` is blocked on the legacy transport (see top callout), agents on OpenClaw can still hit the MCP server directly using the built-in `exec` tool plus `curl`. This is exactly what [Iris (sudo-ceo)](https://github.com/PierreTsia/sudo-ceo) uses in production today, and it works for every tool we expose.
+
+### How it works
+
+1. Store the PAT as an env var on the OpenClaw host (e.g. `GYMLOGIC_PAT` in your service unit, `.env`, or shell profile).
+2. Don't register `gymlogic` under `mcp.servers` (it would only burn 30s at boot trying to handshake the legacy transport).
+3. Inject the MCP usage instructions into the agent's system prompt or skill registry — load [`skills/gymlogic-mcp/SKILL.md`](../../skills/gymlogic-mcp/SKILL.md) and tell the agent to call `exec` with `curl` against the MCP endpoint.
+
+The agent then runs requests like:
+
+```bash
+curl -sS -X POST https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp \
+  -H "Authorization: Bearer $GYMLOGIC_PAT" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Then for any tool call:
+
+```bash
+curl -sS -X POST https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp \
+  -H "Authorization: Bearer $GYMLOGIC_PAT" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_workout_history","arguments":{"limit":5}}}'
+```
+
+### Trade-offs vs native `bundle-mcp`
+
+| | Agent-driven `curl` (today) | Native `bundle-mcp` (future) |
+|---|---|---|
+| Tool list shown in OpenClaw UI | No | Yes |
+| Tool calls auto-validated against MCP schemas | No (agent shapes the JSON) | Yes |
+| Works with current OpenClaw (2026.3–2026.4) | **Yes** | No |
+| PAT rotation | Same env var, restart agent | Same env var, restart agent |
+| Audit trail of calls | Whatever your agent logs from `exec` | OpenClaw's own MCP log |
+
+Once OpenClaw ships Streamable-HTTP support, swap to the native registration above and drop the `curl` pattern.
+
 ## Troubleshooting
 
 | Problem | Fix |
 |---|---|
 | Gateway crash-loops after a config edit | Run `openclaw config validate` (or `OPENCLAW_CONFIG_PATH=/path/to/file openclaw config validate`) — almost always schema drift caught here. |
 | `Unrecognized key: mcpServers` | The schema is `mcp.servers`, NOT `mcpServers`. Different from Cursor / Claude Desktop. |
-| `SSE error: Non-200 status code (405)` | Blocked on [#266](https://github.com/PierreTsia/workout-app/issues/266) — server-side SSE support not shipped yet. No client-side workaround. |
+| `[bundle-mcp] failed to start server "gymlogic": Error: MCP server connection timed out after 30000ms` | Expected today. OpenClaw's legacy HTTP+SSE client isn't compatible with our stateless edge function (see top callout). Remove `gymlogic` from `openclaw.json` and use the [`curl` pattern](#recommended-pattern-today--agent-driven-curl) until OpenClaw upgrades to Streamable HTTP. |
+| `SSE error: Non-200 status code (405)` | You're on a server build older than the GET-SSE listener fix. Self-hosted Supabase: redeploy `supabase/functions/mcp`. Hosted gymlogic.me users get this for free. |
 | `401 Authentication required` | Token revoked, expired, or mistyped. Create a fresh one at [/account/api-tokens](https://gymlogic.me/account/api-tokens) and swap it in. |
 | `gymlogic` not appearing in `openclaw mcp list` | Re-check the JSON path — top-level key must be `mcp.servers.gymlogic`, not `mcpServers.gymlogic`. Then restart the gateway. |
-| Tools missing in agent chats but `mcp mcp list` shows the server | Restart the agent process — connector lists are cached at agent boot. |
+| Tools missing in agent chats but `mcp list` shows the server | Restart the agent process — connector lists are cached at agent boot. |
 
 ## Headless / scripted access (outside OpenClaw)
 

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -86,6 +86,66 @@ function json(body: unknown, status = 200, extraHeaders?: Record<string, string>
 const RESOURCE_METADATA_URL = `${MCP_URL}/.well-known/oauth-protected-resource`
 const WWW_AUTHENTICATE = `Bearer resource_metadata="${RESOURCE_METADATA_URL}"`
 
+// Heartbeat cadence for the GET-SSE listener stream. Keeps connections open
+// through proxy idle timeouts (Supabase / Cloudflare typically cut idle
+// streams around 90-100s) without burning excessive Edge Function compute.
+const SSE_HEARTBEAT_MS = 15_000
+
+// MCP Streamable HTTP (spec 2025-03-26) defines a GET endpoint that opens a
+// server-to-client SSE stream for unsolicited notifications/requests. We have
+// nothing to push (stateless tools, no server-initiated events), but strict
+// new-transport clients refuse to start when the GET returns 405. We return
+// an empty stream with periodic comment-only heartbeats to satisfy them.
+//
+// NOTE: this does NOT support the deprecated 2024-11-05 HTTP+SSE transport,
+// which expects every JSON-RPC response to be relayed back over the SSE
+// stream (stateful, session-correlated). A stateless Edge Function cannot
+// do that without external session storage. Legacy clients (e.g. OpenClaw
+// bundle-mcp 2026.3-2026.4, which probes GET first instead of POST as the
+// new spec recommends) will time out on initialize. They should either
+// upgrade to the new transport or use the agent-driven curl pattern.
+function handleSSE(authHeader: string): Response {
+  if (!authHeader.startsWith("Bearer ")) {
+    return json(
+      fail(null, -32000, "Authentication required"),
+      401,
+      { "WWW-Authenticate": WWW_AUTHENTICATE },
+    )
+  }
+
+  const encoder = new TextEncoder()
+  let interval: ReturnType<typeof setInterval> | undefined
+
+  const stream = new ReadableStream({
+    start(controller) {
+      // Initial comment flushes headers and confirms the stream is live.
+      controller.enqueue(encoder.encode(": stream open\n\n"))
+
+      interval = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(": heartbeat\n\n"))
+        } catch {
+          // Stream already closed by the client; cancel() will clean up.
+        }
+      }, SSE_HEARTBEAT_MS)
+    },
+    cancel() {
+      if (interval !== undefined) clearInterval(interval)
+    },
+  })
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      // Hint to nginx-style proxies not to buffer the stream.
+      "X-Accel-Buffering": "no",
+    },
+  })
+}
+
 async function handleWellKnown(url: URL): Promise<Response | null> {
   const path = url.pathname
 
@@ -127,6 +187,14 @@ Deno.serve(async (req) => {
   if (req.method === "GET") {
     const wellKnown = await handleWellKnown(new URL(req.url))
     if (wellKnown) return wellKnown
+
+    // Streamable HTTP listener stream — only opened when the client explicitly
+    // negotiates SSE via Accept. Other GETs still get the spec-compliant 405.
+    const accept = req.headers.get("Accept") ?? ""
+    if (accept.includes("text/event-stream")) {
+      return handleSSE(req.headers.get("Authorization") ?? "")
+    }
+
     return json(fail(null, -32600, "Only POST is supported"), 405)
   }
 


### PR DESCRIPTION
## What

- Add a GET SSE listener to the MCP edge function: `GET /mcp` with `Accept: text/event-stream` now returns a 200 stream with periodic heartbeats. Other GETs still return the spec-compliant 405.
- Document that native OpenClaw `bundle-mcp` integration is **not supported today**, and promote the agent-driven `curl` pattern (already used by Iris in sudo-ceo) as the recommended workaround in `docs/mcp-connect/openclaw.md`.

## Why

The original `[bundle-mcp] failed to start server "gymlogic": SSE error: Non-200 status code (405)` boot error is gone — strict new-transport clients (current and future) now connect cleanly. The fix is ~50 lines, spec-compliant for [Streamable HTTP MCP (2025-03-26)](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http), and forward-compatible.

Investigation surfaced that the deeper incompatibility is **OpenClaw bundle-mcp 2026.3-2026.4 using the deprecated 2024-11-05 HTTP+SSE transport**, which routes every JSON-RPC response back over a session-correlated SSE stream. That's stateful by design and impractical in a stateless Supabase Edge Function — bridging it would need external session storage (KV / Realtime). That work is captured as a follow-up issue (low priority, since the agent-driven `curl` workaround already works in production).

OpenClaw probes our endpoint with the legacy transport before falling back, so even after this PR, registering `gymlogic` in `openclaw.json` still times out at 30s on initialize. The doc update is honest about this and steers users to the working pattern.

## How

**`supabase/functions/mcp/index.ts`**
- New `handleSSE(authHeader)` returns a `ReadableStream` Response with `Content-Type: text/event-stream`, `Cache-Control: no-cache, no-transform`, and `X-Accel-Buffering: no` (proxy buffering hint).
- Stream emits `: stream open\n\n` immediately to flush headers, then a comment-only heartbeat every 15s to keep proxies (Supabase / Cloudflare) from cutting idle connections around the 90-100s mark.
- Heartbeat interval typed as `ReturnType<typeof setInterval>` to work cross-runtime (Deno returns `number`, Node returns `Timeout`).
- `cancel()` clears the interval on client disconnect.
- Auth: reuses the existing `Bearer` validation, returns 401 with `WWW-Authenticate` if missing.
- The GET handler now branches: `text/event-stream` → `handleSSE`, otherwise → 405 (preserves spec behavior for plain GETs).
- Comments explicitly note the legacy transport is not supported and why, so future maintainers don't re-investigate.

**`docs/mcp-connect/openclaw.md`**
- Top callout rewritten: explains the legacy-vs-new transport mismatch and points to the workaround section.
- New "Recommended pattern today — agent-driven \`curl\`" section with a trade-off table comparing it to native \`bundle-mcp\`.
- "Verify" step and troubleshooting table updated for the new expected error (\`MCP server connection timed out after 30000ms\` instead of \`SSE error: Non-200 status code (405)\`).

### Validation

- \`curl -sN -H "Accept: text/event-stream" -H "Authorization: Bearer \$PAT" .../mcp\` → returns 200 + immediate \`: stream open\` + \`: heartbeat\` every 15s. Verified against deployed function.
- \`curl -X POST .../mcp -d '{...tools/list...}'\` → unchanged JSON-RPC behavior. Verified.
- \`curl GET .../mcp\` (no SSE Accept) → still 405 per spec. Verified.
- OpenClaw gateway logs after redeploy: SSE 405 error gone; replaced by the deeper 30s init timeout (expected, see "Why").
- \`npm run lint\` → 0 errors (11 pre-existing warnings unrelated).
- \`npx tsc -b --noEmit\` → 0 errors.

Closes #266

Made with [Cursor](https://cursor.com)