### PR TITLE
fix(auth): cap getSession() with timeout + visible loader to kill black-screen on flaky network

### DIFF
--- a/src/lib/bootstrapAuth.test.ts
+++ b/src/lib/bootstrapAuth.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { Session } from "@supabase/supabase-js"
+import type { User } from "@/types/auth"
+import { bootstrapAuth } from "./bootstrapAuth"
+
+const FAKE_USER = { id: "user-123" } as User
+
+const buildSessionResult = (user: User | null) => ({
+  data: { session: user ? ({ user } as unknown as Session) : null },
+})
+
+describe("bootstrapAuth", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it("propagates the user and flips loading=false on resolve", async () => {
+    const setAuth = vi.fn()
+    const setLoading = vi.fn()
+    const onUser = vi.fn()
+
+    await bootstrapAuth({
+      getSession: () => Promise.resolve(buildSessionResult(FAKE_USER)),
+      setAuth,
+      setLoading,
+      onUser,
+    })
+
+    expect(setAuth).toHaveBeenCalledWith(FAKE_USER)
+    expect(onUser).toHaveBeenCalledWith(FAKE_USER)
+    expect(setLoading).toHaveBeenCalledWith(false)
+  })
+
+  it("sets user=null and skips onUser when no session is returned", async () => {
+    const setAuth = vi.fn()
+    const setLoading = vi.fn()
+    const onUser = vi.fn()
+
+    await bootstrapAuth({
+      getSession: () => Promise.resolve(buildSessionResult(null)),
+      setAuth,
+      setLoading,
+      onUser,
+    })
+
+    expect(setAuth).toHaveBeenCalledWith(null)
+    expect(onUser).not.toHaveBeenCalled()
+    expect(setLoading).toHaveBeenCalledWith(false)
+  })
+
+  it("falls back to user=null and still flips loading=false when getSession() rejects", async () => {
+    const setAuth = vi.fn()
+    const setLoading = vi.fn()
+    const onUser = vi.fn()
+
+    await bootstrapAuth({
+      getSession: () => Promise.reject(new Error("network down")),
+      setAuth,
+      setLoading,
+      onUser,
+    })
+
+    expect(setAuth).toHaveBeenCalledWith(null)
+    expect(onUser).not.toHaveBeenCalled()
+    expect(setLoading).toHaveBeenCalledWith(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it("times out a hung getSession() and continues offline", async () => {
+    vi.useFakeTimers()
+    const setAuth = vi.fn()
+    const setLoading = vi.fn()
+
+    const hung = new Promise<{ data: { session: Session | null } }>(() => {
+      // never resolves — simulates supabase-js silent refresh hanging on a
+      // flaky network. Without the timeout, authLoadingAtom would stick at
+      // true and AuthGuard would render null (= black screen).
+    })
+
+    const promise = bootstrapAuth({
+      getSession: () => hung,
+      setAuth,
+      setLoading,
+      timeoutMs: 50,
+    })
+
+    await vi.advanceTimersByTimeAsync(50)
+    await promise
+
+    expect(setAuth).toHaveBeenCalledWith(null)
+    expect(setLoading).toHaveBeenCalledWith(false)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("bootstrap timed out"),
+      expect.any(Error),
+    )
+  })
+
+  it("does not invoke setAuth twice when getSession() resolves before timeout", async () => {
+    vi.useFakeTimers()
+    const setAuth = vi.fn()
+    const setLoading = vi.fn()
+
+    const promise = bootstrapAuth({
+      getSession: () => Promise.resolve(buildSessionResult(FAKE_USER)),
+      setAuth,
+      setLoading,
+      timeoutMs: 5000,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    await promise
+
+    expect(setAuth).toHaveBeenCalledTimes(1)
+    expect(setAuth).toHaveBeenCalledWith(FAKE_USER)
+    expect(setLoading).toHaveBeenCalledTimes(1)
+    expect(setLoading).toHaveBeenCalledWith(false)
+  })
+
+  it("guarantees setLoading(false) even if setAuth throws synchronously", async () => {
+    const setLoading = vi.fn()
+    const setAuth = vi.fn(() => {
+      throw new Error("store unavailable")
+    })
+
+    await bootstrapAuth({
+      getSession: () => Promise.resolve(buildSessionResult(FAKE_USER)),
+      setAuth,
+      setLoading,
+    })
+
+    expect(setLoading).toHaveBeenCalledWith(false)
+  })
+})

--- a/src/lib/bootstrapAuth.ts
+++ b/src/lib/bootstrapAuth.ts
@@ -1,0 +1,96 @@
+import type { Session } from "@supabase/supabase-js"
+import type { User } from "@/types/auth"
+
+export interface BootstrapAuthOptions {
+  /** Function returning the supabase getSession() promise. Indirected for testability. */
+  getSession: () => Promise<{ data: { session: Session | null } }>
+  setAuth: (user: User | null) => void
+  setLoading: (loading: boolean) => void
+  /** Called once with the user when bootstrap surfaces a real session. */
+  onUser?: (user: User) => void
+  /**
+   * Hard cap on how long we wait for `getSession()` before giving up and booting
+   * the app as logged-out. supabase-js can hang internally when the stored JWT
+   * is expired and the silent token refresh request never resolves on a flaky
+   * network — without a timeout `authLoadingAtom` would stay `true` forever and
+   * `AuthGuard` would render `null` (= literal black screen).
+   */
+  timeoutMs?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 5000
+
+class AuthBootstrapTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`auth bootstrap timed out after ${ms}ms`)
+    this.name = "AuthBootstrapTimeoutError"
+  }
+}
+
+/**
+ * Resolves the initial auth session and flips `authLoadingAtom = false` no
+ * matter what. Always-resolving by design — three exit paths:
+ *
+ *  1. `getSession()` resolves → propagate the user (or `null`)
+ *  2. `getSession()` rejects → swallow + set user `null` (continue offline)
+ *  3. `timeoutMs` elapses first → swallow + set user `null` (continue offline)
+ *
+ * In (2) and (3) the supabase `onAuthStateChange` listener will still pick up
+ * a recovered session later, so the user transparently lands back into auth
+ * once the network is healthy again.
+ *
+ * Returns `void` because callers (the supabase module top-level) just need to
+ * fire-and-forget; they do not branch on the outcome.
+ */
+export async function bootstrapAuth(opts: BootstrapAuthOptions): Promise<void> {
+  const {
+    getSession,
+    setAuth,
+    setLoading,
+    onUser,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = opts
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  // Defensive `safe(...)` wrapper: every store mutation here must be guarded
+  // because `bootstrapAuth` is the one place where a thrown exception means
+  // the app never paints (loading would stay `true`). Empirically `store.set`
+  // doesn't throw, but we don't want a future atom-with-side-effects to
+  // re-introduce the black-screen failure mode.
+  const safe = (fn: () => void) => {
+    try {
+      fn()
+    } catch (error) {
+      console.warn("[auth] bootstrap callback threw, swallowing", error)
+    }
+  }
+
+  try {
+    const result = await Promise.race([
+      getSession(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new AuthBootstrapTimeoutError(timeoutMs)),
+          timeoutMs,
+        )
+      }),
+    ])
+
+    const user = (result.data.session?.user ?? null) as User | null
+    safe(() => setAuth(user))
+    if (user && onUser) {
+      safe(() => onUser(user))
+    }
+  } catch (error) {
+    if (error instanceof AuthBootstrapTimeoutError) {
+      console.warn("[auth] bootstrap timed out, continuing offline", error)
+    } else {
+      console.warn("[auth] bootstrap failed, continuing offline", error)
+    }
+    safe(() => setAuth(null))
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+    safe(() => setLoading(false))
+  }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -25,6 +25,7 @@ import {
 import { drainQueue } from "@/lib/syncService"
 import { clearSessionExercisePatchStorage } from "@/lib/sessionExercisePatchStorage"
 import { queryClient } from "@/lib/queryClient"
+import { bootstrapAuth } from "@/lib/bootstrapAuth"
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
@@ -38,12 +39,15 @@ const store = getDefaultStore()
 // sync their results to the existing atoms so guards + other readers keep
 // working, without the double-fetch (getSession + SIGNED_IN) and 406 noise
 // the previous imperative `.single()` calls produced.
-supabase.auth.getSession().then(({ data: { session } }) => {
-  store.set(authAtom, session?.user ?? null)
-  store.set(authLoadingAtom, false)
-  if (session?.user) {
-    drainQueue(session.user.id)
-  }
+//
+// `bootstrapAuth` wraps `getSession()` with a 5s timeout + always-resolving
+// guarantee so a hung silent-refresh on a flaky network can't deadlock boot
+// (issue #273 — black screen when `authLoadingAtom` never flipped to `false`).
+void bootstrapAuth({
+  getSession: () => supabase.auth.getSession(),
+  setAuth: (user) => store.set(authAtom, user),
+  setLoading: (loading) => store.set(authLoadingAtom, loading),
+  onUser: (user) => drainQueue(user.id),
 })
 
 export function clearUserState() {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "openMenu": "Open menu",
+  "loading": "Loading",
   "cancel": "Cancel",
   "delete": "Delete",
   "close": "Close",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -1,5 +1,6 @@
 {
   "openMenu": "Ouvrir le menu",
+  "loading": "Chargement",
   "cancel": "Annuler",
   "delete": "Supprimer",
   "close": "Fermer",

--- a/src/router/AuthGuard.tsx
+++ b/src/router/AuthGuard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react"
 import { useAtomValue } from "jotai"
 import { useTranslation } from "react-i18next"
 import { Navigate, Outlet } from "react-router-dom"
+import { Loader2 } from "lucide-react"
 import type { User } from "@/types/auth"
 import { authAtom, authLoadingAtom } from "@/store/atoms"
 import { AuthDataBridge } from "@/router/AuthDataBridge"
@@ -24,7 +25,7 @@ function scheduleShowNotificationDialog(setter: (open: boolean) => void) {
 }
 
 export function AuthGuard() {
-  const { t } = useTranslation("auth")
+  const { t } = useTranslation(["auth", "common"])
   const user = useAtomValue(authAtom)
   const authLoading = useAtomValue(authLoadingAtom)
   const [showDialog, setShowDialog] = useState(false)
@@ -54,8 +55,22 @@ export function AuthGuard() {
     prevUserRef.current = user
   }, [authLoading, user, permissionGranted])
 
+  // Visible fallback (vs. `return null`) so a hung auth bootstrap doesn't
+  // collapse to a black screen. `bootstrapAuth` caps `authLoading` at ~5s
+  // (issue #273) but a loader here is still the right user-facing signal.
   if (authLoading) {
-    return null
+    return (
+      <div
+        className="flex min-h-screen items-center justify-center bg-background"
+        data-testid="auth-loading"
+      >
+        <Loader2
+          className="h-8 w-8 animate-spin text-muted-foreground"
+          aria-hidden="true"
+        />
+        <span className="sr-only">{t("common:loading")}</span>
+      </div>
+    )
   }
 
   if (!user) {


### PR DESCRIPTION
## What

- New `bootstrapAuth({ getSession, setAuth, setLoading, onUser, timeoutMs })` helper in `src/lib/bootstrapAuth.ts`. Always flips `setLoading(false)` in `finally`, races `getSession()` against a 5s timeout, swallows hangs/rejections so the app boots as logged-out instead of dead-locking. Defensive `safe()` wrapper around store mutations.
- `src/lib/supabase.ts` wired to `bootstrapAuth` instead of the bare `.then(...)`.
- `src/router/AuthGuard.tsx` renders a fullscreen `Loader2` + `sr-only` label while `authLoading` (replaces the silent `return null`).
- New `loading` key in `common.json` (en + fr).
- New `src/lib/bootstrapAuth.test.ts` — 6 cases: resolve / no-session / reject / hang→timeout / single-call guarantee / setAuth-throws resilience.

## Why

A user reported a black screen at the gym (basement, intermittent connectivity) — she gave up and lost her workout session. **Nothing in Sentry**: it isn't an error, it's a hung promise.

Root cause: `supabase.auth.getSession()` is **not** purely local. When the stored JWT is near-expiry, supabase-js performs a silent token refresh against `/auth/v1/token` with no client-side timeout. On a flaky connection that request can hang indefinitely → `authLoadingAtom` stays `true` forever → `AuthGuard` returns `null` → black screen on the dark theme background.

Aggravating factors that this PR fixes:
- No `.catch()` on the `getSession()` promise → reject path also stuck loading
- No timeout → no graceful fallback to offline mode
- `AuthGuard` returned `null` → silent failure mode, no debug signal

## How

- `bootstrapAuth` uses `Promise.race` between `getSession()` and a `setTimeout` rejection (`AuthBootstrapTimeoutError`). The timer is cleared in `finally` to avoid leaks even on the happy path.
- All store writes go through `safe(fn)` — a try/catch wrapper that logs to console.warn and never re-throws. This protects `setLoading(false)` from any future atom-with-side-effects regressing the black-screen fix.
- On timeout/error: `setAuth(null)` + `setLoading(false)`. User lands on `/login` — graceful degradation. The existing `supabase.auth.onAuthStateChange` listener still picks up a recovered session later, so users transparently re-auth when the network is back.
- AuthGuard's loader uses `min-h-screen` + `bg-background` so it's themed correctly and never collapses to an empty paint.

Verified: `npm run lint` (0 errors), `npm run build` (OK), `npm run test` (1127/1127), `npx tsc --noEmit` clean.

Closes #273

Made with [Cursor](https://cursor.com)