### PR TITLE
feat(mcp): update_program tool — in-place program editing (Epic C #280)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,11 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-      - run: deno test "supabase/functions/mcp/lib/*_test.ts" --allow-env
+      # `--no-check=remote` skips typechecking of remote modules (e.g. supabase-js),
+      # which transitively reference @types/node and would otherwise require a Node
+      # toolchain in the Deno runner. Local sources are still typechecked, so the
+      # web/Edge parity guard for `programPersistence.ts` and `format.ts` holds.
+      - run: deno test --no-check=remote --allow-env "supabase/functions/mcp/lib/*_test.ts"
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,7 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-      # `--no-check=remote` skips typechecking of remote modules (e.g. supabase-js),
-      # which transitively reference @types/node and would otherwise require a Node
-      # toolchain in the Deno runner. Local sources are still typechecked, so the
-      # web/Edge parity guard for `programPersistence.ts` and `format.ts` holds.
-      - run: deno test --no-check=remote --allow-env "supabase/functions/mcp/lib/*_test.ts"
+      - run: deno test "supabase/functions/mcp/lib/*_test.ts" --allow-env
 
   e2e:
     runs-on: ubuntu-latest

--- a/docs/Epic_Brief_—_MCP_—_update_program_#280.md
+++ b/docs/Epic_Brief_—_MCP_—_update_program_#280.md
@@ -1,0 +1,164 @@
+# Epic Brief — MCP — update_program (#280)
+
+## Summary
+
+Ship the MCP `update_program` write tool — the third and final epic derived from #276 (Epic A `list_programs` / `get_program_details` shipped via #277, Epic B `create_program` prescription shipped via #279). `update_program` lets an AI assistant edit an existing program **in place by ID**: rename the program, add / remove / reorder / re-label days, swap exercises, and revise per-exercise prescription — all without recreating the program from scratch and without breaking the FK from `sessions.workout_day_id` to `workout_days.id` that ties historical training data to program structure.
+
+The patch shape is **PATCH at the top level, declarative inside `days` when supplied**: `name?` and `days?` are both optional, but when `days` is provided it is treated as the full desired list (PUT-style) — days carry an optional `id` to preserve identity. This unblocks natural prompts like *"remplace RDL par soulevé de terre conventionnel et passe le bench à 4×8 @ 80kg"* — today the agent has no addressable edit surface and falls back to `create_program`, which orphans historical sessions and breaks program identity.
+
+---
+
+## Context & Problem
+
+**Who is affected:** GymLogic users running an MCP-connected agent (Iris / OpenClaw, Claude Desktop, Le Chat, Cursor) for AI-assisted programming. Today the agent can list, read, and create programs (Epics A + B) but **cannot edit one in place** — every iteration requires a `create_program` call that drops historical session links and forces re-activation.
+
+**Current state:**
+
+- `create_program` (`file:supabase/functions/mcp/tools/createProgram.ts`) is the only program-write tool. It always inserts a new program and a fresh `workout_days` row tree — there's no surgical-edit surface.
+- `get_program_details` (`file:supabase/functions/mcp/tools/getProgramDetails.ts`, Epic A) exposes the `workout_days.id` so days are addressable from the agent — but it surfaces `workout_exercises.id` (the slot PK) instead of `exercise_id` (the catalog UUID), so an agent doing a swap or even *preserving* an exercise has no addressable handle on the catalog item.
+- `sessions.workout_day_id` references `workout_days(id)` with **no `ON DELETE` clause** (effectively `NO ACTION` — Postgres refuses to delete a `workout_days` row while sessions still point at it). Any "wipe and recreate" approach corrupts history or fails the FK.
+- `set_logs.exercise_id` references `exercises(id)`, **not** `workout_exercises(id)` — so wiping and reinserting `workout_exercises` rows for a given day is safe (no FK to break, history stays attached to the catalog exercise).
+- `cycles` has a partial unique index `one_active_cycle_per_program` on `(program_id, user_id) WHERE finished_at IS NULL` — so detecting a mid-cycle edit is a single `.eq("program_id", X).is("finished_at", null)` query.
+- `programs` has a partial unique index `programs_active_unique` on `(user_id) WHERE is_active = true`. Any `is_active` toggling on `update_program` would conflict with the create-time activation logic — explicitly out of scope.
+- `skills/gymlogic-mcp/SKILL.md` (post-Epic-B) advertises **8 tools** and still carries a stale line stating *"single-day editing is out of scope for MCP"* — Epic C invalidates that.
+
+**Pain points:**
+
+
+| Pain                                                                                                                          | Impact                                                                                                                                                     |
+| ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Agent has no in-place edit surface; iteration requires full program recreation                                                | Each prompt like *"swap RDL for conventional DL"* spawns a new program row, orphans historical sessions, breaks program identity, and forces re-activation |
+| Agent cannot preserve an exercise across an edit (no addressable `exercise_id` in `get_program_details`)                      | Even a no-op edit forces the agent to `search_exercises` by name for every preserved exercise — fragile (name collisions, French-vs-English)               |
+| Wipe-and-recreate would break the `sessions.workout_day_id` FK if the user has logged any session                             | Either a hard Postgres FK violation, or — if the FK were `CASCADE` — silent loss of historical training data                                               |
+| No mid-cycle awareness on the write surface                                                                                   | An agent edit during an active cycle silently changes the user's remaining workouts in that cycle with no warning back to the user                         |
+| Bulk destructive patches (agent hallucinates and re-sends the wrong structure) have no second-line guardrail beyond `dry_run` | A single confirmation flips an entire program structure, with no friction proportional to the destructiveness of the change                                |
+| Validation logic for the prescription union (Epic B) lives only in `create_program`                                           | Without sharing, `update_program` either duplicates the validation or drifts                                                                               |
+
+
+---
+
+## User Stories
+
+### Edit program metadata
+
+1. As an **AI assistant**, I want to call `update_program` with `{ program_id, name: "Push Pull Legs v2" }` and nothing else, so that I can rename a program in a single round-trip without re-sending its full day structure.
+2. As an **AI assistant**, when I omit `days` from the patch, I want the program's days to be left untouched, so that a metadata-only edit is unambiguous.
+
+### Add / remove / reorder days
+
+1. As an **AI assistant**, I want to add a new day by including an entry **without** an `id` in the `days[]` array, so that I can append "Cardio Light" to an existing 3-day split without re-creating the others.
+2. As an **AI assistant**, I want to reorder days by changing their position in the `days[]` array, so that the resulting `sort_order` reflects the array order without me passing `sort_order` explicitly.
+3. As an **AI assistant**, I want to remove a day by **omitting it** from the `days[]` array, so that I can drop "Saturday Cardio" from a program without sending an explicit delete op — provided no logged sessions reference it (see story 16).
+4. As an **AI assistant**, I want to rename a day by including its `id` and a new `label` (and optionally a new `emoji`), so that "Lundi" becomes "Push" without breaking session history.
+
+### Swap exercises and revise prescription
+
+1. As an **AI assistant**, I want to call `get_program_details` and receive each exercise's catalog `exercise_id` (not just the `workout_exercises` slot id), so that I can construct an `update_program` patch that preserves an exercise without re-searching for it by name.
+2. As an **AI assistant**, I want the `exercises[]` array per day in the patch to use the same union shape as Epic B (`string | { exercise_id, sets, reps, weight_kg, rest_seconds, target_duration_seconds? }`), so that I don't have to learn a second prescription syntax.
+3. As an **AI assistant**, when I include an exercise object in the patch, I want **all prescription fields** to be required (sets, reps, weight_kg, rest_seconds + target_duration_seconds for duration exercises), so that I can't accidentally emit a half-baked prescription assuming the existing values will be merged.
+4. As an **AI assistant**, when I send a day in the patch, I want every `workout_exercises` row of that day to be wiped and reinserted from the patch's `exercises[]` array, so that the day's prescription always exactly matches what I sent.
+
+### Default safety: dry_run + confirm
+
+1. As an **AI assistant**, when I call `update_program` without `dry_run: false`, I want the tool to default to a dry-run preview and not write anything, so that a typo or hallucinated patch never silently mutates the user's program.
+2. As an **AI assistant**, I want the dry_run preview to return the **full program state as it would be after apply** (program metadata + days + exercises with resolved weight echoes), so that I can show the user exactly what they're about to commit.
+3. As an **AI assistant**, I want the dry_run output to include auxiliary sections `removed_days[]` (each with `id`, `label`, `session_count`, `blocking`) and `added_days[]` and `warnings[]`, so that a destructive change is visible in addition to the final state.
+4. As an **AI assistant**, when the patch removes one or more days, I want the apply to require an explicit `confirm: true` flag in addition to `dry_run: false`, so that a destructive patch can't be applied with the same call shape as a benign one.
+
+### Hard guardrails (DB-enforced)
+
+1. As an **AI assistant**, when I send a day with `id: "<unknown-uuid>"` (not part of this program), I want a clear validation error explicitly suggesting *"omit the id to create a new day"*, so that I don't accidentally update the wrong program.
+2. As an **AI assistant**, when the patch removes a day that has logged sessions, I want a **structured error** naming the day, its session count, and the suggested remediation (*"rename or repurpose it instead"*), so that I never silently destroy historical data and so the agent can propose a working alternative to the user.
+3. As an **AI assistant**, when I send the same day `id` twice in the `days[]` array, I want a clear error so I don't trigger an undefined update order.
+4. As an **AI assistant**, when I send `days: []` (empty array) or a day with `exercises: []`, I want a validation error preserving the existing invariants (≥1 day per program, ≥1 exercise per day) — same rules as `create_program`.
+
+### Mid-cycle awareness
+
+1. As a **GymLogic user**, when an agent edits a program I'm currently in the middle of training (active cycle), I want the apply response to include a clear warning naming the active cycle, its `started_at` date, and stating *"this affects your remaining workouts in this cycle"*, so that I'm aware the change touches my live training.
+2. As an **AI assistant**, I want the same mid-cycle warning to appear in the dry_run response, so that I can ask the user for explicit confirmation before applying a mid-cycle change.
+
+### Failure transparency
+
+1. As a **GymLogic user**, when an `update_program` apply fails partway through (e.g. transient DB error after day 1 succeeded), I want the response to enumerate which days were applied (`applied_days[]`), at which day the apply failed (`failed_at`), and which days were not attempted (`remaining_days[]`), so that I (or the agent) can resume cleanly without re-applying what already landed.
+
+### Discoverability
+
+1. As a **GymLogic user setting up Iris / Claude Desktop**, I want `skills/gymlogic-mcp/SKILL.md` to advertise the 9th tool `update_program` with at least 3 worked examples (rename only, add a day, swap an exercise + revise prescription), and to drop the legacy *"single-day editing is out of scope"* line, so that the agent picks up the right syntax zero-shot.
+
+### Success measures
+
+
+| Story # | Measure                                                                                                                                                                                     |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 5, 16   | 100% of `update_program` applies leave `set_logs` and `sessions` untouched (verified via DB diff in E2E) — 0 rows mutated, deleted, or orphaned                                             |
+| 7       | `exercise_id` (catalog UUID) is present in 100% of `get_program_details` responses, alongside or replacing the slot id                                                                      |
+| 11      | `dry_run` defaults to `true` — verified by a test asserting that omitting both `dry_run` and `confirm` on a removal patch returns a preview with `removed_days[]` populated and 0 DB writes |
+| 14      | A patch that removes ≥1 day with `dry_run: false` and `confirm: false` (or omitted) returns a structured error and 0 DB writes                                                              |
+| 16      | A patch that removes a day with logged sessions returns the structured error in both dry_run and apply, regardless of `confirm: true`                                                       |
+| 19, 20  | Mid-cycle update response (dry_run AND apply) carries a warning string naming the cycle and the *"affects your remaining workouts"* clause                                                  |
+| 22      | `SKILL.md` advertises 9 tools and contains ≥3 worked `update_program` examples; the stale L188-style "single-day editing out of scope" line is removed                                      |
+
+
+Other stories are validated qualitatively through the user story itself.
+
+---
+
+## Scope
+
+**In scope:**
+
+1. `**update_program` MCP tool** — new 9th tool, registered after `create_program` in the registry. Input schema:
+  - `program_id: string` (required, UUID)
+  - `name?: string` (optional rename)
+  - `days?: Array<{ id?: string, label: string, emoji?: string, exercises: (string | { exercise_id, sets, reps, weight_kg, rest_seconds, target_duration_seconds? })[] }>` (optional; if provided, declarative full list)
+  - `dry_run?: boolean` (default `true`)
+  - `confirm?: boolean` (default `false`, required when patch removes ≥1 day)
+2. **Day identity semantics** — day with `id` matching an existing day → UPDATE; day without `id` → INSERT; existing day absent from `days[]` → DELETE (with FK pre-check). Position in array = `sort_order`. Duplicate `id`s rejected.
+3. **Exercise prescription shape** — strictly mirror `create_program` (Epic B union): bare-string UUID → defaults; object form requires ALL prescription fields. Validation primitives (`parseExerciseInput`, `validateExerciseCrossFields`, `parseRepsBounds`, `BOUNDS`) imported from `createProgramValidation.ts` as-is.
+4. **Wipe-and-reinsert per touched day** — for each day present in the patch, all `workout_exercises` rows of that day are deleted and reinserted from the patch (safe: nothing references `workout_exercises.id`). Days absent from the patch are not touched.
+5. `**get_program_details` extension** — replace `workout_exercises.id` with `exercise_id` in the returned markdown format and selected columns. The slot id (`workout_exercises.id`) is consumed nowhere downstream — verified during T1.
+6. **FK pre-check for day deletion** — for each day being removed, count `sessions WHERE workout_day_id = X`. If `> 0`, return a structured error in both `dry_run` and apply: *"Cannot remove day '**' — it has N logged sessions. Rename or repurpose it instead."*
+7. `**dry_run: true` default + structured output** — preview includes:
+  - `program` (full state after apply)
+  - `rendered` (markdown human-readable using `formatPrescriptionLine` / `formatWeightConvention`)
+  - `removed_days[]` with `{ id, label, session_count, blocking }`
+  - `added_days[]` with `{ label }`
+  - `warnings[]` (mid-cycle warning string when applicable)
+  - `errors[]` (FK violations, etc.) — non-empty `errors[]` returns `isError: true` and blocks apply
+  - `note` ("Dry-run — set dry_run: false to apply.")
+8. `**confirm: true` requirement on destructive patches** — when the patch removes ≥1 day, `dry_run: false` alone is rejected without `confirm: true`. Error message states the count of removed days and the required flag.
+9. **Active-cycle warning** — query `cycles WHERE program_id = X AND finished_at IS NULL`. If a row exists, append a warning string to `warnings[]` in both dry_run and apply: *"Cycle actif depuis YYYY-MM-DD — cette modification affecte vos workouts restants dans ce cycle."*
+10. **Per-day atomicity, partial-success report** — no cross-day rollback. If apply fails after day N succeeded, response includes `applied_days[]`, `failed_at: { day_label, error }`, `remaining_days[]`. All validation passes before the first DB write to minimize mid-flight failure causes (only transient infra issues should land here).
+11. **Tool description + `SKILL.md` update** — advertise the 9th tool, drop the legacy *"single-day editing is out of scope"* line, add ≥3 worked examples (rename only, add a day, swap + revise prescription).
+12. **Server version bump** — `SERVER_INFO.version` 0.3.x → 0.4.0 (additive: new tool + read-side `exercise_id` exposure; non-breaking for `create_program` callers).
+13. **Edge / web parity for any new persistence helpers** — if `update_program` extracts a new helper into `programPersistence.ts`, the existing fixture pattern (`programPersistence_fixtures.json`, consumed by both Vitest and Deno) is extended.
+
+**Out of scope:**
+
+- **Optimistic locking / concurrent-edit detection** — last-write-wins. Documented limitation in tool description.
+- `**is_active` toggling** — belongs to a future `set_active_program` tool. Partial unique index `programs_active_unique` would conflict with create-time activation logic.
+- **Schema migrations** — no `ON DELETE CASCADE` on `sessions.workout_day_id`, no rename of `set_logs.exercise_id` to point at `workout_exercises`. Pre-check pattern handles the FK safely.
+- **Per-set prescription overrides (drop sets, pyramid sets)** — schema is per-exercise; out of scope here as in Epic B.
+- **Web/UI changes** — no changes to the in-app builder, AI generation flow, or any React component. MCP-server-only.
+- **Renaming `createProgramValidation.ts` to `programValidation.ts`** — yak-shaving deferred. Imports happen as-is from the create-named module. If cohabitation becomes painful, rename in a follow-up.
+- **Optional / partial prescription fields on the object form** — the combined tech plan (`docs/done/Tech_Plan_—_MCP_—_Read_&_Edit_Programs_#276.md`) suggested optional fields; explicitly rejected here for symmetry with `create_program` and to avoid the "merge with existing" semantics.
+- `**force_delete: true` override** — no escape hatch for removing days with sessions. Rename / repurpose is the documented workaround.
+- **Cross-day rollback / compensating snapshot** — partial-success report covers user-visible recovery; transactional safety would require either a Postgres RPC migration or a heavier compensating-with-snapshot pattern, neither of which the MVP needs.
+- **Migration / backfill of programs created before Epic C** — `update_program` works on any existing program with stable `workout_days.id`; nothing to backfill.
+- **Bulk-edit primitives** (e.g. *"add 5kg to every weight in this program"*) — outside the agent-driven, declarative-patch model. The agent computes the patch client-side from `get_program_details` if it wants this UX.
+
+---
+
+## Success Criteria
+
+- **Numeric:** Across all `update_program` applies (dry-run + real) in the test suite, `set_logs` and `sessions` row counts are unchanged — verified via before/after `count(*)` snapshots in E2E.
+- **Numeric:** A `dry_run: true` (or omitted) call returns 0 DB writes, verified by a counter on `supabase.from(...).insert/update/delete` invocations in unit tests of the handler.
+- **Numeric:** A patch removing a day that has ≥1 session returns the structured FK error and produces 0 DB writes — verified in both dry_run and apply paths.
+- **Numeric:** A patch removing ≥1 day with `dry_run: false` and `confirm` omitted (or `false`) returns the destructive-guard error and produces 0 DB writes.
+- **Numeric:** A patch updating an existing day with new exercises produces a `workout_exercises` row count for that day matching `patch.days[i].exercises.length` exactly, and `set_logs.exercise_id` references for that day's historical sessions are unchanged.
+- **Numeric:** `SERVER_INFO.version` is `0.4.0` and `tools/list` returns 9 tools including `update_program` immediately after `create_program`.
+- **Numeric:** `get_program_details` response (markdown) contains each exercise's catalog `exercise_id` — verified in unit tests asserting on the rendered markdown shape.
+- **Qualitative:** A French prompt *"remplace RDL par soulevé de terre conventionnel et passe le bench à 4×8 @ 80kg"* resolves to a single `update_program` apply (not a `create_program`), preserving program identity and historical sessions.
+- **Qualitative:** A mid-cycle update response (dry_run AND apply) carries a visible warning naming the active cycle, its `started_at`, and the *"affects your remaining workouts"* clause.
+- **Qualitative:** A partial-success path (simulated transient DB error after day 1 succeeded) returns a response carrying `applied_days[1 entry]`, `failed_at: { day_label: "<failed day>", error: "<message>" }`, `remaining_days[N entries]` — agent or user can resume from the partial state.
+- **Qualitative:** `skills/gymlogic-mcp/SKILL.md` advertises 9 tools (rename / add-day / swap-exercise examples present), and the legacy *"single-day editing is out of scope"* line is removed.

--- a/docs/T76_—_get_program_details_Exposes_exercise_id.md
+++ b/docs/T76_—_get_program_details_Exposes_exercise_id.md
@@ -1,0 +1,80 @@
+# T76 — get_program_details Exposes exercise_id
+
+## Goal
+
+Replace the workout_exercise slot id with the catalog `exercise_id` in `get_program_details`'s markdown output, so an MCP-connected agent can construct an `update_program` patch that references catalog exercises (for swap or preservation) without going through `search_exercises` for every name. This unblocks Story 7 and is a hard prerequisite for Story 22 (the SKILL.md worked examples need a stable `exercise_id` to demo).
+
+Cites Epic Brief stories: **#7, #22 (partial)**.
+
+## Mode
+
+**AFK.** Single-line patches in 2 files + type extension + test assertion update + a one-line repo grep verification. No design judgement required.
+
+## Slice
+
+`tools/getProgramDetails.ts` → `lib/format.ts` → `vitest` → `rg` repo grep verification.
+
+This ticket ships an immediately demoable behavior: any MCP client calling `get_program_details` after T76 sees `*(exercise_id: ...)*` instead of `*(id: ...)*` in the markdown — independently of the rest of Epic C.
+
+## Dependencies
+
+**None.** Can ship in standalone PR before any other Epic C ticket.
+
+## Scope
+
+### File-level changes
+
+| File | Change |
+|---|---|
+| `supabase/functions/mcp/tools/getProgramDetails.ts` | (1) Line 69: extend the inner `select` projection to include `exercise_id`. New string: `"id, name, archived_at, workout_days(id, label, emoji, sort_order, workout_exercises(id, exercise_id, name_snapshot, sets, reps, weight, rest_seconds, target_duration_seconds, sort_order))"`. (2) Lines 20-29: extend `WorkoutExerciseRow` interface with `exercise_id: string`. (3) Line 95-99 mapping: forward `exercise_id` through to the format helper. |
+| `supabase/functions/mcp/lib/format.ts` | (1) Line ~239 (`ProgramDetailsExercise` interface): add `exercise_id: string`. (2) Line 268: change the rendered string from `*(id: ${ex.id})*` to `*(exercise_id: ${ex.exercise_id})*`. The slot `id` field stays in the type for any future reader but is no longer in markdown. |
+| `supabase/functions/mcp/lib/format_test.ts` (and any vitest equivalent) | Update assertion strings: any test that checks for `*(id: <slot-uuid>)*` in `formatProgramDetails` output must now check `*(exercise_id: <catalog-uuid>)*`. |
+
+### Repo grep verification (PR description requirement)
+
+Before merge, run and paste the output in the PR description:
+
+```bash
+rg "workout_exercises.*\(id:" --type=ts
+rg "ex\.id" supabase/functions/mcp/lib/format.ts
+```
+
+Expected output: zero downstream consumer of the slot id rendered in `formatProgramDetails`. If any consumer is found, **stop and add it to the PR conversation** — the design changes (we'd need to expose both `slot_id` and `exercise_id`).
+
+### Markdown output before/after
+
+**Before** (current):
+```
+### 💪 Push *(id: a1b2-...)*
+  - **Bench Press** *(id: c3d4-...)*: 4 × 8 reps @ 80 kg (rest 90s)
+```
+
+**After**:
+```
+### 💪 Push *(id: a1b2-...)*
+  - **Bench Press** *(exercise_id: e5f6-...)*: 4 × 8 reps @ 80 kg (rest 90s)
+```
+
+(The day `id` is `workout_days.id` and remains unchanged — required for `update_program`'s day identity. Only the per-exercise line changes.)
+
+## Out of Scope
+
+- Adding `update_program` itself (T81).
+- Showing both `slot_id` and `exercise_id` (only triggered if grep finds a consumer of the old slot id — escalate then).
+- Touching `get_upcoming_workouts` or any other tool that surfaces program structure.
+- Renaming the `id` field in the `WorkoutExerciseRow` type (kept for defensive completeness).
+
+## Acceptance Criteria
+
+- [ ] `tools/getProgramDetails.ts` `select` includes `exercise_id` in the inner `workout_exercises(...)` projection.
+- [ ] `WorkoutExerciseRow` and `ProgramDetailsExercise` types both carry `exercise_id: string`.
+- [ ] `formatProgramDetails` markdown output renders `*(exercise_id: <uuid>)*` (NOT `*(id: <uuid>)*`) for every exercise line — verified by an updated unit test.
+- [ ] All existing format / get_program_details tests pass green after the assertion update.
+- [ ] PR description includes the output of `rg "workout_exercises.*\(id:" --type=ts` showing zero consumer of the old slot id pattern (or, if a consumer is found, an explicit follow-up plan in the PR conversation).
+- [ ] Demoable end-to-end: a manual MCP call `get_program_details(program_id)` against any non-empty program returns markdown containing at least one `*(exercise_id: ...)*` token.
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_MCP_—_update_program_#280.md` (Story 7, 22)
+- Tech Plan: `file:docs/Tech_Plan_—_MCP_—_update_program_#280.md` ("`get_program_details` change" Key Decision; T1 in Implementation Sequence)
+- Modified files: `file:supabase/functions/mcp/tools/getProgramDetails.ts`, `file:supabase/functions/mcp/lib/format.ts`

--- a/docs/T77_—_Extract_Validation_+_Catalog_Helpers_+_Types.md
+++ b/docs/T77_—_Extract_Validation_+_Catalog_Helpers_+_Types.md
@@ -1,0 +1,174 @@
+# T77 — Extract Validation + Catalog Helpers + Types
+
+## Goal
+
+Pure refactor: extract three pieces from `createProgram.ts` into shared modules so that `update_program` (T81) can import them without code duplication and create + update stay in lockstep on validation semantics. This ticket adds NO new behavior — its acceptance criterion is *zero behavior change for `create_program`*. It also seeds `lib/updateProgramTypes.ts` so T78 and T79 can be developed in parallel against a shared type contract.
+
+Cites Epic Brief stories: **none directly** — this is plumbing that unblocks T78, T79, T80, T81. Without it, every downstream ticket either duplicates validation or coordinates ad-hoc on type shapes.
+
+## Mode
+
+**AFK.** Pure refactor with strict zero-behavior-change AC enforced by existing test suite. No design decisions.
+
+## Slice
+
+`tools/createProgram.ts` (refactor) → `lib/createProgramValidation.ts` (extension) → new `lib/catalogLookup.ts` → new `lib/updateProgramTypes.ts` → `lib/createProgramValidation.test.ts` (extended) → `lib/catalogLookup.test.ts` (new) → all existing tests stay green.
+
+The "demoable" sliver is verifying that `create_program` continues to behave identically: any prompt that worked before T77 must produce the same DB rows after T77.
+
+## Dependencies
+
+**None.** Can run in parallel with T76, T78, T79, T80.
+
+## Scope
+
+### Three extractions
+
+#### 1. `validateDayExercises` (extracted into `lib/createProgramValidation.ts`)
+
+Currently inline in `tools/createProgram.ts` around lines 280-330: the per-day loop that calls `parseExerciseInput` per exercise, accumulates errors, and returns `ParsedExercise[]`.
+
+New helper signature:
+
+```ts
+export function validateDayExercises(
+  rawExercises: unknown[],
+  dayLabel: string,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): { ok: true; parsed: ParsedExercise[] } | { ok: false; error: string }
+```
+
+Wraps:
+1. Loop over `rawExercises`, call `parseExerciseInput` for each.
+2. For each parsed exercise in object form, look up `catalogById.get(parsed.exerciseId)` and call `validateExerciseCrossFields(parsed, catalogExercise)`.
+3. Accumulate first error encountered, return structured `error` string referencing `dayLabel` and exercise index.
+4. On success, return `parsed` array.
+
+Catalog is **passed in** by the caller (which batches the fetch across all days). This module does NOT call supabase.
+
+#### 2. `fetchExercisesByIds` (extracted into new `lib/catalogLookup.ts`)
+
+Currently lines 99-121 of `tools/createProgram.ts`. Direct lift, no logic change.
+
+```ts
+export async function fetchExercisesByIds(
+  supabase: SupabaseClient,
+  ids: string[],
+): Promise<{ data: CatalogExerciseForProgram[]; error: string | null }>
+```
+
+- Single `IN (...)` query against `exercises` table.
+- Maps rows via `catalogRowToExercise` (which itself stays in `createProgram.ts` as a local helper UNLESS it's needed by `update_program` too — verify during refactor; if needed, also extract to `catalogLookup.ts`).
+- Error message names missing ids if any: `"Unknown or inaccessible exercise_id(s): ..."`.
+
+#### 3. `lib/updateProgramTypes.ts` (new file, types-only)
+
+Hosts the shared types that T78 (`updateProgramDiff`) and T79 (`updateProgramValidation`) both depend on. Types only, zero runtime code.
+
+```ts
+import type { ParsedExercise } from "./createProgramValidation.ts"
+
+export interface CurrentProgramSnapshot {
+  id: string
+  name: string
+  days: Array<{
+    id: string
+    label: string
+    emoji: string
+    sort_order: number
+    workout_exercises: Array<{
+      exercise_id: string
+      name_snapshot: string
+      sets: number
+      reps: string
+      weight: string
+      rest_seconds: number
+      target_duration_seconds: number | null
+      sort_order: number
+    }>
+  }>
+}
+
+export interface ParsedPatchDay {
+  id?: string                        // present → UPDATE; absent → INSERT
+  label: string
+  emoji?: string
+  parsed_exercises: ParsedExercise[]  // already validated
+}
+
+export interface ParsedPatch {
+  program_id: string
+  name?: string
+  days?: ParsedPatchDay[]
+  dry_run: boolean                    // resolved (default true)
+  confirm: boolean                    // resolved (default false)
+}
+
+export interface ProgramDiff {
+  program_id: string
+  name_change: { from: string; to: string } | null
+  days_to_insert: Array<{
+    label: string
+    emoji?: string
+    sort_order: number
+    parsed_exercises: ParsedExercise[]
+  }>
+  days_to_update: Array<{
+    id: string
+    current: { label: string; emoji: string; sort_order: number }
+    label: string
+    emoji: string
+    sort_order: number
+    parsed_exercises: ParsedExercise[]
+  }>
+  days_to_delete: Array<{
+    id: string
+    label: string
+    session_count: number   // populated post-FK-precheck (initially 0)
+    blocking: boolean       // populated post-FK-precheck
+  }>
+  days_unchanged: Array<{ id: string; label: string }>
+  apply_order: "default" | "insert_first"
+}
+```
+
+### File-level summary
+
+| File | Change |
+|---|---|
+| `supabase/functions/mcp/tools/createProgram.ts` | Remove inline validation loop (lines ~280-330) — replace with single call to `validateDayExercises(...)` per day. Remove inline `fetchExercisesByIds` (lines 99-121) — replace with import from `lib/catalogLookup.ts`. **Net LOC drop: ~80**. No behavior change. |
+| `supabase/functions/mcp/lib/createProgramValidation.ts` | **Add** export `validateDayExercises`. All existing exports unchanged. |
+| `supabase/functions/mcp/lib/catalogLookup.ts` | **New file.** Exports `fetchExercisesByIds`. ~30 LOC. |
+| `supabase/functions/mcp/lib/updateProgramTypes.ts` | **New file.** Types-only: `CurrentProgramSnapshot`, `ParsedPatchDay`, `ParsedPatch`, `ProgramDiff`. ~50 LOC. Zero runtime code. |
+| `supabase/functions/mcp/lib/createProgramValidation.test.ts` | **Add** direct tests for `validateDayExercises`: 1 happy path (mixed bare + object), 1 catalog miss, 1 cross-field rejection (bodyweight + weight_kg). |
+| `supabase/functions/mcp/lib/catalogLookup.test.ts` | **New file.** 1 happy path (returns mapped rows), 1 missing-id case (returns error naming missing ids). |
+
+### What does NOT move
+
+- `parseExerciseInput`, `validateExerciseCrossFields`, `parseRepsBounds`, `BOUNDS`, `detectLegacyExerciseIds`, `LEGACY_MIGRATION_ERROR_MESSAGE` — stay where they are in `createProgramValidation.ts`. `validateDayExercises` is added alongside.
+- `catalogRowToExercise` — stays local to `createProgram.ts` UNLESS the refactor reveals `update_program` needs it directly. Default: keep local; T81 will surface if a move is needed.
+- `geFromParsed` / `geFromParsedObject` / `defaultGeneratedExercise` — stay local to `createProgram.ts` (they convert ParsedExercise → GeneratedExerciseForProgram for create's specific persistence path; update_program uses a different path via `applyDayUpdate`).
+
+## Out of Scope
+
+- Renaming `createProgramValidation.ts` to `programValidation.ts` (deferred yak-shaving per Epic Brief).
+- Modifying any signature of `parseExerciseInput`, `validateExerciseCrossFields`, etc.
+- Adding any new validation rule to `create_program`.
+- Implementing anything in `lib/updateProgramTypes.ts` beyond type declarations.
+- Touching `programPersistence.ts` (T80's territory).
+
+## Acceptance Criteria
+
+- [ ] `createProgram.ts` no longer contains the inline per-day validation loop nor the inline `fetchExercisesByIds`. Both call sites delegate to imported helpers.
+- [ ] `lib/catalogLookup.ts` exists with `fetchExercisesByIds` exported and a minimal test (happy + missing-id).
+- [ ] `lib/createProgramValidation.ts` exports `validateDayExercises` with the documented signature; direct tests cover happy path + catalog miss + cross-field rejection.
+- [ ] `lib/updateProgramTypes.ts` exists as a types-only module exporting `CurrentProgramSnapshot`, `ParsedPatchDay`, `ParsedPatch`, `ProgramDiff`.
+- [ ] **Zero behavior change for `create_program`**: the existing `createProgramValidation.test.ts`, any `programPersistence.test.ts` cases, and any integration tests of `createProgram` pass unchanged after the refactor (no test assertion edits required for those suites).
+- [ ] Demoable end-to-end: a `create_program` MCP call with any valid Epic-B-shaped input produces the same DB rows after T77 as before — verified by running the existing test suite green AND a manual smoke call (any one prompt from the existing SKILL.md examples).
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_MCP_—_update_program_#280.md`
+- Tech Plan: `file:docs/Tech_Plan_—_MCP_—_update_program_#280.md` ("Validation extraction" + "Catalog lookup extraction" Key Decisions; T2 in Implementation Sequence)
+- Modified files: `file:supabase/functions/mcp/tools/createProgram.ts`, `file:supabase/functions/mcp/lib/createProgramValidation.ts`
+- New files: `file:supabase/functions/mcp/lib/catalogLookup.ts`, `file:supabase/functions/mcp/lib/updateProgramTypes.ts`

--- a/docs/T78_—_updateProgramDiff_Pure_Module.md
+++ b/docs/T78_—_updateProgramDiff_Pure_Module.md
@@ -1,0 +1,158 @@
+# T78 — updateProgramDiff Pure Module
+
+## Goal
+
+Implement the central pure function of Epic C: `computeProgramDiff(currentProgram, parsedPatch) → ProgramDiff`. This is the brain — it decides what changed (rename, days inserted/updated/deleted/unchanged) and computes the smart-reorder flag (`apply_order: "default" | "insert_first"`). Side-effect-free, supabase-free, fully testable through fixtures. T81's handler will consume this diff to render dry_run output AND to drive the apply orchestrator.
+
+Cites Epic Brief stories: **#2 (omit days = unchanged), #3 (add day), #4 (reorder via array position), #5 (omit existing day = delete), #6 (rename day), #8 (union exercise shape passes through), #10 (wipe-and-reinsert per touched day)**.
+
+## Mode
+
+**AFK.** Pure function. All test cases mechanically verifiable via JSON fixtures. No design judgement required mid-flight.
+
+## Slice
+
+`lib/updateProgramDiff.ts` (new) → `lib/updateProgram_fixtures.json` (new, JSON test data) → `lib/updateProgramDiff.test.ts` (new vitest, table-driven from fixture).
+
+Not demoable end-to-end as a user-facing change — this is a pure module. Demoable as: "given any input pair in the fixture, the diff matches the expected output exactly." The full demoability lands in T81.
+
+## Dependencies
+
+**Soft dep on T77** (for the shared types in `lib/updateProgramTypes.ts`). If T78 starts before T77 lands, the developer can locally inline the type definitions and replace with the import once T77 merges. **Recommended: wait for T77 to merge before opening T78 PR**.
+
+## Scope
+
+### `lib/updateProgramDiff.ts`
+
+```ts
+import type {
+  CurrentProgramSnapshot,
+  ParsedPatch,
+  ProgramDiff,
+} from "./updateProgramTypes.ts"
+
+/**
+ * Pure structural diff between the current program state and a parsed patch.
+ * Decides which days are inserted, updated, deleted, or unchanged, and sets
+ * the apply_order flag for the smart-reorder escape hatch.
+ *
+ * Pre-condition: parsedPatch.days has already passed validateDayIdentities
+ * (i.e. all provided ids exist in current.days; no duplicate ids).
+ */
+export function computeProgramDiff(
+  current: CurrentProgramSnapshot,
+  patch: ParsedPatch,
+): ProgramDiff
+```
+
+### Behavior specification
+
+| Input scenario | `name_change` | `days_to_insert` | `days_to_update` | `days_to_delete` | `days_unchanged` | `apply_order` |
+|---|---|---|---|---|---|---|
+| `name` provided + different from current.name; `days` undefined | `{from, to}` | [] | [] | [] | all current.days | `"default"` |
+| `name` provided = current.name; `days` undefined | null | [] | [] | [] | all current.days | `"default"` |
+| `name` undefined; `days` undefined | null | [] | [] | [] | all current.days | `"default"` |
+| `days` provided, all entries have matching `id` | name change as above | [] | all patch.days | [] | [] | `"default"` |
+| `days` provided, all entries are new (no `id`) | name change as above | all patch.days (sort_order = position) | [] | all current.days (with session_count = 0 placeholder) | [] | computed (see below) |
+| `days` provided mixed (some `id`, some not, some current.days omitted) | name change as above | patch entries without `id` | patch entries with `id` | current.days not referenced in patch | [] | computed |
+
+`apply_order = "insert_first"` when:
+- `current.days.length - days_to_delete.length === 0` (i.e. all current days are being deleted), AND
+- `days_to_insert.length > 0`
+
+Otherwise `"default"`.
+
+### Resolved fields per day
+
+For `days_to_update[i]`:
+- `id`: from patch
+- `current`: snapshot of the matching current day's `{label, emoji, sort_order}`
+- `label`: from patch (always provided per shape rule)
+- `emoji`: from patch IF provided, ELSE from `current.emoji`
+- `sort_order`: position-in-patch
+- `parsed_exercises`: from patch (already validated by upstream `validateDayExercises`)
+
+For `days_to_insert[i]`:
+- `label`, `emoji`, `parsed_exercises`: from patch
+- `sort_order`: position-in-patch
+- (no `current`)
+
+For `days_to_delete[i]`:
+- `id`, `label`: from current
+- `session_count`: 0 (placeholder — populated by handler post-FK-precheck)
+- `blocking`: false (placeholder)
+
+### `lib/updateProgram_fixtures.json`
+
+Array of test scenarios. Each scenario is a top-level object:
+
+```json
+{
+  "name": "human-readable scenario name",
+  "current": { ... CurrentProgramSnapshot ... },
+  "patch": { ... ParsedPatch ... },
+  "expected": { ... ProgramDiff ... }
+}
+```
+
+Required fixture scenarios (≥10):
+
+1. **rename only** — name change, days undefined → `name_change` set, all `days_to_*` empty, `days_unchanged` populated.
+2. **noop name** — name same as current, days undefined → `name_change` null.
+3. **add one day** — patch has all current days (with ids) + 1 new (no id) → `days_to_insert.length === 1`, `days_to_update.length === current.length`, `days_to_delete.length === 0`.
+4. **remove one day** — patch omits 1 current day → `days_to_delete.length === 1`, others updated.
+5. **rename day** — patch has matching id but different label → `days_to_update[0].current.label !== days_to_update[0].label`.
+6. **swap exercise** — patch's day has same id but parsed_exercises differs → `days_to_update[0].parsed_exercises` reflects the new list.
+7. **reorder days** — patch reverses the order of current days (with ids) → `days_to_update` entries have new `sort_order` reflecting array position.
+8. **mixed (add + remove + update)** — combination of 3, 4, 5 in one patch.
+9. **drain-to-0 + refill** — patch contains only new days (no `id`); ALL current.days will be deleted and new ones inserted → `apply_order === "insert_first"`.
+10. **emoji preserved when not in patch** — patch updates a day with same id, no `emoji` field → `days_to_update[0].emoji === current.emoji`.
+11. **no apply_order swap when partial drain** — patch removes 2 of 3 days but adds 0 → `apply_order === "default"` (escape hatch only triggers when 0-days transit + new inserts).
+
+### `lib/updateProgramDiff.test.ts`
+
+Table-driven vitest:
+
+```ts
+import fixtures from "./updateProgram_fixtures.json"
+import { computeProgramDiff } from "./updateProgramDiff"
+
+describe("computeProgramDiff", () => {
+  for (const scenario of fixtures) {
+    it(scenario.name, () => {
+      const result = computeProgramDiff(scenario.current, scenario.patch)
+      expect(result).toEqual(scenario.expected)
+    })
+  }
+})
+```
+
+Plus 1-2 additional tests outside the fixture for very specific things hard to express as static JSON (e.g. asserting that the function does NOT mutate its inputs).
+
+## Out of Scope
+
+- Validation of `parsedPatch` shape — assumed pre-validated by T79 upstream. The diff trusts its inputs.
+- Validation of day identity (no duplicate ids, ids exist in current) — assumed pre-validated by T79.
+- FK pre-check on `days_to_delete` — done by T81 handler. Diff sets `session_count = 0` placeholder.
+- Active cycle detection — done by T81 handler.
+- Any supabase calls.
+- Rendering markdown — done by T81 (`formatProgramAfterUpdate`).
+- Apply orchestration — done by T80.
+
+## Acceptance Criteria
+
+- [ ] `lib/updateProgramDiff.ts` exists, exports `computeProgramDiff` with the documented signature.
+- [ ] `lib/updateProgram_fixtures.json` exists with ≥10 scenarios covering all rows of the behavior matrix above.
+- [ ] `lib/updateProgramDiff.test.ts` runs table-driven tests over every fixture entry and all pass.
+- [ ] The "drain-to-0 + refill" fixture asserts `apply_order === "insert_first"`.
+- [ ] The "no apply_order swap when partial drain" fixture asserts `apply_order === "default"`.
+- [ ] Test asserting that `computeProgramDiff` does NOT mutate the input `current` or `patch` objects.
+- [ ] `npm test -- updateProgramDiff` runs green in isolation.
+- [ ] Demoable: any maintainer can add a new entry to `updateProgram_fixtures.json` and verify the diff function handles it just by re-running the test — proving the module is genuinely pure and fixture-driven.
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_MCP_—_update_program_#280.md` (Stories 2-6, 8, 10)
+- Tech Plan: `file:docs/Tech_Plan_—_MCP_—_update_program_#280.md` ("Diff module" Key Decision; "lib/updateProgramDiff.ts (the brain)" component description; T3 in Implementation Sequence)
+- Shared types: `file:supabase/functions/mcp/lib/updateProgramTypes.ts` (created in T77)
+- New files: `file:supabase/functions/mcp/lib/updateProgramDiff.ts`, `file:supabase/functions/mcp/lib/updateProgram_fixtures.json`, `file:supabase/functions/mcp/lib/updateProgramDiff.test.ts`

--- a/docs/T79_—_updateProgramValidation_Pure_Module.md
+++ b/docs/T79_—_updateProgramValidation_Pure_Module.md
@@ -1,0 +1,143 @@
+# T79 — updateProgramValidation Pure Module
+
+## Goal
+
+Implement the three pure validators that gate `update_program` input before any supabase write: (a) top-level patch shape parsing including the `is_active` rejection, (b) day identity rules (unknown ids, duplicates), (c) destructive-guard enforcement. All three return structured `{ ok, value } | { ok: false, error }` results. Each error message is purpose-crafted to guide the agent toward a fix without external doc lookup.
+
+Cites Epic Brief stories: **#11 (dry_run default), #14 (confirm: true requirement), #15 (unknown day id), #17 (duplicate day id), #18 (≥1 day, ≥1 exo invariants)**.
+
+## Mode
+
+**AFK.** Pure functions, every error message is a fixture. No design judgement.
+
+## Slice
+
+`lib/updateProgramValidation.ts` (new) → `lib/updateProgramValidation.test.ts` (new vitest covering every error branch).
+
+Not demoable end-to-end as user-facing — pure module. Demoable as: "every error message is exactly the wording expected by the agent (verified by string equality in tests)."
+
+## Dependencies
+
+**Soft dep on T77** for shared types (`ParsedPatch`, `ProgramDiff` from `lib/updateProgramTypes.ts`). Same coordination as T78. Can run in parallel with T78.
+
+## Scope
+
+### Three exported functions
+
+#### 1. `parsePatchShape(args)` — top-level patch shape
+
+```ts
+export function parsePatchShape(
+  args: Record<string, unknown>,
+): { ok: true; value: ParsedPatch } | { ok: false; error: string }
+```
+
+Validates and normalizes the raw MCP `args` object into a `ParsedPatch`. Order of checks:
+
+1. **`is_active` field rejection** (must come before generic "unknown field" check):
+   - If `args.is_active !== undefined` → return error: *"`is_active` is not editable via update_program. Use the dedicated `set_active_program` tool (coming soon)."*
+2. **`program_id`**:
+   - Required. Must be a UUID (use existing `isUuid` helper from `lib/uuid.ts`).
+   - Error: *"Invalid program_id format (expected UUID)."*
+3. **`name`** (optional):
+   - If present: must be a non-empty trimmed string.
+   - Error: *"`name` must be a non-empty string when provided."*
+4. **`days`** (optional):
+   - If present: must be an array.
+   - Length: 1 ≤ length ≤ 14.
+   - Error (empty): *"`days` must be a non-empty array when provided. Omit the field entirely to leave days unchanged, or pass at least one day."*
+   - Error (too many): *"days: too many entries (max 14)."*
+   - Per-day shape:
+     - `label` required, non-empty trimmed string. Error: *"days[i].label must be a non-empty string."*
+     - `emoji` optional string.
+     - `id` optional, must be UUID if present. Error: *"days[i].id must be a UUID when provided."*
+     - `exercises` required array, length 1-40. Error: *"days[i].exercises must be a non-empty array (≥1 exercise per day)."* / *"days[i].exercises: too many entries (max 40)."*
+     - **Note**: per-exercise validation is delegated to `validateDayExercises` (T77) — `parsePatchShape` only checks the array shape, not each exercise's contents.
+5. **`dry_run`** (optional, default `true`):
+   - If present: must be a boolean. Error: *"`dry_run` must be a boolean."*
+6. **`confirm`** (optional, default `false`):
+   - If present: must be a boolean. Error: *"`confirm` must be a boolean."*
+
+Returns `ParsedPatch` with `dry_run` and `confirm` resolved to their default values when omitted, and per-day `parsed_exercises: []` placeholder (filled by handler after calling `validateDayExercises`).
+
+#### 2. `validateDayIdentities(patchDays, currentDayIds)` — day identity rules
+
+```ts
+export function validateDayIdentities(
+  patchDays: ParsedPatchDay[],
+  currentDayIds: Set<string>,
+): { ok: true } | { ok: false; error: string }
+```
+
+Two rules:
+
+1. **No duplicate `id`** within the patch:
+   - Walk `patchDays`, track seen ids in a `Set`.
+   - On collision, error: *"days[<i>] and days[<j>] both reference id '<uuid>'. Each day id may appear at most once in the patch."*
+2. **All provided `id`s exist in current program**:
+   - For each `patchDays[i].id` (when defined), check it's in `currentDayIds`.
+   - On miss, error: *"days[<i>].id '<uuid>' is not a day of the current program. Omit the id to create a new day, or check the id."*
+
+Order: check duplicates first (cheaper); then check existence.
+
+#### 3. `requireConfirmForDestructive(diff, confirm)` — destructive-guard
+
+```ts
+export function requireConfirmForDestructive(
+  diff: ProgramDiff,
+  confirm: boolean,
+): { ok: true } | { ok: false; error: string }
+```
+
+If `diff.days_to_delete.length > 0` AND `confirm !== true`:
+- Error: *"Patch removes <N> day(s): <comma-separated labels>. Pass `confirm: true` along with `dry_run: false` to apply, or revise the payload to keep these days."*
+
+Otherwise `{ ok: true }`. (Note: `parsePatchShape` already enforces `confirm` is boolean. Here we just check truthiness.)
+
+### `lib/updateProgramValidation.test.ts`
+
+Vitest covering every error branch by exact string equality on the error message:
+
+| Test | Function | Input | Expected error contains |
+|---|---|---|---|
+| is_active rejected | `parsePatchShape` | `{ program_id, is_active: true }` | `"set_active_program"` |
+| invalid program_id | `parsePatchShape` | `{ program_id: "not-uuid" }` | `"expected UUID"` |
+| empty name | `parsePatchShape` | `{ program_id, name: "" }` | `"non-empty string"` |
+| days empty array | `parsePatchShape` | `{ program_id, days: [] }` | `"non-empty array"` |
+| days too long | `parsePatchShape` | `{ program_id, days: [...15 entries] }` | `"max 14"` |
+| day label missing | `parsePatchShape` | `{ program_id, days: [{ exercises: [] }] }` | `"days[0].label"` |
+| day exercises empty | `parsePatchShape` | `{ program_id, days: [{ label: "X", exercises: [] }] }` | `"≥1 exercise"` |
+| day id not uuid | `parsePatchShape` | `{ program_id, days: [{ id: "x", label: "Y", exercises: [...] }] }` | `"days[0].id must be a UUID"` |
+| dry_run not bool | `parsePatchShape` | `{ program_id, dry_run: "yes" }` | `"must be a boolean"` |
+| confirm not bool | `parsePatchShape` | `{ program_id, confirm: 1 }` | `"must be a boolean"` |
+| happy path defaults | `parsePatchShape` | `{ program_id }` | `ok: true, value.dry_run === true, value.confirm === false` |
+| duplicate day id | `validateDayIdentities` | `[{ id: "u1", ... }, { id: "u1", ... }]` | `"both reference id 'u1'"` |
+| unknown day id | `validateDayIdentities` | `[{ id: "u-unknown", ... }]`, `currentDayIds: Set(["u1"])` | `"is not a day of the current program"` |
+| confirm required | `requireConfirmForDestructive` | diff with `days_to_delete: [{label: "Cardio"}]`, `confirm: false` | `"Patch removes 1 day(s): Cardio"` |
+| confirm provided | `requireConfirmForDestructive` | same diff, `confirm: true` | `ok: true` |
+| no destructive | `requireConfirmForDestructive` | diff with `days_to_delete: []`, `confirm: false` | `ok: true` |
+
+## Out of Scope
+
+- Per-exercise validation (`parseExerciseInput`, `validateExerciseCrossFields`, `validateDayExercises`) — handled by T77's extractions, called by T81 handler.
+- Diff computation — T78.
+- FK pre-check / active cycle check — T81 handler.
+- Catalog fetch — T77's extracted `fetchExercisesByIds`.
+- Rendering errors as MCP `content[0].text` — T81 wraps these into the response shape.
+
+## Acceptance Criteria
+
+- [ ] `lib/updateProgramValidation.ts` exists, exports `parsePatchShape`, `validateDayIdentities`, `requireConfirmForDestructive` with the documented signatures.
+- [ ] Every error message in this ticket's behavior table is verified by exact string match in a test.
+- [ ] `parsePatchShape` happy path test asserts the resolved `dry_run: true` and `confirm: false` defaults.
+- [ ] `is_active` rejection test asserts the error string contains `"set_active_program"` (NOT a generic "unknown field" message).
+- [ ] All three functions return `{ ok: true, ... }` on valid input and `{ ok: false, error: <string> }` on invalid (no thrown errors, no nulls).
+- [ ] `npm test -- updateProgramValidation` runs green in isolation.
+- [ ] Demoable: a maintainer reading the test file can see, for every possible validation failure mode, the exact error string the agent will receive.
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_MCP_—_update_program_#280.md` (Stories 11, 14, 15, 17, 18)
+- Tech Plan: `file:docs/Tech_Plan_—_MCP_—_update_program_#280.md` ("lib/updateProgramValidation.ts" component description; T4 in Implementation Sequence)
+- Shared types: `file:supabase/functions/mcp/lib/updateProgramTypes.ts` (created in T77)
+- New files: `file:supabase/functions/mcp/lib/updateProgramValidation.ts`, `file:supabase/functions/mcp/lib/updateProgramValidation.test.ts`

--- a/docs/T80_—_updateProgramApply_+_applyDayUpdate.md
+++ b/docs/T80_—_updateProgramApply_+_applyDayUpdate.md
@@ -1,0 +1,190 @@
+# T80 — updateProgramApply + applyDayUpdate
+
+## Goal
+
+Implement the per-day apply orchestrator that walks a `ProgramDiff` and mutates supabase one day at a time, plus the low-level `applyDayUpdate` persistence helper that wipes-and-reinserts a single day's `workout_exercises`. Includes the smart-reorder escape hatch (insert-first when the patch would transit through a 0-days state) AND the partial-success report with the explicit retry guidance string. T80 is fully testable in isolation by constructing `ProgramDiff` instances manually and using a mock supabase — it does NOT depend on T78 at runtime.
+
+Cites Epic Brief stories: **#10 (wipe-and-reinsert per touched day), #19 (mid-cycle warning passage — value passed through), #20 (warning passes to dry_run too — value passed through), #21 (partial-success report shape)**.
+
+## Mode
+
+**AFK.** All scenarios mechanically verifiable via mock supabase. No design judgement.
+
+## Slice
+
+`lib/programPersistence.ts` (extension: `applyDayUpdate`) → `lib/updateProgramApply.ts` (new orchestrator) → `lib/updateProgramApply.test.ts` (new vitest with mock supabase) → tests for `applyDayUpdate` separately.
+
+Not demoable end-to-end as a user-facing change — pure orchestration. Demoable as: "given any `ProgramDiff`, apply succeeds and produces the documented `ApplyResult`, OR fails with a partial-success report carrying the retry guidance string verbatim."
+
+## Dependencies
+
+**Soft dep on T77** for shared types (`ProgramDiff` from `lib/updateProgramTypes.ts`). Can run in parallel with T78 and T79.
+
+T80's tests construct `ProgramDiff` instances manually (no `computeProgramDiff` call). This is intentional — keeps T80 a true unit test of the orchestrator, decouples from T78's fixture format.
+
+## Scope
+
+### `lib/programPersistence.ts` extension
+
+Add a single new exported helper. **Edge-only — no `src/lib/programPersistence.ts` mirror.**
+
+```ts
+export async function applyDayUpdate(
+  supabase: SupabaseClient,
+  dayId: string,
+  parsedExercises: ParsedExercise[],
+  catalogById: Map<string, CatalogExerciseForProgram>,
+  userId: string,
+): Promise<{ ok: true; inserted_count: number } | { ok: false; error: string }>
+```
+
+Implementation:
+
+1. **DELETE `workout_exercises`** for the given `dayId` (RLS scopes to user).
+   - On error, return `{ ok: false, error: <supabase error message> }`.
+2. **Build insert rows**: convert `parsedExercises` to `GeneratedExerciseForProgram[]` using a local helper `geFromParsedForApply(parsed, catalogById)` (mirrors `geFromParsed` from `createProgram.ts` but lives here since it's apply-specific). Then call existing `buildWorkoutExerciseInsertRowsForDay(dayId, generated, userId)`.
+3. **INSERT `workout_exercises`** in a single bulk insert.
+   - On error, return `{ ok: false, error }`.
+4. Return `{ ok: true, inserted_count: rows.length }`.
+
+Local helper (private to programPersistence.ts):
+
+```ts
+function geFromParsedForApply(
+  parsed: ParsedExercise,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): GeneratedExerciseForProgram {
+  const catalogEx = catalogById.get(parsed.exerciseId)
+  if (!catalogEx) throw new Error(`Catalog miss for exercise_id ${parsed.exerciseId}`)
+  // Same logic as createProgram.ts:geFromParsed (bare → defaults, object → freeze)
+}
+```
+
+(If T81 finds that `geFromParsed` from `createProgram.ts` is identical and callable from here, prefer the import. Otherwise local copy is fine — they're 20 LOC each.)
+
+### `lib/updateProgramApply.ts`
+
+```ts
+import type { ProgramDiff } from "./updateProgramTypes.ts"
+import type { CatalogExerciseForProgram } from "./programPersistence.ts"
+import { applyDayUpdate } from "./programPersistence.ts"
+
+export interface AppliedDay {
+  id: string                  // workout_days.id (filled post-INSERT for new days)
+  label: string
+  ops: Array<"meta_changed" | "exercises_replaced" | "inserted" | "deleted">
+}
+
+export interface ApplyResult {
+  applied_days: AppliedDay[]
+  failed_at: { day_label: string; error: string } | null
+  remaining_days: Array<{ label: string; intent: "delete" | "update" | "insert" }>
+  message: string
+}
+
+export async function applyProgramDiff(
+  supabase: SupabaseClient,
+  diff: ProgramDiff,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+  userId: string,
+): Promise<ApplyResult>
+```
+
+#### Orchestration logic
+
+1. **Step 0 — Program rename** (if `diff.name_change !== null`):
+   - `UPDATE programs SET name = ? WHERE id = ?`.
+   - On error: return `{ applied_days: [], failed_at: { day_label: "<program rename>", error }, remaining_days: <all days from diff>, message: <partial-failure with retry guidance> }`.
+
+2. **Step 1 — Build apply plan** based on `diff.apply_order`:
+   - `"default"`: `[...deletes, ...updates, ...inserts]` (concat).
+   - `"insert_first"`: `[...inserts, ...deletes, ...updates]` (concat).
+   - Each entry tagged with `intent: "delete" | "update" | "insert"` for the `remaining_days` shape.
+
+3. **Step 2 — Per-day loop**:
+   - For each `op` in plan:
+     - **delete**:
+       - DELETE workout_exercises (defensive even with CASCADE).
+       - DELETE workout_days WHERE id = op.id.
+       - On success: push `{ id: op.id, label: op.label, ops: ["deleted"] }` to `applied_days`.
+       - On error: return partial-success with `failed_at` and `remaining_days = <unprocessed ops>`.
+     - **update**:
+       - UPDATE workout_days SET label, emoji, sort_order WHERE id = op.id (only set fields that changed).
+       - Call `applyDayUpdate(supabase, op.id, op.parsed_exercises, catalogById, userId)`.
+       - Track ops: `["meta_changed", "exercises_replaced"]` if both changed, just one if only one.
+       - On success: push to `applied_days`.
+       - On error: return partial-success.
+     - **insert**:
+       - INSERT workout_days RETURNING id.
+       - INSERT workout_exercises via `buildWorkoutExerciseInsertRowsForDay` directly (NOT via `applyDayUpdate` since there's nothing to delete).
+       - On success: push `{ id: <new>, label: op.label, ops: ["inserted"] }`.
+       - On error: return partial-success.
+
+4. **Step 3 — Build message**:
+   - **Full success**: `"Updated <total> day(s)."`
+   - **Partial failure**: `"Updated <N> day(s). Failed at day '<failed_at.day_label>': <error>. <M> day(s) remaining. To retry, submit a new patch containing only the remaining_days (with their \`id\`s) plus any corrections; applied_days are already up to date and should be omitted from \`days[]\` (or included with their existing \`id\` to be left unchanged)."`
+
+5. Return the `ApplyResult`.
+
+### `lib/updateProgramApply.test.ts`
+
+Vitest with an in-memory mock supabase (a `MockSupabase` class that implements just `from(table).select/insert/update/delete/...`).
+
+Required test cases:
+
+| Test | Input ProgramDiff | Mock supabase behavior | Asserted output |
+|---|---|---|---|
+| **rename only success** | name_change set, no day ops | rename UPDATE succeeds | `applied: []`, `failed_at: null`, `message: "Updated 0 day(s)."` (rename succeeded, no day ops counted) |
+| **add one day success** | 1 insert | inserts succeed | `applied: [{ ops: ["inserted"] }]`, `failed_at: null` |
+| **update one day success** | 1 update | UPDATE + applyDayUpdate succeed | `applied: [{ ops: ["meta_changed", "exercises_replaced"] }]` (or just one if no meta change in diff) |
+| **delete one day success** | 1 delete | DELETEs succeed | `applied: [{ ops: ["deleted"] }]` |
+| **mid-flight failure at day 2** | 4 ops total | first op succeeds, second op DELETE fails | `applied.length === 1`, `failed_at.day_label === <2nd label>`, `remaining_days.length === 2`, `message` contains the verbatim retry guidance string |
+| **smart re-order: insert_first** | drain-to-0 + 1 insert (apply_order: "insert_first") | inserts run before deletes (verified by mock call order) | mock recorded INSERT before DELETE |
+| **smart re-order: default** | partial drain (apply_order: "default") | deletes run before inserts | mock recorded DELETE before INSERT |
+| **rename failure** | name_change set + 3 day ops | rename UPDATE fails | `applied: []`, `failed_at.day_label === "<program rename>"`, `remaining_days.length === 3` |
+
+The mock supabase tracks call order so smart-reorder can be asserted. Suggest a simple `MockSupabase` helper in the test file or a test util:
+
+```ts
+class MockSupabase {
+  private state: Map<string, Record<string, unknown>[]> = new Map()
+  public callLog: Array<{ table: string; op: string; args: unknown }> = []
+  // ... implement enough of the SupabaseClient surface for these tests
+}
+```
+
+### `applyDayUpdate` standalone test
+
+Add a few cases to the existing programPersistence test file (or new `applyDayUpdate.test.ts`):
+
+- 1 happy path: existing day with 3 exercises, applyDayUpdate with 5 new exercises → DELETE called once, INSERT called with 5 rows.
+- 1 catalog miss: parsedExercises references an id not in catalogById → throws / returns error.
+- 1 DELETE error: mock supabase returns error on DELETE → `{ ok: false, error }` propagated.
+
+## Out of Scope
+
+- Diff computation (T78).
+- Validation (T79).
+- Handler wiring (T81).
+- FK pre-check on `days_to_delete` (T81 handler — populates `session_count` on diff entries).
+- Active cycle warning generation (T81 handler — passes string into the response).
+- Format helpers (`formatProgramAfterUpdate`, `formatActiveCycleWarning` — T81).
+- Web mirror in `src/lib/programPersistence.ts` — explicitly out per Tech Plan.
+
+## Acceptance Criteria
+
+- [ ] `lib/programPersistence.ts` exports `applyDayUpdate` with the documented signature.
+- [ ] `lib/updateProgramApply.ts` exists, exports `applyProgramDiff` and `ApplyResult` / `AppliedDay` types.
+- [ ] All test cases in the behavior table pass green.
+- [ ] **Mid-flight failure test asserts the `message` field contains the exact retry guidance string** (verbatim match, not regex partial): *"To retry, submit a new patch containing only the remaining_days (with their `id`s) plus any corrections; applied_days are already up to date and should be omitted from `days[]` (or included with their existing `id` to be left unchanged)."*
+- [ ] **Smart re-order test verifies call order** via the MockSupabase callLog: in `apply_order: "insert_first"` scenarios, the INSERT calls precede the DELETE calls.
+- [ ] **Rename failure does NOT touch any day** — no DELETE/INSERT/UPDATE calls on workout_days or workout_exercises after the rename UPDATE failure (verified via callLog being empty post-rename).
+- [ ] Demoable: a maintainer can construct any `ProgramDiff` and confirm the apply behavior in isolation, with no need to spin up real supabase.
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_MCP_—_update_program_#280.md` (Stories 10, 19-21)
+- Tech Plan: `file:docs/Tech_Plan_—_MCP_—_update_program_#280.md` ("Apply order" + "Atomicity" + "Partial-success report" Key Decisions; "lib/updateProgramApply.ts" component description; T5 in Implementation Sequence)
+- Shared types: `file:supabase/functions/mcp/lib/updateProgramTypes.ts` (created in T77)
+- Modified file: `file:supabase/functions/mcp/lib/programPersistence.ts`
+- New files: `file:supabase/functions/mcp/lib/updateProgramApply.ts`, `file:supabase/functions/mcp/lib/updateProgramApply.test.ts`

--- a/docs/T81_—_updateProgram_Handler_+_Wire_+_Format_Helpers.md
+++ b/docs/T81_—_updateProgram_Handler_+_Wire_+_Format_Helpers.md
@@ -1,0 +1,265 @@
+# T81 — updateProgram Handler + Wire + Format Helpers
+
+## Goal
+
+Wire all the modules together: the new MCP tool `update_program` becomes callable end-to-end. The handler orchestrates auth → fetch current program (RLS-protected) → parse patch shape → validate day identities → catalog fetch → validate per-day exercises → compute diff → FK pre-check → active cycle check → destructive-guard → render dry_run output OR call apply orchestrator. Adds the two format helpers (`formatProgramAfterUpdate`, `formatActiveCycleWarning`) used only here. Bumps `SERVER_INFO.version` and registers the 9th tool. This is the first ticket where every Epic Brief story becomes observable.
+
+Cites Epic Brief stories: **#1 (single-call rename), #11 (dry_run defaults), #12 (full result in preview), #13 (auxiliary diff sections), #16 (FK pre-check structured error), #19, #20 (mid-cycle warning), #21 (partial-success report passed through)** — and **all** stories become demoable here for the first time.
+
+## Mode
+
+**AFK.** Every behavior is captured by integration tests against a fake supabase. No design judgement remains — all decisions tabled in Tech Plan and locked through T78-T80.
+
+## Slice
+
+`tools/updateProgram.ts` (new handler) → `tools/registry.ts` (insert) → `index.ts` (version bump) → `lib/format.ts` (extension: 2 new helpers) → `tools/updateProgram_test.ts` (new Deno integration test).
+
+**This is the demoable end-to-end ticket of Epic C** — once T81 lands, an MCP client can call `update_program` and observe every documented behavior.
+
+## Dependencies
+
+**Hard deps**: T77 (catalog helper, validateDayExercises, shared types), T78 (computeProgramDiff), T79 (parsePatchShape, validateDayIdentities, requireConfirmForDestructive), T80 (applyProgramDiff).
+
+**Soft dep**: T76 — both T76 and T81 touch `lib/format.ts`. If T76 is not yet merged, the developer rebases at the end. If T76 was already merged, no conflict.
+
+## Scope
+
+### File-level changes
+
+| File | Change |
+|---|---|
+| `supabase/functions/mcp/tools/updateProgram.ts` | **New file.** ~250 LOC. ToolDefinition with input schema + handler. |
+| `supabase/functions/mcp/tools/registry.ts` | Import `updateProgram`, append after `createProgram` in the `tools` array (becomes 9-element). |
+| `supabase/functions/mcp/index.ts` | Bump `SERVER_INFO.version`: `"0.3.x"` → `"0.4.0"`. |
+| `supabase/functions/mcp/lib/format.ts` | **Add** `formatProgramAfterUpdate(diff, currentProgram, catalogById): string` and `formatActiveCycleWarning(cycle: { started_at: string }): string`. |
+| `supabase/functions/mcp/tools/updateProgram_test.ts` | **New Deno integration test** covering 6+ scenarios with mock supabase. |
+
+### Handler shape
+
+```ts
+import type { ToolDefinition } from "./registry.ts"
+import { isUuid } from "../lib/uuid.ts"
+import { fetchExercisesByIds } from "../lib/catalogLookup.ts"
+import { validateDayExercises } from "../lib/createProgramValidation.ts"
+import {
+  parsePatchShape,
+  validateDayIdentities,
+  requireConfirmForDestructive,
+} from "../lib/updateProgramValidation.ts"
+import { computeProgramDiff } from "../lib/updateProgramDiff.ts"
+import { applyProgramDiff } from "../lib/updateProgramApply.ts"
+import { formatProgramAfterUpdate, formatActiveCycleWarning } from "../lib/format.ts"
+
+export const updateProgram: ToolDefinition = {
+  name: "update_program",
+  description: "...",  // see below
+  inputSchema: { ... },  // see below
+  async handler(args, supabase) { ... },  // see below
+}
+```
+
+### Handler orchestration (in this exact order)
+
+1. **Auth guard**: bail with *"Authentication required — please provide a valid Bearer token."* if `supabase` is null.
+2. **Fetch user_id**: `await supabase.auth.getUser()`. Required for `workout_days.user_id` on INSERTs.
+3. **Parse patch shape**: `parsePatchShape(args)`. Bail on `{ ok: false, error }` → return `{ content: [{ text: error }], isError: true }`.
+4. **Fetch current program** (single PostgREST call):
+   ```ts
+   const { data, error } = await supabase
+     .from("programs")
+     .select("id, name, workout_days(id, label, emoji, sort_order, workout_exercises(exercise_id, name_snapshot, sets, reps, weight, rest_seconds, target_duration_seconds, sort_order))")
+     .eq("id", parsedPatch.program_id)
+     .maybeSingle()
+   ```
+   - On error: bail with the error message.
+   - If `data === null`: bail with *"Program not found or you don't have access."* (RLS-filtered).
+   - Build `CurrentProgramSnapshot` from data.
+5. **Validate day identities**: `validateDayIdentities(parsedPatch.days, currentDayIds)`. Bail on error.
+6. **Catalog fetch (batched)**: collect every `exercise_id` referenced across all days in the patch (string or object form). Single call to `fetchExercisesByIds(supabase, ids)`. Build `catalogById: Map<string, CatalogExerciseForProgram>`.
+7. **Validate per-day exercises**: for each day in `parsedPatch.days`, call `validateDayExercises(day.rawExercises, day.label, catalogById)`. Bail on first error. On success, populate `day.parsed_exercises`.
+8. **Compute diff**: `computeProgramDiff(currentProgram, parsedPatch)`.
+9. **FK pre-check (batched)**: if `diff.days_to_delete.length > 0`:
+   ```ts
+   const { data, error } = await supabase
+     .from("sessions")
+     .select("workout_day_id, count")
+     .in("workout_day_id", diff.days_to_delete.map(d => d.id))
+     // PostgREST aggregate: use .group("workout_day_id") if supported, else fetch and reduce
+   ```
+   Annotate `diff.days_to_delete[i].session_count` and `blocking = (count > 0)`.
+10. **Active cycle check** (always run):
+    ```ts
+    const { data: cycleData } = await supabase
+      .from("cycles")
+      .select("started_at")
+      .eq("program_id", parsedPatch.program_id)
+      .is("finished_at", null)
+      .maybeSingle()
+    ```
+    If `cycleData`, build `warning: string` via `formatActiveCycleWarning(cycleData)`.
+11. **Build dry_run errors**: collect entries from `diff.days_to_delete` where `blocking === true` into `errors[]`. Each entry: `{ day_label: <label>, error: "Cannot remove day '<label>' — it has <N> logged sessions. Rename or repurpose it instead." }`.
+12. **Branch on `dry_run`**:
+    - **dry_run=true** (default):
+      - Render `rendered: string` via `formatProgramAfterUpdate(diff, currentProgram, catalogById)`.
+      - Build `removed_days[]` from `diff.days_to_delete` with `session_count` and `blocking`.
+      - Build `added_days[]` from `diff.days_to_insert` with `label` only.
+      - Build `warnings: string[]` (the active cycle warning if any).
+      - Build response payload (the `UpdateProgramDryRunOutput` shape from Tech Plan).
+      - If `errors.length > 0` → `isError: true`, else success.
+      - Return as `JSON.stringify(payload, null, 2)` in `content[0].text`.
+    - **dry_run=false**:
+      - Destructive-guard: `requireConfirmForDestructive(diff, parsedPatch.confirm)`. Bail on error.
+      - Blocking errors: if `errors.length > 0` → bail with structured FK error message (concat).
+      - Call `applyProgramDiff(supabase, diff, catalogById, user.id)`.
+      - Build response payload (the `UpdateProgramApplyOutput` shape) including `warnings: [activeCycleWarning]` if any.
+      - If `applyResult.failed_at !== null` → `isError: true` (partial failure), else success.
+      - Return as `JSON.stringify(payload, null, 2)`.
+
+### `inputSchema` (JSON Schema for MCP `tools/list`)
+
+```json
+{
+  "type": "object",
+  "required": ["program_id"],
+  "properties": {
+    "program_id": {
+      "type": "string",
+      "description": "UUID of the program to update. Obtain from list_programs or get_program_details."
+    },
+    "name": {
+      "type": "string",
+      "description": "Optional. New program name. Omit to leave the name unchanged."
+    },
+    "days": {
+      "type": "array",
+      "description": "Optional. Full desired list of days (declarative PUT-style inside this field). Days with `id` matching an existing day = UPDATE. Days without `id` = INSERT. Existing days NOT in this array = DELETE (requires `confirm: true` and FK pre-check). Omit the field entirely to leave days unchanged.",
+      "minItems": 1,
+      "maxItems": 14,
+      "items": {
+        "type": "object",
+        "required": ["label", "exercises"],
+        "properties": {
+          "id": { "type": "string", "description": "UUID of an existing day to UPDATE. Omit to INSERT." },
+          "label": { "type": "string" },
+          "emoji": { "type": "string" },
+          "exercises": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 40,
+            "items": {
+              "oneOf": [
+                { "type": "string", "description": "Bare UUID = legacy defaults (3×10 @ 0kg, 90s rest)." },
+                {
+                  "type": "object",
+                  "required": ["exercise_id", "sets", "reps", "weight_kg", "rest_seconds"],
+                  "properties": {
+                    "exercise_id": { "type": "string" },
+                    "sets": { "type": "integer", "minimum": 1, "maximum": 10 },
+                    "reps": { "type": "string", "description": "/^\\d+$/ or /^\\d+-\\d+$/, 1-50" },
+                    "weight_kg": { "type": "number", "minimum": 0, "maximum": 500 },
+                    "rest_seconds": { "type": "integer", "minimum": 0, "maximum": 600 },
+                    "target_duration_seconds": { "type": "integer", "minimum": 5, "maximum": 600 }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "dry_run": { "type": "boolean", "description": "Default true. Set false to apply." },
+    "confirm": { "type": "boolean", "description": "Default false. REQUIRED when patch removes ≥1 day." }
+  }
+}
+```
+
+### Tool description (string, in `description` field)
+
+Concise, agent-friendly. Includes:
+- One-line purpose.
+- The patch shape (PATCH top-level / declarative inside `days`).
+- The atomicity disclaimer ("per-day, no cross-day rollback — partial-success report on failure").
+- Pointer to dry_run default + confirm requirement on destructive patches.
+- Pointer to mid-cycle warning behavior.
+- Pointer to `set_active_program` (coming soon) for `is_active`.
+
+Target ~30-40 lines so it fits `tools/list` reasonably.
+
+### Format helpers in `lib/format.ts`
+
+```ts
+export function formatProgramAfterUpdate(
+  diff: ProgramDiff,
+  currentProgram: CurrentProgramSnapshot,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): string {
+  // Renders the human-readable markdown of the program AS IT WILL BE after apply.
+  // Uses formatPrescriptionLine + formatWeightConvention per exercise.
+  // Headers: program name (resolved post-rename), each day with label + emoji.
+  // For each day: render its parsed_exercises (or, for days_unchanged, its current workout_exercises).
+}
+
+export function formatActiveCycleWarning(cycle: { started_at: string }): string {
+  // Returns: "Cycle actif depuis YYYY-MM-DD — cette modification affecte vos workouts restants dans ce cycle."
+  // Date is YYYY-MM-DD, derived from started_at ISO string.
+}
+```
+
+### `tools/updateProgram_test.ts` (Deno integration test)
+
+Required scenarios with a fake supabase (in-memory state, RLS simulated by user_id filter):
+
+| Scenario | Input | Asserted output |
+|---|---|---|
+| **rename success** | `{ program_id, name: "PPL v2", dry_run: false }` | response is JSON with `applied_days: []`, `failed_at: null`, programs table state has new name |
+| **add day success** | `{ program_id, days: [...current with ids, ...new without id], dry_run: false }` | response includes new day with id, applied_days has 1 inserted |
+| **remove day blocked** | `{ program_id, days: [<one current day omitted>], dry_run: false, confirm: true }` (omitted day has sessions in fake state) | response `isError: true`, message contains *"has N logged sessions"*, no DB writes |
+| **destructive without confirm** | `{ program_id, days: [<one omitted>], dry_run: false }` (no confirm) | response `isError: true`, error contains *"Pass `confirm: true`"*, no DB writes |
+| **dry_run default zero writes** | `{ program_id, days: [...] }` (no dry_run flag) | mock supabase recorded zero INSERT/UPDATE/DELETE on workout_* tables, response is dry_run JSON with full program preview + removed_days/added_days populated |
+| **mid-cycle warning** | `{ program_id, name: "X", dry_run: false }` (fake state has unfinished cycle) | response.warnings contains the French warning string; same warning visible if dry_run defaults |
+| **partial success simulated** | full patch with 4 days, fake supabase fails on 2nd day's INSERT | response includes `applied_days: 1 entry`, `failed_at.day_label = <2nd day label>`, `remaining_days: 2 entries`, `message` contains the verbatim retry guidance |
+| **cross-user blocked** | `{ program_id: <other user's program> }` | response: *"Program not found or you don't have access."*, no DB writes (RLS-simulated by mock) |
+
+### Description of integration test mock supabase
+
+Shared with T80's mock or a copy. Implements:
+- `from(table).select(...)` with filtering + nested embeds for the program SELECT.
+- `from(table).insert(...).select()` returning the inserted row(s) with generated id.
+- `from(table).update(...).eq(...)`.
+- `from(table).delete().eq(...)` and `.in(...)`.
+- `from(table).maybeSingle()`.
+- `auth.getUser()` returning a fixed `{ user: { id: "user-1" } }`.
+- A `callLog` for asserting call order.
+- Optional fault injection: `supabase.failOn({ table: "workout_exercises", op: "insert", afterCalls: 2 })`.
+
+Suggest extracting into `supabase/functions/mcp/test/mockSupabase.ts` if T80 hasn't already done so.
+
+## Out of Scope
+
+- SKILL.md updates (T82).
+- Manual E2E with Iris (T82).
+- Any change to `create_program` (covered by T77's refactor).
+- New web-side functionality.
+- Implementing optional `is_active` field (rejected by T79's `parsePatchShape`; pointer-only message).
+- Multi-tool batch patches.
+
+## Acceptance Criteria
+
+- [ ] `tools/updateProgram.ts` exists with full handler implementation.
+- [ ] `tools/registry.ts` imports `updateProgram` and includes it in the `tools` array immediately after `createProgram` (verified: `tools/list` returns 9 tools, `update_program` is the 7th).
+- [ ] `SERVER_INFO.version` in `index.ts` is `"0.4.0"`.
+- [ ] `lib/format.ts` exports `formatProgramAfterUpdate` and `formatActiveCycleWarning` with the documented signatures.
+- [ ] All 8 integration test scenarios in the table pass green via `deno test supabase/functions/mcp/tools/updateProgram_test.ts`.
+- [ ] **Cross-user RLS test** asserts the response is *"Program not found or you don't have access."* (NOT a generic supabase error) when `program_id` belongs to another user.
+- [ ] **Mid-cycle warning test** asserts the warning string is present in BOTH the dry_run response (when no apply happens) AND the apply response.
+- [ ] **Partial success test** asserts the `message` field contains the verbatim retry guidance string (same one verified in T80).
+- [ ] **Demoable end-to-end via MCP**: starting from a non-empty program, calling `update_program` with `{ program_id, name: "X" }` (no other fields) renames the program and returns success — verified via the Deno integration test.
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_MCP_—_update_program_#280.md` (Stories 1, 11-13, 16, 19-21; all stories become demoable)
+- Tech Plan: `file:docs/Tech_Plan_—_MCP_—_update_program_#280.md` ("tools/updateProgram.ts" component description; T6 in Implementation Sequence)
+- Shared types: `file:supabase/functions/mcp/lib/updateProgramTypes.ts` (T77)
+- Imports from upstream tickets: T77 (`fetchExercisesByIds`, `validateDayExercises`), T78 (`computeProgramDiff`), T79 (validators), T80 (`applyProgramDiff`)
+- Modified files: `file:supabase/functions/mcp/tools/registry.ts`, `file:supabase/functions/mcp/index.ts`, `file:supabase/functions/mcp/lib/format.ts`
+- New files: `file:supabase/functions/mcp/tools/updateProgram.ts`, `file:supabase/functions/mcp/tools/updateProgram_test.ts`

--- a/docs/T82_—_SKILL.md_Update_+_Manual_E2E.md
+++ b/docs/T82_—_SKILL.md_Update_+_Manual_E2E.md
@@ -1,0 +1,170 @@
+# T82 — SKILL.md Update + Manual E2E
+
+## Goal
+
+Make `update_program` discoverable to MCP-connected agents (Iris, Claude Desktop, Le Chat, Cursor) by updating `skills/gymlogic-mcp/SKILL.md` with a precise tool roster entry, three worked French examples, and removal of the legacy stale "single-day editing is out of scope" line. Validate end-to-end by running each example through Iris (or Claude Desktop) and confirming zero-shot resolution to the right `update_program` shape.
+
+Cites Epic Brief stories: **#22 (SKILL.md advertises 9 tools, ≥3 worked examples, drops the L334-338 stale line)**. Indirectly validates the qualitative success criteria of the Epic ("a French prompt resolves to a single `update_program` apply").
+
+## Mode
+
+**HITL.** The SKILL.md patches themselves are mechanical, but the manual E2E phase requires a human:
+
+- Tap each of the 3 reference prompts in Iris (and ideally Claude Desktop)
+- Inspect the agent's chosen tool call shape
+- Judge whether the wording in SKILL.md is vivid enough to guide the agent zero-shot — this is editorial judgement (an AI agent cannot self-validate its own discoverability)
+- Iterate the wording if any prompt fails to resolve
+
+## Slice
+
+`skills/gymlogic-mcp/SKILL.md` (surgical patches in 3 places) → manual E2E with Iris/Claude Desktop → PR description includes screenshots / transcripts of the 3 prompts resolving correctly.
+
+This is the ticket where the qualitative success criteria of Epic C are observed: *"A French prompt 'remplace RDL par soulevé de terre conventionnel et passe le bench à 4×8 @ 80kg' resolves to a single `update_program` apply."*
+
+## Dependencies
+
+**Hard dep on T81** — the `update_program` tool must exist and be deployed (or runnable locally against a test Supabase) for the manual E2E to make sense.
+
+## Scope
+
+### Three SKILL.md patches
+
+#### Patch A — bump tool count in roster header
+
+Search the section that says "GymLogic MCP exposes **eight tools**" (or similar — current wording post-Epic-B). Replace with **nine tools**. Update any auxiliary count references in the same section.
+
+#### Patch B — add `update_program` row to tool roster
+
+Insert immediately AFTER the `create_program` row in the existing tool roster table. Format follows the pattern of the existing rows.
+
+Suggested entry:
+
+```markdown
+| `update_program` | Edit an existing program in place by id — rename, add / remove / reorder / re-label days, swap exercises, revise per-exercise prescription. Patch shape: PATCH at top-level (`name?`, `days?`); inside `days`, declarative full-list with optional `id` per day (id present → UPDATE, id absent → INSERT, omitted current day → DELETE). `dry_run: true` by default; pass `confirm: true` along with `dry_run: false` when removing days. Mid-cycle updates surface a warning. Atomicity is per-day — partial-success report on failure. |
+```
+
+#### Patch C — drop the legacy "single-day editing is out of scope" line
+
+Locate lines L334-338 (or wherever the stale line lives post-Epic-B; the Tech Plan referenced lines 334-338). The line reads roughly:
+
+> *"User asks to modify one day of an existing program → Out of scope for MCP — create_program replaces the whole program"*
+
+Replace this entire bullet with the new pattern guidance:
+
+> *"User asks to modify one day, swap an exercise, or rename a program → use `update_program` (NEVER `create_program` — that would orphan training history)."*
+
+(Adjust the exact wording to match the surrounding bullet style.)
+
+#### Patch D — add new "Common write patterns: update_program" section
+
+New sub-section, placed AFTER the existing Epic-B "Common write patterns" section (the one with `create_program` examples). Keep ≥3 worked French examples to maximize zero-shot value.
+
+**Example 1 — rename only**:
+
+> Prompt: *"renomme mon programme PPL en 'PPL v2'"*
+>
+> Resolution: single `update_program` call.
+>
+> ```json
+> {
+>   "program_id": "<from list_programs>",
+>   "name": "PPL v2",
+>   "dry_run": false
+> }
+> ```
+>
+> Expected response: `{ "applied_days": [], "failed_at": null, "message": "Updated 0 day(s)." }` (rename succeeded; no day ops).
+
+**Example 2 — add a day**:
+
+> Prompt: *"ajoute une journée Cardio à mon programme PPL avec 3 exos: course 4×30s, jump rope 4×60s, plank 4×45s"*
+>
+> Resolution: agent must fetch program details first (to get current days' ids), then send a patch with all current days (preserved by id) + 1 new day:
+>
+> ```json
+> {
+>   "program_id": "<from list_programs>",
+>   "days": [
+>     { "id": "<push day id>", "label": "Push", "exercises": [...same exercises as before, with exercise_id values...] },
+>     { "id": "<pull day id>", "label": "Pull", "exercises": [...] },
+>     { "id": "<legs day id>", "label": "Legs", "exercises": [...] },
+>     { "label": "Cardio", "emoji": "🏃", "exercises": [
+>       { "exercise_id": "<run uuid>", "sets": 4, "reps": "0", "weight_kg": 0, "rest_seconds": 60, "target_duration_seconds": 30 },
+>       { "exercise_id": "<jump rope uuid>", "sets": 4, "reps": "0", "weight_kg": 0, "rest_seconds": 60, "target_duration_seconds": 60 },
+>       { "exercise_id": "<plank uuid>", "sets": 4, "reps": "0", "weight_kg": 0, "rest_seconds": 60, "target_duration_seconds": 45 }
+>     ]}
+>   ],
+>   "dry_run": false
+> }
+> ```
+>
+> Note: the agent uses bare-string form for any day's exercises that don't change to keep the payload concise — but here the new Cardio day uses object form because we're prescribing duration explicitly.
+
+**Example 3 — swap an exercise + revise prescription**:
+
+> Prompt: *"remplace RDL par soulevé de terre conventionnel et passe le bench à 4×8 @ 80kg"*
+>
+> Resolution: agent fetches program details, identifies the day(s) containing RDL and the day containing bench. Sends a patch updating ONLY those days (others omitted from `days[]` → leave unchanged). Wait — that's wrong: omitting days from `days[]` triggers DELETE. Correct pattern: include ALL current days, modify the affected ones.
+>
+> ```json
+> {
+>   "program_id": "<from list_programs>",
+>   "days": [
+>     { "id": "<push day id>", "label": "Push", "exercises": [
+>       "<warmup exercise_id>",
+>       { "exercise_id": "<bench uuid>", "sets": 4, "reps": "8", "weight_kg": 80, "rest_seconds": 120 },
+>       "<accessory exercise_id>"
+>     ]},
+>     { "id": "<pull day id>", "label": "Pull", "exercises": [
+>       { "exercise_id": "<conventional deadlift uuid>", "sets": 3, "reps": "5", "weight_kg": 100, "rest_seconds": 180 },
+>       "<other pull exercise_id>"
+>     ]},
+>     { "id": "<legs day id>", "label": "Legs", "exercises": ["<legs exercise_id>"] }
+>   ],
+>   "dry_run": false
+> }
+> ```
+>
+> Note: this preserves the program's identity AND the historical sessions — `create_program` would have orphaned them.
+
+### Manual E2E acceptance
+
+For each of the 3 reference prompts above:
+
+1. Open Iris (or Claude Desktop) connected to the GymLogic MCP server (against a test Supabase with a non-empty PPL-shaped program).
+2. Type the French prompt verbatim.
+3. Observe the tool call(s) the agent makes.
+4. **Required**: the agent calls `update_program` (not `create_program`).
+5. **Required**: the call shape matches the documented schema (the agent fetches `get_program_details` first if needed for ids).
+6. **Required**: the response is non-error (or, if `dry_run: true` is the agent's first call, a clean preview).
+7. Capture screenshots / paste transcripts in the PR description.
+
+If any prompt fails to resolve:
+- Iterate the SKILL.md wording (typically: clearer naming, more vivid example, additional explicit hint about preserving days).
+- Re-test.
+- Loop until all 3 succeed OR escalate as a Tech Plan issue if a structural blocker emerges.
+
+## Out of Scope
+
+- Code changes (the handler is T81).
+- Adding worked examples for >3 prompts (e.g. mid-cycle, destructive with confirm, partial-success retry). If the 3 above are insufficient for zero-shot resolution, that's a SKILL.md content gap to address in this ticket; if they're sufficient, additional examples can land later as discovered needs.
+- Updating any other tool's SKILL.md entry beyond the surgical patches listed.
+- Translating the examples to English (current SKILL.md is bilingual; French primary).
+- Generating images / videos for the SKILL.md.
+
+## Acceptance Criteria
+
+- [ ] SKILL.md tool roster header says "**nine tools**" (or equivalent — exact wording matches surrounding style).
+- [ ] SKILL.md contains an `update_program` row in the tool roster table, placed immediately after `create_program`.
+- [ ] The legacy line at L334-338 (*"single-day editing is out of scope"*) is removed; replaced with a positive pointer to `update_program`.
+- [ ] SKILL.md contains a new sub-section with ≥3 worked `update_program` examples covering: rename only, add a day, swap exercise + revise prescription. Each example shows the prompt AND the JSON tool call shape AND the expected response shape.
+- [ ] **Manual E2E #1**: prompt *"renomme mon programme PPL en 'PPL v2'"* resolves to a single `update_program` call in Iris (transcript / screenshot in PR).
+- [ ] **Manual E2E #2**: prompt *"ajoute une journée Cardio à mon programme PPL avec 3 exos: course 4×30s, jump rope 4×60s, plank 4×45s"* resolves to a single `update_program` call (with prior `get_program_details` for ids) in Iris.
+- [ ] **Manual E2E #3**: prompt *"remplace RDL par soulevé de terre conventionnel et passe le bench à 4×8 @ 80kg"* resolves to a single `update_program` call (NOT `create_program`) preserving program identity in Iris.
+- [ ] PR description includes a verbatim transcript or screenshots of all 3 E2E sessions.
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_MCP_—_update_program_#280.md` (Story 22)
+- Tech Plan: `file:docs/Tech_Plan_—_MCP_—_update_program_#280.md` (`SKILL.md` updates Key Decision; T7 in Implementation Sequence)
+- Modified file: `file:skills/gymlogic-mcp/SKILL.md`

--- a/docs/Tech_Plan_—_MCP_—_update_program_#280.md
+++ b/docs/Tech_Plan_—_MCP_—_update_program_#280.md
@@ -1,0 +1,507 @@
+# Tech Plan — MCP — update_program (#280)
+
+## Architectural Approach
+
+### Key Decisions
+
+
+| Decision                          | Choice                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Rationale                                                                                                                                                                                                                                |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Patch shape**                   | PATCH at top-level (`name?`, `days?`, `dry_run?`, `confirm?`), declarative full-list inside `days` when supplied. `days: []` rejected.                                                                                                                                                                                                                                                                                                                                                                          | Allows trivial rename without re-sending day structure; declarative inside `days` keeps diff calculation deterministic and dry_run preview unambiguous.                                                                                  |
+| **Day identity semantics**        | Optional `id` on each day input. Present + matches → UPDATE. Absent → INSERT. Existing day not in payload → DELETE (FK pre-check first). Position in `days[]` array → `sort_order`. Duplicate `id`s rejected at validation.                                                                                                                                                                                                                                                                                     | Stable `workout_days.id` already preserved by Postgres `gen_random_uuid()`. Implicit position-as-sort_order mirrors `create_program` and avoids exposing `sort_order` to the agent.                                                      |
+| **Exercise prescription shape**   | Strict mirror of `create_program` (Epic B union): bare-string UUID → defaults; object form requires ALL prescription fields. Reuse `parseExerciseInput`, `validateExerciseCrossFields`, `parseRepsBounds`, `BOUNDS` from `createProgramValidation.ts` as-is.                                                                                                                                                                                                                                                    | Symmetry with create reduces surface and bugs; agent already has the per-day current state via `get_program_details` so re-sending the full day is acceptable verbosity.                                                                 |
+| **Validation extraction**         | New helper `validateDayExercises(rawExercises, dayLabel, catalogById) → { ok: true, parsed } | { ok: false, error }` extracted from `createProgram.ts`. Both create + update import it. Existing primitives (`parseExerciseInput`, etc.) unchanged.                                                                                                                                                                                                                                                             | Plumbing around the per-exercise primitives (loop + accumulate errors + structured output) was duplicated by Epic B; Epic C extracts now to prevent drift. Mini-refactor of create handler in scope, no behavior change.                 |
+| **Catalog lookup extraction**     | `fetchExercisesByIds` (currently private in `createProgram.ts:99-121`) extracted into new `lib/catalogLookup.ts`. Both create + update import it. Bundled with the validation extraction (same refactor ticket T2).                                                                                                                                                                                                                                                                                             | Same drift-prevention rationale as `validateDayExercises`; the function is non-trivial and lives at the catalog/validation boundary.                                                                                                     |
+| **Diff module**                   | Pure function `lib/updateProgramDiff.ts`: `computeProgramDiff(currentProgram, parsedPatch) → ProgramDiff`. Returns `{ name_change, days_to_insert, days_to_update, days_to_delete, days_unchanged }`.                                                                                                                                                                                                                                                                                                           | The diff is the central piece of Epic C — extracting it isolates complexity, makes it trivially testable, and produces a structured result that both dry_run renderer and apply orchestrator consume.                                    |
+| **Execution strategy**            | Per-day wipe-and-reinsert of `workout_exercises` rows for every day present in the patch (whether INSERT or UPDATE). Days absent from the patch are not touched.                                                                                                                                                                                                                                                                                                                                                | Safe because nothing references `workout_exercises.id` (`set_logs.exercise_id` points at `exercises`, verified). Mirror of `create_program` insert path — reuses `buildWorkoutExerciseInsertRowsForDay`.                                 |
+| **Apply order**                   | Default order: name change → deletes → updates → inserts. **Smart re-order escape hatch**: if applying deletes-first would transit through a 0-days state for the program (i.e. `current.days.length - days_to_delete.length + 0 === 0` when at least one insert is also planned), inverse the order to inserts-first → deletes-last.                                                                                                                                                                           | Default order is simplest and protects against sort_order collisions. The escape hatch handles the pathological case "drain to 0, then refill" without ever leaving the program in an empty intermediate state on failure.               |
+| **Atomicity**                     | Per-day atomic, no cross-day rollback. All validation passes BEFORE any DB write to minimize mid-flight failure causes (only transient infra issues should land here). Partial-success report on apply failure.                                                                                                                                                                                                                                                                                                 | Acted in grilling: cross-day transactional safety would require Postgres RPC migration, not justified for MVP. Documented limitation in tool description.                                                                                |
+| **Partial-success report**        | Apply response includes `applied_days[]` (with each day's ops), `failed_at: { day_label, error } | null`, `remaining_days[]`, and a `message` field that **explicitly explains the retry path**: *"To retry, submit a new patch containing only the remaining_days (with their `id`s) plus any corrections; applied_days are already up to date and should be omitted from `days[]` (or included with their existing `id` to be left unchanged)."*                                                              | Without explicit retry guidance, the agent must figure out itself that omitting an already-applied day from `days[]` would re-DELETE it. Subtle invariant — surfaced in the message.                                                     |
+| **Dry_run output**                | Full result (program-as-it-will-be) + auxiliary sections: `removed_days[]` (with `id, label, session_count, blocking`), `added_days[]`, `warnings[]` (mid-cycle), `errors[]` (FK violations). Non-empty `errors[]` returns `isError: true` and blocks apply.                                                                                                                                                                                                                                                    | Acted in grilling: full-result for symmetry with create, auxiliary diff for the issue's "removed days with session_count" requirement.                                                                                                   |
+| `**confirm: true` requirement**   | Required when `dry_run: false` AND patch removes ≥1 day. Otherwise rejected with explicit error stating count of removed days.                                                                                                                                                                                                                                                                                                                                                                                  | Acted in grilling: friction proportional to destructiveness. Benign edits stay 1-call.                                                                                                                                                   |
+| **Active-cycle warning**          | Plain string in `warnings[]` (both dry_run and apply): *"Cycle actif depuis YYYY-MM-DD — cette modification affecte vos workouts restants dans ce cycle."* Single query: `cycles WHERE program_id=X AND finished_at IS NULL`.                                                                                                                                                                                                                                                                                   | Acted in grilling: simple string is sufficient for both human readability and agent parsing. Structured shape can be added later without breaking.                                                                                       |
+| **FK pre-check**                  | Single batched query: `SELECT workout_day_id, count(*) FROM sessions WHERE workout_day_id IN (<ids_to_delete>) GROUP BY workout_day_id`. Block with structured error when `count > 0` for any candidate.                                                                                                                                                                                                                                                                                                        | One round-trip regardless of N days to delete. Trivial to implement vs N queries.                                                                                                                                                        |
+| `**get_program_details` change**  | Replace `workout_exercises.id` (slot id) with `exercise_id` (catalog UUID) in markdown format. Single line patched in `format.ts:268`, single field added to `select` in `getProgramDetails.ts:69`. T1 of the epic.                                                                                                                                                                                                                                                                                             | Slot id is consumed nowhere downstream (verified via repo grep at T1). Without `exercise_id` exposure, agent must `search_exercises` for every preserved exercise — fragile (name collisions, accents).                                  |
+| **Server version bump**           | `SERVER_INFO.version`: `"0.3.x"` → `"0.4.0"` (additive minor)                                                                                                                                                                                                                                                                                                                                                                                                                                                   | New tool + read-side `exercise_id` exposure. The slot_id swap is technically markdown-breaking but markdown is informal output; agents should not string-match opaque IDs.                                                               |
+| `**SKILL.md` updates**            | Bump tool count 8 → 9. Add `update_program` row to roster with 3 worked examples (rename only, add day, swap exercise + revise prescription). Drop legacy *"single-day editing is out of scope"* line at L334-338.                                                                                                                                                                                                                                                                                              | Per Epic Brief; agent loads SKILL.md as zero-shot context.                                                                                                                                                                               |
+| `**is_active` field rejection**   | If patch contains `is_active` at top level, reject with explicit error pointing to future `set_active_program` tool — not a generic "unknown field".                                                                                                                                                                                                                                                                                                                                                            | The DB has a partial unique index `programs_active_unique` that would conflict with create-time activation. Explicit error message guides agents away from the dead-end.                                                                 |
+| **Validation order**              | Handler-side, in this order: (1) auth + program ownership check, (2) top-level patch shape (`program_id` UUID, `name?` non-empty, `days?` array, `is_active` rejection), (3) per-day shape + day identity rules (id in current set, no duplicates), (4) reuse `validateDayExercises` for per-day exercises (with catalog fetch interleaved), (5) compute diff, (6) FK pre-check on `days_to_delete`, (7) destructive-guard (`confirm` flag), (8) build apply plan. Apply only when dry_run=false AND no errors. | Mirrors `createProgram.ts` ordering. Catalog fetch happens once for all exercise_ids across all days in the patch (single `IN (...)` query via the new shared helper). Ownership check first guards against confusing downstream errors. |
+| **No web mirror for new helpers** | `lib/updateProgramDiff.ts`, `lib/updateProgramValidation.ts`, `lib/updateProgramApply.ts`, and the new `applyDayUpdate` helper live ONLY in `supabase/functions/mcp/lib/`. No `src/lib/` mirror.                                                                                                                                                                                                                                                                                                                | `update_program` is strictly MCP-only; no web caller. The existing `programPersistence.ts` mirror remains untouched.                                                                                                                     |
+
+
+### Critical Constraints
+
+**RLS scoping is the security backbone** — `programs` policy is `FOR ALL USING (auth.uid() = user_id)` (`file:supabase/migrations/20260314000002_create_programs.sql:12-16`); `workout_days` policy is identical (`file:supabase/migrations/20240101000002_create_workout_days.sql:12-13`). Handler uses `createUserClient(authHeader)` (`file:supabase/functions/mcp/lib/supabaseClient.ts`) — any UPDATE / DELETE / INSERT for a row not owned by the caller silently no-ops (PostgREST returns 0 rows affected, no error). The handler MUST check the initial program SELECT returns `data !== null` and return *"Program not found or you don't have access."* (mirror `file:supabase/functions/mcp/tools/getProgramDetails.ts:81-85`).
+
+`**workout_days.user_id` is `NOT NULL` and FK to `auth.users`** (`file:supabase/migrations/20240101000002_create_workout_days.sql:3`). For each new day INSERT, the handler must pass `user_id` — fetched once via `supabase.auth.getUser()` at the top of the handler. `create_program` already does this (`file:supabase/functions/mcp/tools/createProgram.ts:418-420`).
+
+`**workout_days.program_id` is `NOT NULL ON DELETE CASCADE**` (`file:supabase/migrations/20260314000008_add_program_id_to_workout_days.sql:3-4`). Programs deletion would cascade to days — irrelevant to `update_program` but means we can never end up with orphan days from a partial apply.
+
+`**sessions.workout_day_id` is `REFERENCES workout_days(id)` with NO `ON DELETE` clause** (`file:supabase/migrations/20240101000004_create_sessions.sql:4`). Effective behavior is `NO ACTION` — Postgres refuses to delete a `workout_days` row while a session points at it. The pre-check handles this ergonomically; the DB constraint is the safety net if the pre-check is ever bypassed.
+
+`**set_logs.exercise_id` references `exercises(id)`, NOT `workout_exercises(id)`** (`file:supabase/migrations/20240101000005_create_set_logs.sql:4`). This is THE invariant that makes wipe-and-reinsert safe: deleting/reinserting `workout_exercises` rows breaks no FK from set_logs. **If this ever changes**, Epic C's execution strategy is invalidated.
+
+`**workout_exercises.exercise_id` is `NOT NULL REFERENCES exercises(id)`** (`file:supabase/migrations/20240101000003_create_workout_exercises.sql:4`). Each INSERT must reference a valid catalog id — the catalog fetch step covers this.
+
+`**workout_exercises.name_snapshot` must be re-fetched from catalog at INSERT time**, even for "preserved" exercises in an UPDATE day. If the catalog name changed since the program was created, the new snapshot reflects the current name. Same convention as `create_program` (`file:supabase/functions/mcp/tools/createProgram.ts:43-46`).
+
+`**weight` is `TEXT NOT NULL DEFAULT '0'`** in `workout_exercises` — string, not numeric. Cast `weight_kg: number` to `String(weight_kg)` on INSERT. Reused as-is from `programPersistence.ts`.
+
+`**is_active` toggling is explicitly excluded** from the input schema. The partial unique index `programs_active_unique` on `(user_id) WHERE is_active = true` (`file:supabase/migrations/20260314000002_create_programs.sql:18-19`) would conflict with create-time activation logic; out of scope per Epic Brief. Handler returns a specific error pointing at the future `set_active_program` tool when an agent passes `is_active` in the patch (rather than a generic "unknown field").
+
+**Validation order matters for security** — the program ownership check (step 1) must happen BEFORE validating day identities (step 3). Otherwise an agent passing a day `id` from another user's program gets a confusing "unknown day id" error instead of "program not found". Cleaner UX + tighter security signal.
+
+`**createProgramValidation.ts` is shared, not renamed** — `update_program` imports as-is. New helpers `validateDayExercises` (extracted from `createProgram.ts`) and `fetchExercisesByIds` (extracted into `lib/catalogLookup.ts`) are added to the shared surface. Cohabitation acceptable — names are imperfect but rename is yak-shaving.
+
+**Apply order escape hatch invariant**: when computing the plan, if `current.days.length - days_to_delete.length === 0` AND `days_to_insert.length > 0`, the apply plan is reversed: inserts go first (creating new days), then deletes. This guarantees the program is never observably empty mid-flight (even if the apply fails after some deletes, the new days have already landed). For all other patterns, default delete → update → insert order applies.
+
+**Cold start neutrality** — new tool + new modules add ~700 LOC + 1 fixture file. Bundle size impact negligible. No new external dependencies.
+
+---
+
+## Data Model
+
+No schema changes, no new tables, no new columns, no migration. Epic C operates entirely on existing schema.
+
+```mermaid
+classDiagram
+  class programs {
+    +uuid id
+    +uuid user_id
+    +text name
+    +bool is_active
+    +timestamptz archived_at
+  }
+  class workout_days {
+    +uuid id
+    +uuid user_id
+    +uuid program_id
+    +text label
+    +text emoji
+    +int sort_order
+  }
+  class workout_exercises {
+    +uuid id
+    +uuid workout_day_id
+    +uuid exercise_id
+    +text name_snapshot
+    +int sets
+    +text reps
+    +text weight
+    +int rest_seconds
+    +int sort_order
+    +int target_duration_seconds
+  }
+  class sessions {
+    +uuid id
+    +uuid workout_day_id
+    +uuid cycle_id
+  }
+  class cycles {
+    +uuid id
+    +uuid program_id
+    +timestamptz finished_at
+  }
+  class set_logs {
+    +uuid id
+    +uuid session_id
+    +uuid exercise_id
+  }
+  programs --> workout_days : program_id ON DELETE CASCADE
+  workout_days --> workout_exercises : workout_day_id ON DELETE CASCADE
+  workout_days <-- sessions : workout_day_id NO ACTION (blocks delete)
+  cycles <-- sessions : cycle_id
+  programs --> cycles : program_id ON DELETE CASCADE
+  set_logs --> sessions : session_id ON DELETE CASCADE
+```
+
+
+
+### Tool input/output shapes (TypeScript)
+
+```ts
+// update_program input
+type UpdateProgramInput = {
+  program_id: string                              // required, UUID
+  name?: string                                   // optional rename, non-empty when present
+  days?: Array<{
+    id?: string                                   // present → UPDATE; absent → INSERT
+    label: string                                 // required, non-empty
+    emoji?: string                                // optional, defaults to current value if id provided
+    exercises: Array<                             // required, non-empty (≥1 per day invariant)
+      | string                                    // bare UUID = legacy defaults (3×10 @ 0kg, 90s rest)
+      | {
+          exercise_id: string
+          sets: number                            // 1-10
+          reps: string                            // /^\d+$/ or /^\d+-\d+$/, 1-50
+          weight_kg: number                       // 0-500 (rejected if equipment===bodyweight && >0)
+          rest_seconds: number                    // 0-600
+          target_duration_seconds?: number        // required iff measurement_type==='duration'; 5-600
+        }
+    >
+  }>
+  dry_run?: boolean                               // default true
+  confirm?: boolean                               // default false; required when patch removes ≥1 day
+}
+
+// computeProgramDiff output (lib/updateProgramDiff.ts)
+type ProgramDiff = {
+  program_id: string
+  name_change: { from: string; to: string } | null
+  days_to_insert: Array<{
+    label: string
+    emoji?: string
+    sort_order: number                            // position in patch.days
+    parsed_exercises: ParsedExercise[]            // already validated
+  }>
+  days_to_update: Array<{
+    id: string
+    current: { label: string; emoji: string; sort_order: number }
+    label: string                                 // possibly unchanged
+    emoji: string                                 // resolved (kept current if not provided)
+    sort_order: number                            // possibly unchanged
+    parsed_exercises: ParsedExercise[]
+  }>
+  days_to_delete: Array<{
+    id: string
+    label: string
+    session_count: number                         // populated after FK pre-check
+    blocking: boolean                             // true iff session_count > 0
+  }>
+  days_unchanged: Array<{ id: string; label: string }>
+  apply_order: "default" | "insert_first"        // smart re-order flag (set by post-diff orchestrator)
+}
+
+// dry_run output
+type UpdateProgramDryRunOutput = {
+  dry_run: true
+  program: {                                      // full state as it will be after apply
+    id: string
+    name: string
+    workout_days: Array<{
+      id: string | null                           // null for new days (no id yet)
+      label: string
+      emoji: string
+      sort_order: number
+      workout_exercises: Array<{
+        exercise_id: string
+        name_snapshot: string                     // resolved from catalog
+        sets: number
+        reps: string
+        weight: string
+        rest_seconds: number
+        target_duration_seconds: number | null
+        sort_order: number
+      }>
+    }>
+  }
+  rendered: string                                // human-readable markdown using formatProgramAfterUpdate
+  removed_days: Array<{ id: string; label: string; session_count: number; blocking: boolean }>
+  added_days: Array<{ label: string }>
+  warnings: string[]                              // mid-cycle warning string when applicable
+  errors: Array<{ day_label: string; error: string }>  // FK violations etc.
+  note: string                                    // "Dry-run — set dry_run: false to apply (and confirm: true if removing days)."
+}
+
+// apply output (success or partial)
+type UpdateProgramApplyOutput = {
+  dry_run: false
+  program_id: string
+  applied_days: Array<{
+    id: string                                    // workout_days.id (or null for an insert that succeeded — id captured from RETURNING)
+    label: string
+    ops: Array<"meta_changed" | "exercises_replaced" | "inserted" | "deleted">
+  }>
+  failed_at: { day_label: string; error: string } | null  // null on full success
+  remaining_days: Array<{ label: string; intent: "delete" | "update" | "insert" }>
+  warnings: string[]                              // mid-cycle warning
+  message: string                                 // includes explicit retry guidance on partial success
+}
+```
+
+---
+
+## Component Architecture
+
+### Layer Overview
+
+```mermaid
+graph TD
+  subgraph mcp [Edge Function: mcp]
+    Index[index.ts SERVER_INFO 0.4.0]
+    Registry[tools/registry.ts<br/>+ updateProgram registered after createProgram]
+  end
+
+  subgraph newTools [New & modified MCP tools]
+    UP[tools/updateProgram.ts<br/>NEW orchestrator]
+    CP[tools/createProgram.ts<br/>refactored to import validateDayExercises + fetchExercisesByIds]
+    GPD[tools/getProgramDetails.ts<br/>+ exercise_id in select & format]
+  end
+
+  subgraph newLibs [New libs]
+    Diff[lib/updateProgramDiff.ts<br/>NEW pure diff: current + patch → ProgramDiff]
+    UPV[lib/updateProgramValidation.ts<br/>NEW patch shape, day identity, destructive-guard, is_active rejection]
+    Apply[lib/updateProgramApply.ts<br/>NEW per-day orchestrator + smart re-order + partial-success report]
+    Catalog[lib/catalogLookup.ts<br/>NEW fetchExercisesByIds extracted from createProgram.ts]
+  end
+
+  subgraph extendedLibs [Extended libs]
+    CPV[lib/createProgramValidation.ts<br/>+ validateDayExercises extracted from createProgram.ts]
+    PP[lib/programPersistence.ts<br/>+ applyDayUpdate helper, no web mirror]
+    Format[lib/format.ts<br/>+ formatProgramAfterUpdate, formatActiveCycleWarning, exercise_id swap in formatProgramDetails]
+  end
+
+  subgraph testFiles [Test runners]
+    Vitest[updateProgramDiff.test.ts<br/>updateProgramValidation.test.ts<br/>fixture-based]
+    DenoTest[updateProgram_test.ts<br/>handler integration with mock supabase]
+    Fixtures[lib/updateProgram_fixtures.json<br/>NEW shared diff scenarios]
+  end
+
+  subgraph docs [Doc updates]
+    Skill[skills/gymlogic-mcp/SKILL.md<br/>9 tools, 3 worked examples for update_program, drop L334-338 stale line]
+  end
+
+  Index --> Registry
+  Registry --> UP
+  Registry --> CP
+  Registry --> GPD
+  UP --> UPV
+  UP --> CPV
+  UP --> Diff
+  UP --> Apply
+  UP --> Catalog
+  Apply --> PP
+  UP --> Format
+  CP --> CPV
+  CP --> Catalog
+  GPD --> Format
+  Vitest --> Fixtures
+  Vitest --> Diff
+  Vitest --> UPV
+  DenoTest --> UP
+```
+
+
+
+### New Files & Responsibilities
+
+
+| File                                                         | Purpose                                                                                                                                                                                                                                                                                                                                                                                                |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `supabase/functions/mcp/tools/updateProgram.ts`              | The handler. Orchestrates: auth → fetch current program (RLS-protected) → parse patch shape → validate day identities → catalog fetch (via `catalogLookup`) → call `validateDayExercises` per day → call `computeProgramDiff` → FK pre-check on delete candidates → enforce `confirm` for destructive patches → render dry_run output OR call `applyProgramDiff`. Tool definition + handler. ~250 LOC. |
+| `supabase/functions/mcp/lib/updateProgramDiff.ts`            | Pure function `computeProgramDiff(currentProgram: CurrentProgramSnapshot, parsedPatch: ParsedPatch): ProgramDiff`. Zero side effects, zero external calls. Decides what changed, how, and computes the `apply_order` flag based on the smart-reorder invariant. ~140 LOC.                                                                                                                              |
+| `supabase/functions/mcp/lib/updateProgramValidation.ts`      | `parsePatchShape(rawArgs)` (top-level shape, `is_active` rejection). `validateDayIdentities(days, currentDayIds)` (no duplicates, all provided ids exist). `requireConfirmForDestructive(diff, confirm)` (destructive-guard). All return `{ ok: true, value } | { ok: false, error }`. ~180 LOC.                                                                                                       |
+| `supabase/functions/mcp/lib/updateProgramApply.ts`           | `applyProgramDiff(supabase, diff, catalogById, userId): Promise<ApplyResult>` — orchestrates per the diff's `apply_order` flag. Tracks `applied_days[]`, returns `failed_at` and `remaining_days[]` on first failure. Builds the partial-success message with explicit retry guidance. ~200 LOC.                                                                                                       |
+| `supabase/functions/mcp/lib/catalogLookup.ts`                | `fetchExercisesByIds(supabase, ids): Promise<{ data: CatalogExerciseForProgram[]; error: string | null }>` — extracted from `createProgram.ts:99-121`. Single `IN (...)` query, error message names missing ids. ~30 LOC.                                                                                                                                                                              |
+| `supabase/functions/mcp/lib/updateProgram_fixtures.json`     | Diff scenarios: rename only, add day, remove day clean, remove day blocked, swap exercise, mixed (add + remove + update), reorder, no-op patch, smart-reorder pathological case (drain to 0 + refill), edge cases. Loaded by `updateProgramDiff.test.ts`.                                                                                                                                              |
+| `supabase/functions/mcp/lib/updateProgramDiff.test.ts`       | Vitest. Loads `updateProgram_fixtures.json` and asserts diff output matches expected for each scenario. Pure function = pure tests.                                                                                                                                                                                                                                                                    |
+| `supabase/functions/mcp/lib/updateProgramValidation.test.ts` | Vitest. Patch shape failures, day identity duplicates, unknown ids, destructive-guard with confirm omitted/present, `is_active` rejection.                                                                                                                                                                                                                                                             |
+| `supabase/functions/mcp/tools/updateProgram_test.ts`         | Deno test. Handler integration with a fake supabase client (in-memory state, RLS simulated by user_id filter). Scenarios: rename success, add day success, remove day with sessions blocked, mid-cycle warning present, partial success when fake supabase errors at day 2, full success, dry_run returns 0 writes, smart-reorder applied for drain-to-0+refill.                                       |
+
+
+### Modified Files & Responsibilities
+
+
+| File                                                                 | Change                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `supabase/functions/mcp/index.ts`                                    | Bump `SERVER_INFO.version`: `"0.3.x"` → `"0.4.0"`.                                                                                                                                                                                                                                                                                                                                                                               |
+| `supabase/functions/mcp/tools/registry.ts`                           | Import `updateProgram`, append after `createProgram` in the `tools` array (becomes 9-element).                                                                                                                                                                                                                                                                                                                                   |
+| `supabase/functions/mcp/tools/createProgram.ts`                      | Refactor: extract the per-day exercise validation loop (currently inline lines ~280-330) into `validateDayExercises` (new helper in `createProgramValidation.ts`). Replace inline `fetchExercisesByIds` (lines 99-121) with import from `lib/catalogLookup.ts`. Call sites reduced. NO behavior change — existing tests must pass unchanged.                                                                                     |
+| `supabase/functions/mcp/lib/createProgramValidation.ts`              | Add new exported helper `validateDayExercises(rawExercises, dayLabel, catalogById): { ok: true, parsed: ParsedExercise[] } | { ok: false, error: string }`. Wraps the loop: per-exercise `parseExerciseInput` → catalog lookup (passed in by caller) → `validateExerciseCrossFields`. Catalog is passed in (caller batches the fetch).                                                                                           |
+| `supabase/functions/mcp/tools/getProgramDetails.ts`                  | Extend `select`: add `exercise_id` to the inner `workout_exercises(...)` projection (line 69). Extend `WorkoutExerciseRow` type with `exercise_id: string`. Extend the mapping at line 95-99 to forward `exercise_id` to the format helper.                                                                                                                                                                                      |
+| `supabase/functions/mcp/lib/format.ts`                               | Update `ProgramDetailsExercise` type: add `exercise_id: string`. Update `formatProgramDetails` line 268: render `*(exercise_id: ${ex.exercise_id})*` instead of `*(id: ${ex.id})*`. Add `formatProgramAfterUpdate(diff, currentProgram, catalogById): string` helper for dry_run rendering. Add `formatActiveCycleWarning(cycle: { started_at: string }): string` for the warning text.                                          |
+| `supabase/functions/mcp/lib/programPersistence.ts`                   | Add `applyDayUpdate(supabase, dayId, parsedExercises, catalogById, userId)` helper: DELETE existing `workout_exercises` rows for that day, then INSERT new ones via `buildWorkoutExerciseInsertRowsForDay`. Returns `{ ok: true, inserted_count } | { ok: false, error }`. Edge-only, no web mirror.                                                                                                                             |
+| `supabase/functions/mcp/tools/getProgramDetails.test.ts` (if exists) | Update assertion strings: `exercise_id` instead of slot `id` in markdown.                                                                                                                                                                                                                                                                                                                                                        |
+| `skills/gymlogic-mcp/SKILL.md`                                       | Bump tool count 8 → 9 in the roster. Add `update_program` row with: brief description, input shape examples, when-to-use guidance. New "Common write patterns" sub-section with 3 worked examples: (a) rename only `{ program_id, name: "PPL v2" }`, (b) add a day to existing 3-day split, (c) swap an exercise + revise prescription on a single day. Drop the legacy line at L334-338 *"single-day editing is out of scope"*. |
+
+
+### Component Responsibilities
+
+`**tools/updateProgram.ts` (the handler — orchestration only)**
+
+1. **Auth guard** — same pattern as existing handlers; bail with *"Authentication required..."* if `supabase` is null.
+2. **Fetch user_id** — `await supabase.auth.getUser()`. Required for new day INSERTs.
+3. **Parse patch shape** — `parsePatchShape(args)` (top-level fields, `is_active` rejection). Bail on shape error.
+4. **Fetch current program** — `select("id, name, workout_days(id, label, emoji, sort_order, workout_exercises(exercise_id, name_snapshot, sets, reps, weight, rest_seconds, target_duration_seconds, sort_order))")` filtered by `program_id`. RLS does the ownership check. If `data === null` → *"Program not found or you don't have access."*
+5. **Validate day identities** — `validateDayIdentities(parsedPatch.days, currentDayIds)`. Catches unknown ids and duplicates BEFORE any expensive catalog fetch.
+6. **Catalog fetch (batched)** — collect every `exercise_id` referenced across all days, single call to `fetchExercisesByIds(supabase, ids)`.
+7. **Validate per-day exercises** — for each day in `parsedPatch.days`, call `validateDayExercises(rawExercises, dayLabel, catalogById)`. Accumulate errors; bail if any.
+8. **Compute diff** — `computeProgramDiff(currentProgram, parsedPatch)`. Pure. Sets `apply_order` flag.
+9. **FK pre-check (batched)** — single `select workout_day_id, count(*) from sessions where workout_day_id in (<delete_candidates>) group by workout_day_id`. Annotate `diff.days_to_delete` entries with `session_count` and `blocking`.
+10. **Active cycle check** — `select started_at from cycles where program_id = X and finished_at is null limit 1`. If row exists, build warning string for `warnings[]`.
+11. **Build dry_run errors** — collect blocking days into `errors[]`. If non-empty AND we're in dry_run, return preview with `isError: true` so agent doesn't try to apply.
+12. **Branch on `dry_run*`*:
+  - **dry_run=true (default)**: render preview output (full program-after, removed/added sections, warnings, errors, note) via `formatProgramAfterUpdate`. Return.
+    - **dry_run=false**:
+      - Destructive-guard: if `diff.days_to_delete.length > 0` AND `confirm !== true` → return error.
+      - Blocking errors: if `errors.length > 0` → return error (FK violation reported earlier).
+      - Call `applyProgramDiff(supabase, diff, catalogById, userId)`. Return apply output (with `applied_days`, `failed_at`, `remaining_days`, `warnings`, retry-aware `message`).
+
+`**lib/updateProgramDiff.ts` (the brain)**
+
+```ts
+export function computeProgramDiff(
+  current: CurrentProgramSnapshot,
+  patch: ParsedPatch,
+): ProgramDiff
+```
+
+- `name_change`: `current.name !== patch.name` ? `{ from, to }` : `null`. (When `patch.name === undefined`, treat as no change.)
+- If `patch.days === undefined`: all `days_to_*` empty, `days_unchanged = current.days`.
+- Else: iterate `patch.days`. For each entry:
+  - `id` provided + matches a current day → `days_to_update` (record current as `current` for diff visibility, resolve `emoji` to provided-or-current).
+  - `id` absent → `days_to_insert` with `sort_order = position-in-patch`.
+- `days_to_delete = current.days.filter(d => !patch.days.some(p => p.id === d.id))`.
+- `days_unchanged`: empty when `patch.days` provided (because every patch day → update or insert). When `patch.days` undefined, all current days.
+- `apply_order`: `"insert_first"` iff `current.days.length - days_to_delete.length === 0` AND `days_to_insert.length > 0`. Otherwise `"default"`.
+
+`**lib/updateProgramValidation.ts**`
+
+- `parsePatchShape(args)`:
+  - `program_id`: required, must be UUID (`isUuid`).
+  - `**is_active` field at top level**: explicit rejection with custom message: *"`is_active` is not editable via update_program. Use the dedicated `set_active_program` tool (coming soon)."* Surfaced before the generic "unknown field" check.
+  - `name`: optional. If present, must be non-empty trimmed string.
+  - `days`: optional. If present, must be array, length ≥1 and ≤14. Each element: `label` non-empty string, `emoji?` string, `id?` UUID, `exercises` array length 1-40.
+  - `dry_run`: optional boolean, default `true`.
+  - `confirm`: optional boolean, default `false`.
+- `validateDayIdentities(patchDays, currentDayIds)`:
+  - For each `patchDays[i].id` provided: must be in `currentDayIds`. Error message names the offending position and suggests *"omit the id to create a new day"*.
+  - No two patchDays share the same `id`. Error names both positions.
+- `requireConfirmForDestructive(diff, confirm)`:
+  - If `diff.days_to_delete.length > 0` AND `confirm !== true` → error: *"Patch removes N day(s): X, Y, Z. Pass `confirm: true` along with `dry_run: false` to apply, or revise the payload to keep these days."*
+
+`**lib/updateProgramApply.ts`**
+
+- `applyProgramDiff(supabase, diff, catalogById, userId): Promise<ApplyResult>`:
+  - **Step 0**: if `diff.name_change`: `update programs set name = ... where id = ...`. On error, return `{ applied: [], failed_at: { day_label: '<program name>', error }, remaining: [...all days] }`.
+  - **Compute apply plan** based on `diff.apply_order`:
+    - `"default"`: `[deletes, updates, inserts]` (concat in this order).
+    - `"insert_first"`: `[inserts, deletes, updates]`.
+  - **Per-day loop**: for each `op` in plan:
+    - `delete`: DELETE workout_exercises (for safety, even though CASCADE would handle), DELETE workout_day. Add `{ id, label, ops: ["deleted"] }` to `applied[]` on success.
+    - `update`: UPDATE workout_days set label/emoji/sort_order, then `applyDayUpdate(supabase, day.id, parsed, catalogById, userId)`. Add `{ id, label, ops: ["meta_changed", "exercises_replaced"] }` (or just one of them if only one changed). On error, return.
+    - `insert`: INSERT workout_day (returning id), then INSERT workout_exercises via `buildWorkoutExerciseInsertRowsForDay`. Add `{ id, label, ops: ["inserted"] }`.
+    - On any error: return `{ applied, failed_at: { day_label, error }, remaining: <unprocessed ops as { label, intent }> }`.
+  - **Build message** on partial success: explicitly include the retry guidance: *"Updated N days. Failed at day '**'. M days remaining. To retry, submit a new patch containing only the remaining_days (with their `id`s) plus any corrections; applied_days are already up to date and should be omitted from `days[]` (or included with their existing `id` to be left unchanged)."*
+  - On full success: `{ applied, failed_at: null, remaining: [], message: "Updated <total> days." }`.
+
+`**lib/programPersistence.ts` extension**
+
+```ts
+export async function applyDayUpdate(
+  supabase: SupabaseClient,
+  dayId: string,
+  parsedExercises: ParsedExercise[],
+  catalogById: Map<string, CatalogExerciseForProgram>,
+  userId: string,
+): Promise<{ ok: true } | { ok: false; error: string }>
+```
+
+- DELETE `workout_exercises WHERE workout_day_id = dayId` (RLS scopes to user).
+- Build rows via `buildWorkoutExerciseInsertRowsForDay(dayId, parsedExercises.map(p => geFromParsed(p, catalogById.get(...))), userId)`.
+- INSERT.
+- Return result.
+
+`**lib/catalogLookup.ts` (new shared module)**
+
+```ts
+export async function fetchExercisesByIds(
+  supabase: SupabaseClient,
+  ids: string[],
+): Promise<{ data: CatalogExerciseForProgram[]; error: string | null }>
+```
+
+- Direct lift from `createProgram.ts:99-121`. Single `IN (...)` query, error message names missing ids.
+
+`**tools/getProgramDetails.ts` extension**
+
+- Single line patched in `select`: add `exercise_id` to the projection.
+- Single line patched in `WorkoutExerciseRow` type.
+- Forward `exercise_id` through the mapping at line 95-99 (no logic change).
+- Markdown rendering changes in `format.ts` (see below).
+
+`**lib/format.ts` changes**
+
+- `ProgramDetailsExercise` type: add `exercise_id: string`.
+- `formatProgramDetails` line 268: change from `*(id: ${ex.id})*` to `*(exercise_id: ${ex.exercise_id})*`. The slot `id` field stays in the type (defensive) but is no longer rendered.
+- New helper `formatProgramAfterUpdate(diff, currentProgram, catalogById): string` — renders the dry_run "what it will look like" markdown section. Reuses `formatPrescriptionLine` per exercise.
+- New helper `formatActiveCycleWarning(cycle: { started_at: string }): string` — returns the localized French warning string.
+
+### Failure Mode Analysis
+
+
+| Failure                                                                                                     | Behavior                                                                                                                                                                                                                                                                                                                                  |
+| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `program_id` not a UUID                                                                                     | `parsePatchShape` rejects: *"Invalid program_id format (expected UUID)."* No DB queries.                                                                                                                                                                                                                                                  |
+| `program_id` valid but program doesn't exist or doesn't belong to user                                      | Initial SELECT returns null (RLS filters out non-owned rows). Handler returns *"Program not found or you don't have access."*                                                                                                                                                                                                             |
+| Patch contains `is_active: true` at top level                                                               | `parsePatchShape` rejects with specific error: *"`is_active` is not editable via update_program. Use the dedicated `set_active_program` tool (coming soon)."*                                                                                                                                                                             |
+| `name: ""` (empty after trim)                                                                               | `parsePatchShape` rejects: *"`name` must be a non-empty string when provided."*                                                                                                                                                                                                                                                           |
+| `days: []` (empty array)                                                                                    | `parsePatchShape` rejects: *"`days` must be a non-empty array when provided. Omit the field entirely to leave days unchanged, or pass at least one day."*                                                                                                                                                                                 |
+| Day with `exercises: []`                                                                                    | `validateDayExercises` rejects: *"days[i].exercises must be a non-empty array (≥1 exercise per day)."*                                                                                                                                                                                                                                    |
+| Day `id` doesn't match any current day                                                                      | `validateDayIdentities` rejects: *"days[i].id '**' is not a day of program **. Omit the id to create a new day, or check the id."*                                                                                                                                                                                                        |
+| Same day `id` appears twice in `days[]`                                                                     | `validateDayIdentities` rejects: *"days[i] and days[j] both reference id '**'. Each day id may appear at most once in the patch."*                                                                                                                                                                                                        |
+| Day `label` missing or empty                                                                                | `parsePatchShape` rejects: *"days[i].label must be a non-empty string."*                                                                                                                                                                                                                                                                  |
+| Patch removes a day that has logged sessions                                                                | FK pre-check populates `session_count > 0`, dry_run output includes structured error in `errors[]`, apply rejected before any write: *"Cannot remove day '**' — it has N logged sessions. Rename or repurpose it instead, or remove the corresponding entries from the patch and resubmit."* (Same message in dry_run preview AND apply.) |
+| Patch removes a day, agent calls `dry_run: false` without `confirm: true`                                   | Apply rejected: *"Patch removes 1 day(s): 'Cardio'. Pass `confirm: true` along with `dry_run: false` to apply, or revise the payload."* No DB writes.                                                                                                                                                                                     |
+| Patch drains to 0 days then re-adds new days (e.g. complete program restructure)                            | `apply_order: "insert_first"` set by diff. Apply does inserts before deletes — program is never observably empty. If insert fails partway, the original days are still present. If deletes fail later, the new days are present + the old days that failed to delete. Failure report makes the partial state explicit.                    |
+| Mid-cycle update (active cycle exists for this program)                                                     | `warnings[]` contains: *"Cycle actif depuis YYYY-MM-DD — cette modification affecte vos workouts restants dans ce cycle."* Both dry_run and apply. Warning is informational, does NOT block.                                                                                                                                              |
+| Apply: program rename SQL fails (transient)                                                                 | Return early: `applied = []`, `failed_at = { day_label: '<program-rename>', error }`, `remaining = [...diff.days_to_*]`.                                                                                                                                                                                                                  |
+| Apply: day 2 of 4 fails mid-flight (DB connection blip)                                                     | Days 1 succeeded. `applied = [day1_summary]`, `failed_at = { day_label: 'day2', error }`, `remaining = [day3, day4]`. Message includes explicit retry guidance.                                                                                                                                                                           |
+| Concurrent edit during apply (user changes day 2 in-app while agent applies)                                | Last-write-wins. Documented limitation in tool description. No detection.                                                                                                                                                                                                                                                                 |
+| Catalog fetch returns fewer rows than requested (some `exercise_id` invalid)                                | `fetchExercisesByIds` returns error: *"Unknown or inaccessible exercise_id(s): **."* No DB writes.                                                                                                                                                                                                                                        |
+| Cross-field validation fails (e.g. `weight_kg: 25` for `Push-up` bodyweight)                                | `validateExerciseCrossFields` rejects: *"days[i].exercises[j] (**) is bodyweight — weight_kg > 0 not supported. See #281 for weighted-bodyweight tracking."* (Same as create_program; reused as-is.)                                                                                                                                      |
+| Patch with `days` containing all currently-existing day ids + same data + no new days                       | Diff: `days_to_update = current.days`, `days_to_insert = []`, `days_to_delete = []`. Apply wipes-and-reinserts every day's exercises (idempotent, no-op-equivalent). Acceptable.                                                                                                                                                          |
+| Patch with `name` unchanged + `days` undefined                                                              | `name_change = null`, `days_to_*` all empty. Handler returns success message *"No changes to apply."* — short-circuits before any DB writes (in both dry_run and apply).                                                                                                                                                                  |
+| Patch with `id` provided but matching day already has the requested `label`/`emoji` AND identical exercises | `days_to_update` populated (we're in the patch), but the apply will still wipe-and-reinsert exercises (per design — idempotent, simple). Acceptable noise.                                                                                                                                                                                |
+| Patch tries to insert a 15th day (exceeds `MAX_DAYS = 14`)                                                  | `parsePatchShape` rejects with the existing bound: *"days: too many entries (max 14)."*                                                                                                                                                                                                                                                   |
+| Slot id no longer in markdown breaks an agent that string-matched it                                        | Markdown contract is informal; agents should not parse opaque IDs. If a real consumer surfaces, add back as `slot_id: X, exercise_id: Y`. T1's acceptance criterion includes a repo grep to confirm no consumer.                                                                                                                          |
+| `getProgramDetails` test asserting on old markdown string fails after T1                                    | Update assertion as part of T1. Required.                                                                                                                                                                                                                                                                                                 |
+| `createProgram.ts` behavior changes after T2 refactor                                                       | Existing `createProgramValidation.test.ts` cases must pass unchanged AND existing `getProgramDetails.test.ts`-equivalent cases must pass unchanged. Required acceptance criterion of T2.                                                                                                                                                  |
+| Web caller of `programPersistence.applyDayUpdate` would be a regression                                     | None planned — `applyDayUpdate` lives in `supabase/functions/mcp/lib/`, not in `src/lib/`. Web doesn't see it.                                                                                                                                                                                                                            |
+
+
+---
+
+## Implementation Sequence (proposed checklist for the epic)
+
+1. **T1 — `get_program_details` exposes `exercise_id`** (S, AFK, no deps). Replaces slot id in markdown. Updates type, select, format, tests. Verifies no downstream consumer of slot id via repo grep.
+2. **T2 — Extract `validateDayExercises` + `fetchExercisesByIds`** (S/M, AFK, no deps). Pure refactor of `createProgram.ts`. New `lib/catalogLookup.ts` + new helper in `createProgramValidation.ts`. Existing `createProgram.ts` tests must pass unchanged.
+3. **T3 — `updateProgramDiff.ts` + fixtures + tests** (M, AFK, no infra deps). Pure function, full TDD red-green-refactor. Lands the brain of Epic C in isolation.
+4. **T4 — `updateProgramValidation.ts` + tests** (S, AFK, no deps). Patch shape, day identity, destructive-guard, `is_active` rejection.
+5. **T5 — `updateProgramApply.ts` + tests** (M, AFK, deps T2 + T3). Per-day orchestration with mock supabase. Smart re-order. Partial-success report with explicit retry message.
+6. **T6 — `tools/updateProgram.ts` handler + integration test** (M, AFK, deps T3 + T4 + T5). Wires everything together. Registry update + version bump.
+7. **T7 — `SKILL.md` patch** (S, HITL — needs human review of agent UX wording). Bumps tool count, drops L334-338 line, adds `update_program` row + 3 worked examples. Manual E2E with Iris validates the 3 examples.
+
+---
+
+## Out of Scope (this epic)
+
+- `is_active` toggling on this surface — future `set_active_program` tool.
+- Optimistic locking / concurrent-edit detection.
+- Schema migrations or `ON DELETE CASCADE` on `sessions.workout_day_id`.
+- `force_delete: true` override for days with sessions.
+- Cross-day rollback / compensating snapshot.
+- Renaming `createProgramValidation.ts` → `programValidation.ts`.
+- Optional / partial prescription fields (object-form merge with existing).
+- Web/UI changes.
+- Bulk-edit primitives (e.g. *"+5 kg on every weight"*).
+- Migration / backfill.
+
+---
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_MCP_—_update_program_#280.md`
+- Predecessor Tech Plan (Epic B): `file:docs/Tech_Plan_—_MCP_—_create_program_Prescription_#276.md`
+- Combined original Tech Plan (legacy B+C): `file:docs/done/Tech_Plan_—_MCP_—_Read_&_Edit_Programs_#276.md`
+- Issue #280 (Epic C), #276 (parent), #277 (Epic A delivery)
+- Existing read tool to extend: `file:supabase/functions/mcp/tools/getProgramDetails.ts`
+- Existing write tool to mirror: `file:supabase/functions/mcp/tools/createProgram.ts`
+- Validation primitives (post-Epic-B): `file:supabase/functions/mcp/lib/createProgramValidation.ts`
+- Persistence helpers: `file:supabase/functions/mcp/lib/programPersistence.ts`
+- Format helpers: `file:supabase/functions/mcp/lib/format.ts`
+- Registry: `file:supabase/functions/mcp/tools/registry.ts`
+- RLS policies: `file:supabase/migrations/20260314000002_create_programs.sql`, `file:supabase/migrations/20240101000002_create_workout_days.sql`
+- FK constraints: `file:supabase/migrations/20240101000004_create_sessions.sql`, `file:supabase/migrations/20240101000005_create_set_logs.sql`
+- Skill (to update): `file:skills/gymlogic-mcp/SKILL.md`
+

--- a/skills/gymlogic-mcp/SKILL.md
+++ b/skills/gymlogic-mcp/SKILL.md
@@ -10,9 +10,9 @@ description: >
 
 # GymLogic MCP Skill
 
-This skill teaches an LLM how to be a competent training coach on top of the [GymLogic](https://gymlogic.me) MCP server. It covers when to invoke each of the **eight tools** (seven reads, one write), how to format their parameters, the **propose-confirm-act handshake** required on every write, and the non-obvious quirks that bite zero-shot agents — most importantly the **per-side weight convention for unilateral equipment** (issue [#263](https://github.com/PierreTsia/workout-app/issues/263)).
+This skill teaches an LLM how to be a competent training coach on top of the [GymLogic](https://gymlogic.me) MCP server. It covers when to invoke each of the **nine tools** (seven reads, two writes), how to format their parameters, the **propose-confirm-act handshake** required on every write, and the non-obvious quirks that bite zero-shot agents — most importantly the **per-side weight convention for unilateral equipment** (issue [#263](https://github.com/PierreTsia/workout-app/issues/263)).
 
-GymLogic is a French/English workout tracker. The user logs sessions, weights, reps; you read this data and either analyze it or design a new program with `create_program`.
+GymLogic is a French/English workout tracker. The user logs sessions, weights, reps; you read this data and either analyze it (`get_*` reads) or shape their program with `create_program` (new) or `update_program` (in-place edits — preserves training history).
 
 ---
 
@@ -57,13 +57,13 @@ Dynamic client registration, browser consent at `www.gymlogic.me/oauth/consent`.
 https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp
 ```
 
-All eight tools 401 if no auth context. The tool response will be `Authentication required — please provide a valid Bearer token.` — surface that to the user and ask them to (re)connect.
+All nine tools 401 if no auth context. The tool response will be `Authentication required — please provide a valid Bearer token.` — surface that to the user and ask them to (re)connect.
 
 ---
 
 ## Tool reference (intent → tool)
 
-Eight tools total — seven reads, one write.
+Nine tools total — seven reads, two writes.
 
 | User intent | Tool | Notes |
 |---|---|---|
@@ -75,6 +75,7 @@ Eight tools total — seven reads, one write.
 | "List / browse the user's training programs" | `list_programs` | Returns id, name, is_active, day_count, created_at, has_active_cycle for every non-archived program. Pass `include_archived: true` to see archived ones. Works regardless of cycle state — use to enumerate programs before drilling into one. |
 | "Show me the structure of program X / review my draft / what's in this program" | `get_program_details` | Requires a UUID (`program_id`). Returns the full structure (days + exercises with sets/reps/weights/rest). Works on **any** program — active, draft, or archived. **Always run `list_programs` first** to resolve the UUID, or use the `program_id` surfaced by `get_upcoming_workouts` / `get_workout_history`. |
 | "Design / save / replace my program" | `create_program` | Multi-day. **`dry_run` defaults to `true`** — preview first, then re-call with `dry_run: false` to persist. Deactivates other active programs. |
+| "Rename / edit / tweak / swap exercises in a program (without losing history)" | `update_program` | In-place edit by `program_id`. **Preserves all logged sessions** — never recreate via `create_program` for an existing program (that orphans history). PATCH at top-level (`name?`, `days?`); inside `days`, declarative full-list with optional `id` per day (id present → UPDATE, id absent → INSERT, **omitted current day → DELETE**). `dry_run: true` by default. Removing days requires `confirm: true` along with `dry_run: false`. Mid-cycle edits surface a French warning. Atomicity is per-day → on failure, response includes `applied_days` / `failed_at` / `remaining_days` + retry guidance. |
 
 There's also one **MCP resource** (`exercise_catalog_schema`) exposing the muscle-group / equipment / difficulty taxonomy. Read it once at the start of a session if the runtime supports resources, otherwise rely on `search_exercises`'s built-in aliasing.
 
@@ -86,7 +87,7 @@ When the user wants to review, inspect, or talk about *a specific program* (acti
 
 1. **`list_programs`** — enumerate the user's programs to identify the right one by name. Each entry surfaces `*(id: <uuid>)*` for downstream addressability.
 2. **`get_program_details(program_id)`** — fetch the full structure of the chosen program (days, exercises, sets/reps/weights, rest). Works on **any** program — active, draft, or archived — regardless of cycle state. Use this to answer "review my draft program" / "show me the structure" / "compare these two". Returns markdown with inline `*(id: ...)*` on every day and exercise line, ready for downstream tools.
-3. **(Epic C will add)** `update_program(id, patch)` — apply targeted edits to a program by ID without recreating it.
+3. **`update_program(program_id, patch)`** — apply targeted edits to that program by id without recreating it. Use whenever the user wants to *modify* an existing program (rename, swap an exercise, add/remove a day, revise a prescription) — it preserves training history. See the dedicated patterns section below.
 
 For the *active* program with an *active cycle*, `get_upcoming_workouts` is the cheaper alternative when the user wants only the next few days (it returns dated, scheduled instances). Use `get_program_details` instead when the user wants the **whole program template** or the active program has **no cycle started**.
 
@@ -94,7 +95,7 @@ For the *active* program with an *active cycle*, `get_upcoming_workouts` is the 
 
 ## Writes — propose → confirm → act → echo (always, no exceptions)
 
-Every write tool — currently `create_program`, future `update_program` (Epic C) and any logging tools — goes through a **four-step handshake**, even when the user gave a direct, unambiguous request.
+Every write tool — `create_program`, `update_program`, and any future logging tools — goes through a **four-step handshake**, even when the user gave a direct, unambiguous request.
 
 ### Why this is mandatory
 
@@ -154,7 +155,7 @@ Volume math depends on **equipment type**. The `weight_logged` field on a set lo
 
 ### Read AND write side use the same convention
 
-The `weight_convention` exposed by `get_exercise_details` is the same convention that future write tools (`create_program`, `update_program`) interpret when you send `weight_kg`. So if you read `Weight convention: per_hand` on a dumbbell exercise and the user says *"40 kg"*, send `weight_kg: 40` (per hand) — the tool will not silently double it. **When in doubt before a write, call `get_exercise_details` first** to confirm the convention you're committing to.
+The `weight_convention` exposed by `get_exercise_details` is the same convention that the write tools (`create_program`, `update_program`) interpret when you send `weight_kg`. So if you read `Weight convention: per_hand` on a dumbbell exercise and the user says *"40 kg"*, send `weight_kg: 40` (per hand) — the tool will not silently double it. **When in doubt before a write, call `get_exercise_details` first** to confirm the convention you're committing to.
 
 ### Failure mode to avoid
 
@@ -319,6 +320,152 @@ These are the three patterns that cover ~95% of strength prescriptions. Pick the
 }
 ```
 
+### Common write patterns — `update_program` (in-place edits, v0.4.0+)
+
+Use `update_program` whenever the user wants to **modify** an existing program — rename, add / remove / reorder days, swap exercises, revise prescriptions. Reach for it **first** for any edit intent on a program that already exists. `create_program` on top of an existing program **orphans** every logged session that pointed at the old day rows.
+
+**The two non-obvious rules** (these trip every agent on the first try):
+
+1. **Inside `days[]`, the array is declarative — not a partial patch.** A day with `id` matching a current day is an UPDATE; without `id` is an INSERT; **a current day NOT in `days[]` is a DELETE**. So if the user wants to edit one day, you echo *every* current day, modifying only the affected one.
+2. **`days` is itself optional.** Omit the field entirely if you only want to rename. Pass `name` only → no day touched, no destructive guard, single PATCH.
+
+Always `dry_run: true` first. The preview returns:
+- `rendered`: human-readable markdown of the program *as it will be after apply*
+- `removed_days[]`: every day that would be deleted (with `session_count` and `blocking` flag)
+- `added_days[]`: every new day that would be inserted
+- `warnings[]`: includes the active-cycle warning (`"Cycle actif depuis YYYY-MM-DD — ..."`) when applicable
+- `errors[]`: blocking issues (e.g. trying to delete a day with logged sessions)
+
+**Discovery prerequisite for any non-rename edit**: `list_programs` → `get_program_details(program_id)` to read every current day's `id`, label, and exercise prescription. The `*(exercise_id: <uuid>)*` annotation on every exercise line in `get_program_details` (since v0.4.0) is the catalog id you reuse in your patch — not the row's slot id.
+
+**Worked example 1 — rename only** (no day touched):
+
+> Prompt: *"renomme mon programme PPL en 'PPL v2'"*
+
+```jsonc
+// Step 1 — find the program id
+list_programs({})
+// → entry: PPL *(id: <pid>)*
+
+// Step 2 — preview (always)
+update_program({
+  program_id: "<pid>",
+  name: "PPL v2"
+  // dry_run defaults to true → no writes; agent reads `rendered` back to user
+})
+
+// Step 3 — apply once user confirms
+update_program({
+  program_id: "<pid>",
+  name: "PPL v2",
+  dry_run: false
+})
+// → { applied_days: [], failed_at: null, message: "Updated 0 day(s)." }
+```
+
+**Worked example 2 — add a day** (echo every current day, append the new one):
+
+> Prompt: *"ajoute une journée Cardio à mon programme PPL avec 3 exos: course 4×30s, jump rope 4×60s, plank 4×45s"*
+
+```jsonc
+// Step 1 — id resolution
+list_programs({})
+get_program_details({ program_id: "<pid>" })   // ← read every day id + every exercise_id
+
+// Step 2 — search the new exercises (one search per movement)
+search_exercises({ query: "running" })         // → <uuid-run>
+search_exercises({ query: "jump rope" })       // → <uuid-jump>
+search_exercises({ query: "plank" })           // → <uuid-plank>
+
+// Step 3 — preview the patch
+update_program({
+  program_id: "<pid>",
+  days: [
+    // Echo each current day with its id → UPDATE-but-leave-as-is. Bare UUIDs
+    // for unchanged exercises keep the payload concise.
+    { id: "<push-day-id>", label: "Push", emoji: "💪", exercises: ["<bench-uuid>", "<incline-uuid>"] },
+    { id: "<pull-day-id>", label: "Pull", emoji: "🪝", exercises: ["<row-uuid>", "<curl-uuid>"] },
+    { id: "<legs-day-id>", label: "Legs", emoji: "🦵", exercises: ["<squat-uuid>", "<rdl-uuid>"] },
+    // New day — no `id` → INSERT. Duration exercises need full object form.
+    {
+      label: "Cardio",
+      emoji: "🏃",
+      exercises: [
+        { exercise_id: "<uuid-run>",   sets: 4, reps: "0", weight_kg: 0, rest_seconds: 60, target_duration_seconds: 30 },
+        { exercise_id: "<uuid-jump>",  sets: 4, reps: "0", weight_kg: 0, rest_seconds: 60, target_duration_seconds: 60 },
+        { exercise_id: "<uuid-plank>", sets: 4, reps: "0", weight_kg: 0, rest_seconds: 60, target_duration_seconds: 45 }
+      ]
+    }
+  ]
+  // dry_run defaults to true
+})
+// → preview shows added_days: [{ label: "Cardio" }], removed_days: []. Echo to user.
+
+// Step 4 — apply with dry_run: false after explicit consent.
+```
+
+**Worked example 3 — swap an exercise + revise prescription** (preserves history):
+
+> Prompt: *"remplace RDL par soulevé de terre conventionnel et passe le bench à 4×8 @ 80kg"*
+
+The agent must **include every current day** in `days[]` — the array is declarative, omitting Legs (or any day) deletes it.
+
+```jsonc
+list_programs({})
+get_program_details({ program_id: "<pid>" })   // read every day id + current prescriptions
+search_exercises({ query: "conventional deadlift" })  // → <uuid-conv-dl>
+
+update_program({
+  program_id: "<pid>",
+  days: [
+    {
+      id: "<push-day-id>",
+      label: "Push",
+      emoji: "💪",
+      exercises: [
+        "<warmup-uuid>",                                                 // unchanged → bare UUID
+        { exercise_id: "<bench-uuid>", sets: 4, reps: "8", weight_kg: 80, rest_seconds: 120 },  // revised
+        "<accessory-uuid>"                                               // unchanged
+      ]
+    },
+    {
+      id: "<pull-day-id>",
+      label: "Pull",
+      emoji: "🪝",
+      exercises: [
+        // RDL swapped out → conventional deadlift in. Object form because
+        // we're prescribing weight + rep range explicitly.
+        { exercise_id: "<uuid-conv-dl>", sets: 3, reps: "5", weight_kg: 100, rest_seconds: 180 },
+        "<other-pull-uuid>"
+      ]
+    },
+    // Legs unchanged but MUST be echoed (omitting it = DELETE).
+    { id: "<legs-day-id>", label: "Legs", emoji: "🦵", exercises: ["<squat-uuid>", "<leg-press-uuid>"] }
+  ],
+  dry_run: true
+})
+// Echo `rendered` back: "Bench Press — 4 × 8 × 80 kg total — 120s rest", etc.
+// Apply with dry_run: false on consent.
+```
+
+**Destructive edits** (removing days):
+
+When the dry_run preview's `removed_days[]` is non-empty, applying needs **both** `dry_run: false` AND `confirm: true`. Without `confirm`, the server returns: *"Patch removes N day(s): … Pass `confirm: true` along with `dry_run: false` to apply, or revise the payload to keep these days."*
+
+Days with logged sessions are **always** blocked, even with `confirm: true` — the response surfaces an `errors[]` entry: *"Cannot remove day 'X' — it has N logged sessions. Rename or repurpose it instead, or remove the corresponding entries from the patch and resubmit."* The user has to decide between renaming (keep history) or doing it manually in-app.
+
+**Mid-cycle awareness**:
+
+If the program has an unfinished cycle, both dry_run and apply responses include a French warning string in `warnings[]`: *"Cycle actif depuis YYYY-MM-DD — cette modification affecte vos workouts restants dans ce cycle."* Surface this verbatim to the user in your propose step so they can opt out before confirming.
+
+**Partial-success on apply failure**:
+
+`update_program` is **per-day atomic** — there's no cross-day rollback. If a mid-flight day fails to write, the response is `isError: true` and contains `applied_days` (what landed), `failed_at: { day_label, error }`, `remaining_days[]`, and a `message` ending with verbatim retry guidance. **Show it to the user as-is** and let them resubmit a patch covering only `remaining_days`.
+
+**Activation / `is_active`**:
+
+`update_program` rejects `is_active` in the patch with a pointer: *"Use the dedicated `set_active_program` tool (coming soon)."* Until that tool ships, activation/deactivation happens in-app.
+
 ---
 
 ## Edge cases
@@ -335,7 +482,7 @@ These are the three patterns that cover ~95% of strength prescriptions. Pick the
 | `reps exercise "X" cannot have target_duration_seconds` | You set `target_duration_seconds` on a reps-mode exercise. Drop it (use reps + weight_kg instead). Duration exercises (planks, holds) get T75 support. |
 | `Authentication required` / `401` | Token expired or revoked. Tell the user to create a fresh PAT at `/account/api-tokens`. |
 | Ambiguous muscle group (`"chest"` vs `"Pectoraux"`) | `search_exercises` accepts both — pass the user's term as-is. For `get_training_stats` the filter must be the FR name (`Pectoraux`). |
-| User asks to *modify* one day of an existing program | Out of scope for MCP — `create_program` replaces the whole program. Tell the user single-day tweaks happen in-app (Workout Builder). Single-day program editing arrives in Epic C (`update_program`) — until then, `create_program` is still the only write surface. |
+| User asks to *modify* one day, swap an exercise, or rename an existing program | Use `update_program` (NEVER `create_program` — that would orphan training history). Pull the current structure with `list_programs` → `get_program_details` first to read every day's `id` and exercise prescription, then send a patch that **echoes every current day** (modifying the affected ones; omitting any day = DELETE). Always `dry_run: true` first. |
 
 ---
 

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -14,7 +14,7 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!
 const MCP_URL = `${SUPABASE_URL}/functions/v1/mcp`
 const AUTH_ISSUER = `${SUPABASE_URL}/auth/v1`
 
-const SERVER_INFO = { name: "gymlogic", version: "0.3.0" }
+const SERVER_INFO = { name: "gymlogic", version: "0.4.0" }
 const PROTOCOL_VERSION = "2025-03-26"
 
 function ok(id: string | number | null, result: unknown) {

--- a/supabase/functions/mcp/lib/applyDayUpdate.test.ts
+++ b/supabase/functions/mcp/lib/applyDayUpdate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { applyDayUpdate, type CatalogExerciseForProgram } from "./programPersistence"
+import { applyDayUpdate } from "./applyDayUpdate"
+import type { CatalogExerciseForProgram } from "./programPersistence"
 import type { ParsedExercise } from "./createProgramValidation"
 
 const ID_BENCH = "11111111-1111-4111-8111-111111111111"

--- a/supabase/functions/mcp/lib/applyDayUpdate.test.ts
+++ b/supabase/functions/mcp/lib/applyDayUpdate.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest"
+import { applyDayUpdate, type CatalogExerciseForProgram } from "./programPersistence"
+import type { ParsedExercise } from "./createProgramValidation"
+
+const ID_BENCH = "11111111-1111-4111-8111-111111111111"
+const ID_PUSHUP = "22222222-2222-4222-8222-222222222222"
+const ID_OFF = "99999999-9999-4999-8999-999999999999"
+const DAY_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+const USER_ID = "uuuuuuuu-uuuu-4uuu-8uuu-uuuuuuuuuuuu"
+
+const BENCH: CatalogExerciseForProgram = {
+  id: ID_BENCH,
+  name: "Bench Press",
+  muscle_group: "chest",
+  emoji: null,
+  equipment: "barbell",
+  measurement_type: "reps",
+  default_duration_seconds: null,
+}
+
+const PUSHUP: CatalogExerciseForProgram = {
+  id: ID_PUSHUP,
+  name: "Push-up",
+  muscle_group: "chest",
+  emoji: null,
+  equipment: "bodyweight",
+  measurement_type: "reps",
+  default_duration_seconds: null,
+}
+
+interface CallEntry {
+  table: string
+  op: "delete" | "insert"
+  details: unknown
+}
+
+interface MockSupabaseConfig {
+  /** Indexed by call order. If a call's index is in this map, return the error. */
+  errorAt?: Map<number, string>
+}
+
+function makeMockSupabase(config: MockSupabaseConfig = {}) {
+  const calls: CallEntry[] = []
+  const errorAt = config.errorAt ?? new Map<number, string>()
+
+  function maybeError() {
+    const idx = calls.length - 1
+    const message = errorAt.get(idx)
+    return message ? { message } : null
+  }
+
+  return {
+    calls,
+    from(table: string) {
+      return {
+        delete() {
+          return {
+            eq(col: string, val: unknown) {
+              calls.push({ table, op: "delete", details: { col, val } })
+              return Promise.resolve({ data: null, error: maybeError() })
+            },
+          }
+        },
+        insert(payload: unknown) {
+          calls.push({ table, op: "insert", details: { payload } })
+          return Promise.resolve({ data: null, error: maybeError() })
+        },
+      }
+    },
+  }
+}
+
+const benchObject: ParsedExercise = {
+  kind: "object",
+  exerciseId: ID_BENCH,
+  sets: 4,
+  reps: "8",
+  weightKg: 80,
+  restSeconds: 120,
+  targetDurationSeconds: null,
+}
+
+const pushupBare: ParsedExercise = { kind: "bare", exerciseId: ID_PUSHUP }
+
+describe("applyDayUpdate", () => {
+  it("deletes existing exercises for the day, then inserts the new rows built from parsedExercises", async () => {
+    const supabase = makeMockSupabase()
+    const catalog = new Map([
+      [ID_BENCH, BENCH],
+      [ID_PUSHUP, PUSHUP],
+    ])
+
+    const result = await applyDayUpdate(
+      supabase as never,
+      DAY_ID,
+      [benchObject, pushupBare],
+      catalog,
+      USER_ID,
+    )
+
+    expect(result).toEqual({ ok: true, inserted_count: 2 })
+    expect(supabase.calls).toHaveLength(2)
+    expect(supabase.calls[0]).toMatchObject({
+      table: "workout_exercises",
+      op: "delete",
+      details: { col: "workout_day_id", val: DAY_ID },
+    })
+    expect(supabase.calls[1].table).toBe("workout_exercises")
+    expect(supabase.calls[1].op).toBe("insert")
+    const inserted = (supabase.calls[1].details as { payload: unknown[] }).payload
+    expect(inserted).toHaveLength(2)
+    expect(inserted[0]).toMatchObject({
+      workout_day_id: DAY_ID,
+      exercise_id: ID_BENCH,
+      sets: 4,
+      reps: "8",
+      weight: "80",
+      sort_order: 0,
+    })
+    expect(inserted[1]).toMatchObject({
+      workout_day_id: DAY_ID,
+      exercise_id: ID_PUSHUP,
+      sort_order: 1,
+    })
+  })
+
+  it("returns a structured error and does NOT touch the database when an exerciseId is missing from the catalog", async () => {
+    const supabase = makeMockSupabase()
+    const catalog = new Map([[ID_BENCH, BENCH]])
+
+    const orphanObject: ParsedExercise = { ...benchObject, exerciseId: ID_OFF }
+
+    const result = await applyDayUpdate(
+      supabase as never,
+      DAY_ID,
+      [orphanObject],
+      catalog,
+      USER_ID,
+    )
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain("Catalog miss")
+      expect(result.error).toContain(ID_OFF)
+    }
+    expect(supabase.calls).toEqual([])
+  })
+
+  it("propagates the supabase error message and skips the INSERT when the DELETE fails", async () => {
+    const supabase = makeMockSupabase({ errorAt: new Map([[0, "DELETE blew up"]]) })
+    const catalog = new Map([[ID_BENCH, BENCH]])
+
+    const result = await applyDayUpdate(
+      supabase as never,
+      DAY_ID,
+      [benchObject],
+      catalog,
+      USER_ID,
+    )
+
+    expect(result).toEqual({ ok: false, error: "DELETE blew up" })
+    expect(supabase.calls).toHaveLength(1)
+    expect(supabase.calls[0].op).toBe("delete")
+  })
+
+  it("propagates the supabase error message when the INSERT fails (after the DELETE succeeded)", async () => {
+    const supabase = makeMockSupabase({ errorAt: new Map([[1, "INSERT exploded"]]) })
+    const catalog = new Map([[ID_BENCH, BENCH]])
+
+    const result = await applyDayUpdate(
+      supabase as never,
+      DAY_ID,
+      [benchObject],
+      catalog,
+      USER_ID,
+    )
+
+    expect(result).toEqual({ ok: false, error: "INSERT exploded" })
+    expect(supabase.calls).toHaveLength(2)
+  })
+})

--- a/supabase/functions/mcp/lib/applyDayUpdate.ts
+++ b/supabase/functions/mcp/lib/applyDayUpdate.ts
@@ -1,0 +1,119 @@
+/**
+ * Edge-only persistence helpers for `update_program` (T80, Epic C #280).
+ *
+ * Extracted from `programPersistence.ts` so that file stays types-pure (no
+ * `supabase-js` import). The Deno CI typecheck on `lib/*_test.ts` walks every
+ * transitive type import; a `SupabaseClient` reference there pulls in the
+ * supabase-js declarations, which transitively reference `@types/node` and
+ * fail to resolve on the Node-less Deno runner. Keeping the supabase touch
+ * here means `format.ts` / `programPersistence.ts` (and their tests) never
+ * reach a Node-typed module.
+ *
+ * Web parity note: this module has no web mirror by design — `update_program`
+ * is MCP-only.
+ */
+
+import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.103.3"
+import type { ParsedExercise } from "./createProgramValidation.ts"
+import {
+  buildWorkoutExerciseInsertRowsForDay,
+  parseRepsBounds,
+  type CatalogExerciseForProgram,
+  type GeneratedExerciseForProgram,
+} from "./programPersistence.ts"
+
+/**
+ * Defaults applied to bare-string entries that lack an explicit prescription.
+ * Mirror of `createProgram.ts` constants — duplicated intentionally to keep
+ * `applyDayUpdate` self-contained on the Edge side.
+ */
+const APPLY_DEFAULT_SETS = 3
+const APPLY_DEFAULT_REPS = "10"
+const APPLY_DEFAULT_REST_SECONDS = 90
+
+/**
+ * Build the `GeneratedExerciseForProgram` shape for an `update_program` apply
+ * step. Mirror of the equivalent helper in `tools/createProgram.ts` —
+ * duplicated intentionally to keep the apply pipeline self-contained on the
+ * Edge side (no cross-tool import). Throws on catalog miss; callers MUST
+ * pre-flight via `catalogById.has(...)`.
+ */
+export function parsedExerciseToGeneratedForApply(
+  parsed: ParsedExercise,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): GeneratedExerciseForProgram {
+  const catalogEx = catalogById.get(parsed.exerciseId)
+  if (!catalogEx) {
+    throw new Error(`Catalog miss for exercise_id ${parsed.exerciseId}`)
+  }
+
+  if (parsed.kind === "bare") {
+    const isDuration = catalogEx.measurement_type === "duration"
+    return {
+      exercise: catalogEx,
+      sets: APPLY_DEFAULT_SETS,
+      reps: isDuration ? "0" : APPLY_DEFAULT_REPS,
+      restSeconds: APPLY_DEFAULT_REST_SECONDS,
+      isCompound: false,
+    }
+  }
+
+  const bounds = parseRepsBounds(parsed.reps)
+  return {
+    exercise: catalogEx,
+    sets: parsed.sets,
+    reps: parsed.reps,
+    restSeconds: parsed.restSeconds,
+    isCompound: false,
+    weightKg: parsed.weightKg,
+    repRangeMin: bounds.min,
+    repRangeMax: bounds.max,
+    setRangeMin: parsed.sets,
+    setRangeMax: parsed.sets,
+    targetDurationSeconds: parsed.targetDurationSeconds ?? undefined,
+  }
+}
+
+/**
+ * Wipe-and-reinsert the `workout_exercises` rows for a single day. Used by
+ * the `update_program` apply orchestrator (T80) for every day touched by the
+ * patch — both UPDATE-day flows and (indirectly) INSERT-day flows when the
+ * orchestrator chooses to reuse this helper.
+ *
+ * Pre-flight: every `parsed.exerciseId` must be present in `catalogById`. If
+ * any miss, returns `{ ok: false }` BEFORE touching the database — we never
+ * DELETE rows we cannot then reinsert.
+ *
+ * RLS scopes both DELETE and INSERT to the caller; `userId` is accepted for
+ * interface symmetry with future helpers but is not used here (the
+ * `workout_exercises` table has no `user_id` column — RLS joins through
+ * `workout_days.user_id`).
+ */
+export async function applyDayUpdate(
+  supabase: SupabaseClient,
+  dayId: string,
+  parsedExercises: ParsedExercise[],
+  catalogById: Map<string, CatalogExerciseForProgram>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _userId: string,
+): Promise<{ ok: true; inserted_count: number } | { ok: false; error: string }> {
+  const missing = parsedExercises.find((p) => !catalogById.has(p.exerciseId))
+  if (missing) {
+    return { ok: false, error: `Catalog miss for exercise_id ${missing.exerciseId}` }
+  }
+
+  const generated = parsedExercises.map((p) => parsedExerciseToGeneratedForApply(p, catalogById))
+
+  const { error: deleteErr } = await supabase
+    .from("workout_exercises")
+    .delete()
+    .eq("workout_day_id", dayId)
+
+  if (deleteErr) return { ok: false, error: deleteErr.message }
+
+  const rows = buildWorkoutExerciseInsertRowsForDay(dayId, generated)
+  const { error: insertErr } = await supabase.from("workout_exercises").insert(rows)
+  if (insertErr) return { ok: false, error: insertErr.message }
+
+  return { ok: true, inserted_count: rows.length }
+}

--- a/supabase/functions/mcp/lib/catalogLookup.test.ts
+++ b/supabase/functions/mcp/lib/catalogLookup.test.ts
@@ -139,6 +139,16 @@ describe("fetchExercisesByIds", () => {
     expect(result.data).toEqual([])
   })
 
+  it("short-circuits without hitting supabase when the id list is empty (rename-only patches with no current exercises)", async () => {
+    const supabase = makeFakeSupabase({ rows: [] })
+
+    const result = await fetchExercisesByIds(supabase as never, [])
+
+    expect(result.error).toBeNull()
+    expect(result.data).toEqual([])
+    expect(supabase._calls).toHaveLength(0)
+  })
+
   it("normalises measurement_type 'duration' and parses default_duration_seconds to a finite number", async () => {
     const supabase = makeFakeSupabase({
       rows: [

--- a/supabase/functions/mcp/lib/catalogLookup.test.ts
+++ b/supabase/functions/mcp/lib/catalogLookup.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest"
+import { fetchExercisesByIds } from "./catalogLookup"
+
+const ID_BENCH = "11111111-1111-4111-8111-111111111111"
+const ID_OHP = "22222222-2222-4222-8222-222222222222"
+const ID_MISSING = "99999999-9999-4999-8999-999999999999"
+
+interface CatalogRow {
+  id: string
+  name: string
+  muscle_group: string
+  emoji: string | null
+  equipment: string
+  measurement_type: "reps" | "duration" | null
+  default_duration_seconds: number | null
+}
+
+interface FakeSupabaseConfig {
+  rows: CatalogRow[]
+  error?: string
+}
+
+function makeFakeSupabase(config: FakeSupabaseConfig) {
+  const calls: { table: string; columns: string; column: string; values: string[] }[] = []
+  return {
+    from(table: string) {
+      return {
+        select(columns: string) {
+          return {
+            in(column: string, values: string[]) {
+              calls.push({ table, columns, column, values: [...values] })
+              if (config.error) {
+                return Promise.resolve({ data: null, error: { message: config.error } })
+              }
+              const valueSet = new Set(values)
+              const matched = config.rows.filter((r) => valueSet.has(r.id))
+              return Promise.resolve({ data: matched, error: null })
+            },
+          }
+        },
+      }
+    },
+    _calls: calls,
+  }
+}
+
+describe("fetchExercisesByIds", () => {
+  it("returns the catalog rows mapped to CatalogExerciseForProgram on the happy path", async () => {
+    const supabase = makeFakeSupabase({
+      rows: [
+        {
+          id: ID_BENCH,
+          name: "Bench Press",
+          muscle_group: "chest",
+          emoji: "🏋️",
+          equipment: "barbell",
+          measurement_type: "reps",
+          default_duration_seconds: null,
+        },
+        {
+          id: ID_OHP,
+          name: "Overhead Press",
+          muscle_group: "shoulders",
+          emoji: null,
+          equipment: "barbell",
+          measurement_type: "reps",
+          default_duration_seconds: null,
+        },
+      ],
+    })
+
+    const result = await fetchExercisesByIds(supabase as never, [ID_BENCH, ID_OHP])
+
+    expect(result.error).toBeNull()
+    expect(result.data).toHaveLength(2)
+    expect(result.data.map((e) => e.id).sort()).toEqual([ID_BENCH, ID_OHP].sort())
+    const bench = result.data.find((e) => e.id === ID_BENCH)
+    expect(bench).toMatchObject({
+      name: "Bench Press",
+      muscle_group: "chest",
+      emoji: "🏋️",
+      equipment: "barbell",
+      measurement_type: "reps",
+      default_duration_seconds: null,
+    })
+  })
+
+  it("dedupes the input ids before querying supabase", async () => {
+    const supabase = makeFakeSupabase({
+      rows: [
+        {
+          id: ID_BENCH,
+          name: "Bench Press",
+          muscle_group: "chest",
+          emoji: null,
+          equipment: "barbell",
+          measurement_type: "reps",
+          default_duration_seconds: null,
+        },
+      ],
+    })
+
+    await fetchExercisesByIds(supabase as never, [ID_BENCH, ID_BENCH, ID_BENCH])
+
+    expect(supabase._calls).toHaveLength(1)
+    expect(supabase._calls[0].values).toEqual([ID_BENCH])
+  })
+
+  it("returns a structured error naming the missing ids when supabase returns fewer rows than requested", async () => {
+    const supabase = makeFakeSupabase({
+      rows: [
+        {
+          id: ID_BENCH,
+          name: "Bench Press",
+          muscle_group: "chest",
+          emoji: null,
+          equipment: "barbell",
+          measurement_type: "reps",
+          default_duration_seconds: null,
+        },
+      ],
+    })
+
+    const result = await fetchExercisesByIds(supabase as never, [ID_BENCH, ID_MISSING])
+
+    expect(result.error).not.toBeNull()
+    expect(result.error).toContain("Unknown or inaccessible exercise_id")
+    expect(result.error).toContain(ID_MISSING)
+    expect(result.error).not.toContain(ID_BENCH)
+    expect(result.data).toEqual([])
+  })
+
+  it("propagates the supabase error message verbatim when the underlying query fails", async () => {
+    const supabase = makeFakeSupabase({ rows: [], error: "PostgREST connection refused" })
+
+    const result = await fetchExercisesByIds(supabase as never, [ID_BENCH])
+
+    expect(result.error).toBe("PostgREST connection refused")
+    expect(result.data).toEqual([])
+  })
+
+  it("normalises measurement_type 'duration' and parses default_duration_seconds to a finite number", async () => {
+    const supabase = makeFakeSupabase({
+      rows: [
+        {
+          id: ID_BENCH,
+          name: "Plank",
+          muscle_group: "core",
+          emoji: "🧘",
+          equipment: "bodyweight",
+          measurement_type: "duration",
+          default_duration_seconds: 45,
+        },
+      ],
+    })
+
+    const result = await fetchExercisesByIds(supabase as never, [ID_BENCH])
+
+    expect(result.error).toBeNull()
+    expect(result.data[0]).toMatchObject({
+      measurement_type: "duration",
+      default_duration_seconds: 45,
+    })
+  })
+})

--- a/supabase/functions/mcp/lib/catalogLookup.ts
+++ b/supabase/functions/mcp/lib/catalogLookup.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared exercise-catalog lookup for the MCP write tools (`create_program`,
+ * `update_program`). Single batched `IN (...)` fetch — no per-id round-trip.
+ *
+ * Extracted from the inline `fetchExercisesByIds` previously private to
+ * `tools/createProgram.ts` (T77). Behaviour is preserved verbatim.
+ */
+
+import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.103.3"
+import type { CatalogExerciseForProgram } from "./programPersistence.ts"
+
+const CATALOG_COLUMNS =
+  "id, name, muscle_group, emoji, equipment, measurement_type, default_duration_seconds"
+
+function catalogRowToExercise(row: Record<string, unknown>): CatalogExerciseForProgram {
+  const mt = row.measurement_type
+  const measurement_type: "reps" | "duration" = mt === "duration" ? "duration" : "reps"
+  const rawDur = row.default_duration_seconds
+  let default_duration_seconds: number | null = null
+  if (rawDur != null && rawDur !== "") {
+    const n = Number(rawDur)
+    default_duration_seconds = Number.isFinite(n) ? n : null
+  }
+  return {
+    id: String(row.id),
+    name: String(row.name),
+    muscle_group: String(row.muscle_group),
+    emoji: row.emoji != null ? String(row.emoji) : null,
+    equipment: String(row.equipment),
+    measurement_type,
+    default_duration_seconds,
+  }
+}
+
+/**
+ * Fetch the catalog rows for a list of exercise UUIDs. RLS scopes the query to
+ * the calling user. Returns an error string naming any IDs that did not come
+ * back (catalog miss / inaccessible to the user).
+ */
+export async function fetchExercisesByIds(
+  supabase: SupabaseClient,
+  ids: string[],
+): Promise<{ data: CatalogExerciseForProgram[]; error: string | null }> {
+  const unique = [...new Set(ids)]
+  const { data, error } = await supabase
+    .from("exercises")
+    .select(CATALOG_COLUMNS)
+    .in("id", unique)
+
+  if (error) return { data: [], error: error.message }
+  const rows = (data ?? []) as Record<string, unknown>[]
+  const mapped = rows.map(catalogRowToExercise)
+  if (mapped.length !== unique.length) {
+    const found = new Set(mapped.map((e) => e.id))
+    const missing = unique.filter((id) => !found.has(id))
+    return {
+      data: [],
+      error: `Unknown or inaccessible exercise_id(s): ${missing.join(", ")}`,
+    }
+  }
+  return { data: mapped, error: null }
+}

--- a/supabase/functions/mcp/lib/catalogLookup.ts
+++ b/supabase/functions/mcp/lib/catalogLookup.ts
@@ -42,6 +42,13 @@ export async function fetchExercisesByIds(
   ids: string[],
 ): Promise<{ data: CatalogExerciseForProgram[]; error: string | null }> {
   const unique = [...new Set(ids)]
+  // Short-circuit: PostgREST `.in("id", [])` can error or return unexpected
+  // results, and `update_program` legitimately calls this helper with an empty
+  // union for rename-only patches on programs that happen to have zero
+  // exercises. Skip the round-trip entirely.
+  if (unique.length === 0) {
+    return { data: [], error: null }
+  }
   const { data, error } = await supabase
     .from("exercises")
     .select(CATALOG_COLUMNS)

--- a/supabase/functions/mcp/lib/createProgramValidation.test.ts
+++ b/supabase/functions/mcp/lib/createProgramValidation.test.ts
@@ -3,9 +3,11 @@ import {
   detectLegacyExerciseIds,
   LEGACY_MIGRATION_ERROR_MESSAGE,
   parseExerciseInput,
+  validateDayExercises,
   validateExerciseCrossFields,
   validateRepsModeCrossField,
 } from "./createProgramValidation"
+import type { CatalogExerciseForProgram } from "./programPersistence"
 
 const VALID_UUID = "11111111-2222-4333-8444-555555555555"
 const VALID_UUID_2 = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
@@ -519,6 +521,140 @@ describe("validateRepsModeCrossField (deprecated T74 shim — backwards compatib
     if (!result.ok) {
       expect(result.error).toContain("Bench Press")
       expect(result.error).toContain("target_duration_seconds")
+    }
+  })
+})
+
+describe("validateDayExercises (T77)", () => {
+  const ID_BENCH = "11111111-1111-4111-8111-111111111111"
+  const ID_PUSHUP = "22222222-2222-4222-8222-222222222222"
+  const ID_PLANK = "33333333-3333-4333-8333-333333333333"
+  const ID_OFF = "99999999-9999-4999-8999-999999999999"
+
+  const BENCH: CatalogExerciseForProgram = {
+    id: ID_BENCH,
+    name: "Bench Press",
+    muscle_group: "chest",
+    emoji: null,
+    equipment: "barbell",
+    measurement_type: "reps",
+    default_duration_seconds: null,
+  }
+
+  const PUSHUP: CatalogExerciseForProgram = {
+    id: ID_PUSHUP,
+    name: "Push-up",
+    muscle_group: "chest",
+    emoji: null,
+    equipment: "bodyweight",
+    measurement_type: "reps",
+    default_duration_seconds: null,
+  }
+
+  const PLANK: CatalogExerciseForProgram = {
+    id: ID_PLANK,
+    name: "Plank",
+    muscle_group: "core",
+    emoji: null,
+    equipment: "bodyweight",
+    measurement_type: "duration",
+    default_duration_seconds: 30,
+  }
+
+  function catalogOf(...exercises: CatalogExerciseForProgram[]) {
+    return new Map(exercises.map((e) => [e.id, e] as const))
+  }
+
+  it("returns parsed exercises on a happy mixed-form day (bare UUID + object prescription)", () => {
+    const raw = [
+      ID_BENCH,
+      {
+        exercise_id: ID_PUSHUP,
+        sets: 4,
+        reps: "12",
+        weight_kg: 0,
+        rest_seconds: 90,
+      },
+    ]
+
+    const result = validateDayExercises(raw, "Push", catalogOf(BENCH, PUSHUP))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.parsed).toHaveLength(2)
+      expect(result.parsed[0]).toEqual({ kind: "bare", exerciseId: ID_BENCH })
+      expect(result.parsed[1]).toMatchObject({
+        kind: "object",
+        exerciseId: ID_PUSHUP,
+        sets: 4,
+        reps: "12",
+        weightKg: 0,
+        restSeconds: 90,
+      })
+    }
+  })
+
+  it("returns a parse error with the day-and-position locator when one entry is malformed", () => {
+    const raw = [ID_BENCH, "not-a-uuid"]
+
+    const result = validateDayExercises(raw, "Push", catalogOf(BENCH))
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('days["Push"].exercises[1]')
+      expect(result.error).toContain("not-a-uuid")
+    }
+  })
+
+  it("returns an error referencing the missing exercise_id when the catalog map lacks an object-form prescription", () => {
+    const raw = [
+      {
+        exercise_id: ID_OFF,
+        sets: 4,
+        reps: "8",
+        weight_kg: 80,
+        rest_seconds: 120,
+      },
+    ]
+
+    const result = validateDayExercises(raw, "Push", catalogOf(BENCH))
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('days["Push"].exercises[0]')
+      expect(result.error).toContain(ID_OFF)
+    }
+  })
+
+  it("returns the cross-field error when an object prescription violates a catalog-aware rule (bodyweight + weight_kg > 0)", () => {
+    const raw = [
+      {
+        exercise_id: ID_PUSHUP,
+        sets: 4,
+        reps: "12",
+        weight_kg: 25,
+        rest_seconds: 90,
+      },
+    ]
+
+    const result = validateDayExercises(raw, "Push", catalogOf(PUSHUP))
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('days["Push"].exercises[0]')
+      expect(result.error).toContain("Push-up")
+      expect(result.error).toContain("#281")
+    }
+  })
+
+  it("does NOT cross-field check bare-string entries (bare UUIDs always pass through to defaults)", () => {
+    const raw = [ID_PLANK]
+
+    const result = validateDayExercises(raw, "Core", catalogOf(PLANK))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.parsed).toEqual([{ kind: "bare", exerciseId: ID_PLANK }])
     }
   })
 })

--- a/supabase/functions/mcp/lib/createProgramValidation.ts
+++ b/supabase/functions/mcp/lib/createProgramValidation.ts
@@ -12,7 +12,7 @@
  */
 
 import { isUuid } from "./uuid.ts"
-import { parseRepsBounds } from "./programPersistence.ts"
+import { parseRepsBounds, type CatalogExerciseForProgram } from "./programPersistence.ts"
 
 export const BOUNDS = {
   sets: { min: 1, max: 10 },
@@ -272,6 +272,55 @@ export function validateExerciseCrossFields(
   }
 
   return { ok: true, value: true }
+}
+
+/**
+ * Per-day validation: parses every raw exercise entry and runs cross-field
+ * checks for object-form prescriptions against the pre-fetched catalog map.
+ *
+ * Returns the FIRST error encountered (parse OR cross-field) so the agent gets
+ * one actionable error per call. Bare-string entries always skip the catalog
+ * lookup — defaults are applied downstream.
+ *
+ * The handler is responsible for fetching the catalog (via
+ * `lib/catalogLookup.ts#fetchExercisesByIds`) and passing the resulting
+ * `Map<id, CatalogExerciseForProgram>` here. This module performs zero I/O.
+ *
+ * Defensive: if an object-form `exerciseId` is missing from the catalog map,
+ * returns a structured error rather than throwing. Reaching this branch means
+ * the handler skipped or partially performed the catalog fetch — surface
+ * loudly instead of crashing.
+ */
+export function validateDayExercises(
+  rawExercises: unknown[],
+  dayLabel: string,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): { ok: true; parsed: ParsedExercise[] } | { ok: false; error: string } {
+  const parsed: ParsedExercise[] = []
+  for (const [j, raw] of rawExercises.entries()) {
+    const parseResult = parseExerciseInput(raw, dayLabel, j)
+    if (!parseResult.ok) {
+      return { ok: false, error: parseResult.error }
+    }
+    parsed.push(parseResult.value)
+  }
+
+  for (const [j, p] of parsed.entries()) {
+    if (p.kind !== "object") continue
+    const ex = catalogById.get(p.exerciseId)
+    if (!ex) {
+      return {
+        ok: false,
+        error: `${locator(dayLabel, j)}.exercise_id "${p.exerciseId}" was not found in the fetched catalog (unknown or inaccessible).`,
+      }
+    }
+    const cf = validateExerciseCrossFields(p, ex, dayLabel, j)
+    if (!cf.ok) {
+      return { ok: false, error: cf.error }
+    }
+  }
+
+  return { ok: true, parsed }
 }
 
 /**

--- a/supabase/functions/mcp/lib/format.test.ts
+++ b/supabase/functions/mcp/lib/format.test.ts
@@ -94,6 +94,7 @@ describe("formatProgramListEntry", () => {
 
 interface ProgramDetailsExercise {
   id: string
+  exercise_id: string
   name_snapshot: string
   sets: number
   reps: string
@@ -137,6 +138,7 @@ function makeDay(overrides: Partial<ProgramDetailsDay> = {}): ProgramDetailsDay 
 function makeExercise(overrides: Partial<ProgramDetailsExercise> = {}): ProgramDetailsExercise {
   return {
     id: "33333333-3333-4333-8333-333333333333",
+    exercise_id: "ex000033-3333-4333-8333-333333333333",
     name_snapshot: "Bench Press",
     sets: 4,
     reps: "8",
@@ -148,12 +150,13 @@ function makeExercise(overrides: Partial<ProgramDetailsExercise> = {}): ProgramD
 }
 
 describe("formatProgramDetails", () => {
-  it("renders a single-day program with multiple exercises, surfacing inline UUIDs on program/day/exercise lines", () => {
+  it("renders a single-day program with multiple exercises, surfacing the catalog exercise_id on each exercise line", () => {
     const program = makeProgram()
     const day = makeDay()
     const exercises = [
       makeExercise({
         id: "33333333-3333-4333-8333-333333333333",
+        exercise_id: "cccccccc-3333-4333-8333-333333333333",
         name_snapshot: "Bench Press",
         sets: 4,
         reps: "8",
@@ -162,6 +165,7 @@ describe("formatProgramDetails", () => {
       }),
       makeExercise({
         id: "44444444-4444-4444-8444-444444444444",
+        exercise_id: "cccccccc-4444-4444-8444-444444444444",
         name_snapshot: "Overhead Press",
         sets: 3,
         reps: "10",
@@ -176,8 +180,8 @@ describe("formatProgramDetails", () => {
     expect(md).toBe(
       "## **Mai 2026 v2** *(id: 11111111-1111-4111-8111-111111111111)*\n\n" +
         "### 💪 Push *(id: 22222222-2222-4222-8222-222222222222)*\n" +
-        "  - **Bench Press** *(id: 33333333-3333-4333-8333-333333333333)*: 4 × 8 reps @ 80 kg (rest 120s)\n" +
-        "  - **Overhead Press** *(id: 44444444-4444-4444-8444-444444444444)*: 3 × 10 reps @ 40 kg (rest 90s)",
+        "  - **Bench Press** *(exercise_id: cccccccc-3333-4333-8333-333333333333)*: 4 × 8 reps @ 80 kg (rest 120s)\n" +
+        "  - **Overhead Press** *(exercise_id: cccccccc-4444-4444-8444-444444444444)*: 3 × 10 reps @ 40 kg (rest 90s)",
     )
   })
 
@@ -231,6 +235,7 @@ describe("formatProgramDetails", () => {
     const exercises = [
       makeExercise({
         id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        exercise_id: "cccccccc-ffff-4fff-8fff-ffffffffffff",
         name_snapshot: "Pull-up",
         sets: 4,
         reps: "8",
@@ -242,7 +247,7 @@ describe("formatProgramDetails", () => {
 
     const md = formatProgramDetails(program, [day], exercisesByDay)
 
-    expect(md).toContain("**Pull-up** *(id: ffffffff-ffff-4fff-8fff-ffffffffffff)*: 4 × 8 reps (rest 90s)")
+    expect(md).toContain("**Pull-up** *(exercise_id: cccccccc-ffff-4fff-8fff-ffffffffffff)*: 4 × 8 reps (rest 90s)")
     expect(md).not.toContain("@ 0 kg")
   })
 
@@ -252,6 +257,7 @@ describe("formatProgramDetails", () => {
     const exercises = [
       makeExercise({
         id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        exercise_id: "cccccccc-eeee-4eee-8eee-eeeeeeeeeeee",
         name_snapshot: "Plank",
         sets: 3,
         reps: "0",
@@ -264,7 +270,7 @@ describe("formatProgramDetails", () => {
 
     const md = formatProgramDetails(program, [day], exercisesByDay)
 
-    expect(md).toContain("**Plank** *(id: eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee)*: 3 × 45s (rest 60s)")
+    expect(md).toContain("**Plank** *(exercise_id: cccccccc-eeee-4eee-8eee-eeeeeeeeeeee)*: 3 × 45s (rest 60s)")
     expect(md).not.toContain("reps")
   })
 })

--- a/supabase/functions/mcp/lib/format.test.ts
+++ b/supabase/functions/mcp/lib/format.test.ts
@@ -1,12 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
+  formatActiveCycleWarning,
   formatPrescriptionLine,
+  formatProgramAfterUpdate,
   formatProgramDetails,
   formatProgramListEntry,
   formatSessionSummary,
   formatWeightConvention,
   type WeightConvention,
 } from "./format"
+import type { CatalogExerciseForProgram } from "./programPersistence"
+import type {
+  CurrentProgramSnapshot,
+  ProgramDiff,
+} from "./updateProgramTypes"
 
 interface ProgramListEntryInput {
   id: string
@@ -484,5 +491,286 @@ describe("formatPrescriptionLine — duration mode (T75)", () => {
     expect(line).toBe("Plank — 3 × 45s — 60s rest")
     expect(line).not.toContain("kg")
     expect(line).not.toContain("12")
+  })
+})
+
+describe("formatActiveCycleWarning (T81)", () => {
+  it("returns the French warning with YYYY-MM-DD extracted from the ISO started_at", () => {
+    const warning = formatActiveCycleWarning({ started_at: "2026-04-15T10:00:00.000Z" })
+    expect(warning).toBe(
+      "Cycle actif depuis 2026-04-15 — cette modification affecte vos workouts restants dans ce cycle.",
+    )
+  })
+
+  it("strips the time portion regardless of timezone offset (uses the literal date prefix of the ISO)", () => {
+    const warning = formatActiveCycleWarning({ started_at: "2026-12-31T23:59:59+02:00" })
+    expect(warning).toContain("Cycle actif depuis 2026-12-31")
+  })
+})
+
+describe("formatProgramAfterUpdate (T81)", () => {
+  const ID_PROGRAM = "11111111-1111-4111-8111-111111111111"
+  const ID_DAY_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+  const ID_DAY_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+  const ID_BENCH = "cccccccc-1111-4111-8111-cccccccccccc"
+  const ID_PUSHUP = "cccccccc-2222-4222-8222-cccccccccccc"
+
+  const BENCH: CatalogExerciseForProgram = {
+    id: ID_BENCH,
+    name: "Bench Press",
+    muscle_group: "chest",
+    emoji: null,
+    equipment: "barbell",
+    measurement_type: "reps",
+    default_duration_seconds: null,
+  }
+
+  const PUSHUP: CatalogExerciseForProgram = {
+    id: ID_PUSHUP,
+    name: "Push-up",
+    muscle_group: "chest",
+    emoji: null,
+    equipment: "bodyweight",
+    measurement_type: "reps",
+    default_duration_seconds: null,
+  }
+
+  const catalog = new Map([
+    [ID_BENCH, BENCH],
+    [ID_PUSHUP, PUSHUP],
+  ])
+
+  function makeCurrent(overrides: Partial<CurrentProgramSnapshot> = {}): CurrentProgramSnapshot {
+    return {
+      id: ID_PROGRAM,
+      name: "PPL",
+      days: [
+        {
+          id: ID_DAY_A,
+          label: "Push",
+          emoji: "💪",
+          sort_order: 0,
+          workout_exercises: [
+            {
+              exercise_id: ID_BENCH,
+              name_snapshot: "Bench Press",
+              sets: 4,
+              reps: "8",
+              weight: "80",
+              rest_seconds: 120,
+              target_duration_seconds: null,
+              sort_order: 0,
+            },
+          ],
+        },
+      ],
+      ...overrides,
+    }
+  }
+
+  function emptyDiff(overrides: Partial<ProgramDiff> = {}): ProgramDiff {
+    return {
+      program_id: ID_PROGRAM,
+      name_change: null,
+      days_to_insert: [],
+      days_to_update: [],
+      days_to_delete: [],
+      days_unchanged: [],
+      apply_order: "default",
+      ...overrides,
+    }
+  }
+
+  it("renders the program header with the renamed name when name_change is set", () => {
+    const current = makeCurrent({ name: "Old name" })
+    const diff = emptyDiff({
+      name_change: { from: "Old name", to: "PPL v2" },
+      days_unchanged: [{ id: ID_DAY_A, label: "Push" }],
+    })
+
+    const md = formatProgramAfterUpdate(diff, current, catalog)
+
+    expect(md).toContain(`## **PPL v2** *(id: ${ID_PROGRAM})*`)
+    expect(md).not.toContain("Old name")
+  })
+
+  it("renders the current name when name_change is null", () => {
+    const current = makeCurrent({ name: "PPL" })
+    const diff = emptyDiff({
+      days_unchanged: [{ id: ID_DAY_A, label: "Push" }],
+    })
+
+    const md = formatProgramAfterUpdate(diff, current, catalog)
+
+    expect(md).toContain(`## **PPL** *(id: ${ID_PROGRAM})*`)
+  })
+
+  it("renders unchanged days using their persisted workout_exercises (rest of program left untouched)", () => {
+    const current = makeCurrent()
+    const diff = emptyDiff({
+      days_unchanged: [{ id: ID_DAY_A, label: "Push" }],
+    })
+
+    const md = formatProgramAfterUpdate(diff, current, catalog)
+
+    expect(md).toContain("### 💪 Push")
+    expect(md).toContain("Bench Press — 4 × 8 × 80 kg total — 120s rest")
+  })
+
+  it("renders updated days using their parsed_exercises (post-apply state) and the resolved emoji", () => {
+    const current = makeCurrent()
+    const diff = emptyDiff({
+      days_to_update: [
+        {
+          id: ID_DAY_A,
+          current: { label: "Push", emoji: "💪", sort_order: 0 },
+          label: "Push v2",
+          emoji: "💪",
+          sort_order: 0,
+          parsed_exercises: [
+            {
+              kind: "object",
+              exerciseId: ID_BENCH,
+              sets: 5,
+              reps: "5",
+              weightKg: 100,
+              restSeconds: 180,
+              targetDurationSeconds: null,
+            },
+          ],
+        },
+      ],
+    })
+
+    const md = formatProgramAfterUpdate(diff, current, catalog)
+
+    expect(md).toContain("### 💪 Push v2")
+    expect(md).toContain("Bench Press — 5 × 5 × 100 kg total — 180s rest")
+    // Old prescription should NOT appear.
+    expect(md).not.toContain("4 × 8 × 80 kg")
+  })
+
+  it("renders inserted days at the right position with their parsed_exercises (defaults applied to bare-string entries)", () => {
+    const current = makeCurrent({
+      days: [
+        {
+          id: ID_DAY_A,
+          label: "Push",
+          emoji: "💪",
+          sort_order: 0,
+          workout_exercises: [],
+        },
+      ],
+    })
+    const diff = emptyDiff({
+      days_to_update: [
+        {
+          id: ID_DAY_A,
+          current: { label: "Push", emoji: "💪", sort_order: 0 },
+          label: "Push",
+          emoji: "💪",
+          sort_order: 0,
+          parsed_exercises: [],
+        },
+      ],
+      days_to_insert: [
+        {
+          label: "Pull",
+          emoji: "🪝",
+          sort_order: 1,
+          parsed_exercises: [{ kind: "bare", exerciseId: ID_PUSHUP }],
+        },
+      ],
+    })
+
+    const md = formatProgramAfterUpdate(diff, current, catalog)
+
+    expect(md).toContain("### 🪝 Pull")
+    // Bare entry on a bodyweight reps exercise → default 3 × 10, bodyweight branch.
+    expect(md).toContain("Push-up — 3 × 10 (bodyweight) — 90s rest")
+  })
+
+  it("excludes deleted days from the rendered output entirely", () => {
+    const current = makeCurrent({
+      days: [
+        {
+          id: ID_DAY_A,
+          label: "Push",
+          emoji: "💪",
+          sort_order: 0,
+          workout_exercises: [
+            {
+              exercise_id: ID_BENCH,
+              name_snapshot: "Bench Press",
+              sets: 4,
+              reps: "8",
+              weight: "80",
+              rest_seconds: 120,
+              target_duration_seconds: null,
+              sort_order: 0,
+            },
+          ],
+        },
+        {
+          id: ID_DAY_B,
+          label: "Drop me",
+          emoji: "🗑️",
+          sort_order: 1,
+          workout_exercises: [],
+        },
+      ],
+    })
+    const diff = emptyDiff({
+      days_to_delete: [{ id: ID_DAY_B, label: "Drop me", session_count: 0, blocking: false }],
+      days_to_update: [
+        {
+          id: ID_DAY_A,
+          current: { label: "Push", emoji: "💪", sort_order: 0 },
+          label: "Push",
+          emoji: "💪",
+          sort_order: 0,
+          parsed_exercises: [
+            {
+              kind: "object",
+              exerciseId: ID_BENCH,
+              sets: 4,
+              reps: "8",
+              weightKg: 80,
+              restSeconds: 120,
+              targetDurationSeconds: null,
+            },
+          ],
+        },
+      ],
+    })
+
+    const md = formatProgramAfterUpdate(diff, current, catalog)
+
+    expect(md).not.toContain("Drop me")
+    expect(md).not.toContain("🗑️")
+    expect(md).toContain("### 💪 Push")
+  })
+
+  it("renders the empty-program placeholder when no days remain after the diff", () => {
+    const current = makeCurrent({
+      days: [
+        {
+          id: ID_DAY_A,
+          label: "Last one",
+          emoji: "💪",
+          sort_order: 0,
+          workout_exercises: [],
+        },
+      ],
+    })
+    // Hypothetical "delete the only day" diff (would be blocked by AC in practice,
+    // but the renderer must not crash on an empty final state).
+    const diff = emptyDiff({
+      days_to_delete: [{ id: ID_DAY_A, label: "Last one", session_count: 0, blocking: false }],
+    })
+
+    const md = formatProgramAfterUpdate(diff, current, catalog)
+
+    expect(md).toContain("_(empty program — no days defined)_")
   })
 })

--- a/supabase/functions/mcp/lib/format.ts
+++ b/supabase/functions/mcp/lib/format.ts
@@ -238,6 +238,7 @@ interface ProgramDetailsDay {
 
 interface ProgramDetailsExercise {
   id: string
+  exercise_id: string
   name_snapshot: string
   sets: number
   reps: string
@@ -265,7 +266,7 @@ export function formatProgramDetails(
         ? `${ex.sets} × ${ex.target_duration_seconds}s`
         : `${ex.sets} × ${ex.reps} reps`
       const weightSuffix = Number(ex.weight) > 0 ? ` @ ${ex.weight} kg` : ""
-      return `  - **${ex.name_snapshot}** *(id: ${ex.id})*: ${measure}${weightSuffix} (rest ${ex.rest_seconds}s)`
+      return `  - **${ex.name_snapshot}** *(exercise_id: ${ex.exercise_id})*: ${measure}${weightSuffix} (rest ${ex.rest_seconds}s)`
     })
     return [`### ${day.emoji} ${day.label} *(id: ${day.id})*`, ...exLines].join("\n")
   })

--- a/supabase/functions/mcp/lib/format.ts
+++ b/supabase/functions/mcp/lib/format.ts
@@ -1,3 +1,14 @@
+import type { ParsedExercise } from "./createProgramValidation.ts"
+import type { CatalogExerciseForProgram } from "./programPersistence.ts"
+import type {
+  CurrentProgramSnapshot,
+  CurrentProgramSnapshotDay,
+  CurrentProgramSnapshotExercise,
+  DiffDayInsert,
+  DiffDayUpdate,
+  ProgramDiff,
+} from "./updateProgramTypes.ts"
+
 const MS_PER_MINUTE = 60_000
 const MS_PER_HOUR = 3_600_000
 
@@ -285,4 +296,181 @@ export function formatWorkoutDay(day: WorkoutDayForFormat, exercises: WorkoutExF
   })
 
   return [`### ${day.emoji} ${day.label}`, ...exLines].join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// T81 — update_program dry_run rendering helpers
+// ---------------------------------------------------------------------------
+
+const APPLY_DEFAULT_SETS = 3
+const APPLY_DEFAULT_REPS = "10"
+const APPLY_DEFAULT_REST_SECONDS = 90
+const APPLY_DEFAULT_DURATION_SECONDS = 30
+const DEFAULT_INSERT_EMOJI = "🏋️"
+
+interface RenderableDay {
+  label: string
+  emoji: string
+  sort_order: number
+  exerciseLines: string[]
+}
+
+/**
+ * Renders the program AS IT WILL BE after the diff is applied (dry_run preview).
+ *
+ * - Header uses the renamed name when `diff.name_change` is set, otherwise the current name.
+ * - Days come from `days_to_update` + `days_to_insert` + `days_unchanged` (deletes excluded),
+ *   sorted by their final `sort_order`.
+ * - Exercises are rendered via `formatPrescriptionLine` so the dry_run output mirrors the
+ *   convention-aware echo agents already see from `create_program`.
+ * - Bare-string exercises resolve to legacy defaults (3×10 @ 0kg, 90s rest), with the duration
+ *   branch kicking in for `measurement_type === "duration"` catalog entries.
+ *
+ * Caller contract: `catalogById` must contain every `exercise_id` referenced across
+ * `days_to_update`, `days_to_insert`, and the unchanged days' persisted exercises.
+ */
+export function formatProgramAfterUpdate(
+  diff: ProgramDiff,
+  currentProgram: CurrentProgramSnapshot,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): string {
+  const finalName = diff.name_change?.to ?? currentProgram.name
+  const header = `## **${finalName}** *(id: ${currentProgram.id})*`
+
+  const fromUpdates: RenderableDay[] = diff.days_to_update.map((u) =>
+    renderableFromUpdate(u, catalogById),
+  )
+
+  const fromInserts: RenderableDay[] = diff.days_to_insert.map((i) =>
+    renderableFromInsert(i, catalogById),
+  )
+
+  const fromUnchanged: RenderableDay[] = diff.days_unchanged
+    .map((u) => currentProgram.days.find((d) => d.id === u.id))
+    .filter((d): d is CurrentProgramSnapshotDay => d !== undefined)
+    .map((d) => renderableFromCurrent(d, catalogById))
+
+  const finalDays = [...fromUpdates, ...fromInserts, ...fromUnchanged].sort(
+    (a, b) => a.sort_order - b.sort_order,
+  )
+
+  if (finalDays.length === 0) {
+    return [header, "_(empty program — no days defined)_"].join("\n\n")
+  }
+
+  const dayBlocks = finalDays.map((d) =>
+    [`### ${d.emoji} ${d.label}`, ...d.exerciseLines].join("\n"),
+  )
+  return [header, ...dayBlocks].join("\n\n")
+}
+
+/**
+ * Returns the active-cycle warning string surfaced in both dry_run and apply responses
+ * when the program is currently being followed in an unfinished cycle.
+ *
+ * The message is intentionally French — it lands as-is in the agent's reply and the
+ * product copy is localized at this layer (cf. Tech Plan).
+ */
+export function formatActiveCycleWarning(cycle: { started_at: string }): string {
+  // started_at is an ISO-8601 timestamp; the literal YYYY-MM-DD prefix is enough
+  // and avoids any timezone surprises.
+  const date = cycle.started_at.slice(0, 10)
+  return `Cycle actif depuis ${date} — cette modification affecte vos workouts restants dans ce cycle.`
+}
+
+function renderableFromUpdate(
+  u: DiffDayUpdate,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): RenderableDay {
+  return {
+    label: u.label,
+    emoji: u.emoji,
+    sort_order: u.sort_order,
+    exerciseLines: u.parsed_exercises.map((p) => `  - ${renderParsedLine(p, catalogById)}`),
+  }
+}
+
+function renderableFromInsert(
+  i: DiffDayInsert,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): RenderableDay {
+  return {
+    label: i.label,
+    emoji: i.emoji ?? DEFAULT_INSERT_EMOJI,
+    sort_order: i.sort_order,
+    exerciseLines: i.parsed_exercises.map((p) => `  - ${renderParsedLine(p, catalogById)}`),
+  }
+}
+
+function renderableFromCurrent(
+  d: CurrentProgramSnapshotDay,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): RenderableDay {
+  const sortedExercises = [...d.workout_exercises].sort((a, b) => a.sort_order - b.sort_order)
+  return {
+    label: d.label,
+    emoji: d.emoji,
+    sort_order: d.sort_order,
+    exerciseLines: sortedExercises.map((ex) => `  - ${renderCurrentLine(ex, catalogById)}`),
+  }
+}
+
+function renderParsedLine(
+  parsed: ParsedExercise,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): string {
+  const catalog = catalogById.get(parsed.exerciseId)
+  // Defensive fallback: catalog should always be present (handler fetches the union of
+  // patch + current ids), but a missing entry must not crash dry_run rendering.
+  const name = catalog?.name ?? "(unknown exercise)"
+  const convention = catalog ? formatWeightConvention(catalog.equipment) : "total"
+
+  if (parsed.kind === "bare") {
+    const isDuration = catalog?.measurement_type === "duration"
+    const targetDuration = isDuration
+      ? (catalog?.default_duration_seconds ?? APPLY_DEFAULT_DURATION_SECONDS)
+      : undefined
+    return formatPrescriptionLine({
+      exerciseName: name,
+      sets: APPLY_DEFAULT_SETS,
+      reps: APPLY_DEFAULT_REPS,
+      weightKg: 0,
+      restSeconds: APPLY_DEFAULT_REST_SECONDS,
+      weightConvention: convention,
+      ...(targetDuration !== undefined ? { targetDurationSeconds: targetDuration } : {}),
+    })
+  }
+
+  return formatPrescriptionLine({
+    exerciseName: name,
+    sets: parsed.sets,
+    reps: parsed.reps,
+    weightKg: parsed.weightKg,
+    restSeconds: parsed.restSeconds,
+    weightConvention: convention,
+    ...(parsed.targetDurationSeconds !== null && parsed.targetDurationSeconds !== undefined
+      ? { targetDurationSeconds: parsed.targetDurationSeconds }
+      : {}),
+  })
+}
+
+function renderCurrentLine(
+  ex: CurrentProgramSnapshotExercise,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): string {
+  const catalog = catalogById.get(ex.exercise_id)
+  const name = catalog?.name ?? ex.name_snapshot
+  const convention = catalog ? formatWeightConvention(catalog.equipment) : "total"
+
+  return formatPrescriptionLine({
+    exerciseName: name,
+    sets: ex.sets,
+    reps: ex.reps,
+    weightKg: Number(ex.weight),
+    restSeconds: ex.rest_seconds,
+    weightConvention: convention,
+    ...(ex.target_duration_seconds !== null
+      ? { targetDurationSeconds: ex.target_duration_seconds }
+      : {}),
+  })
 }

--- a/supabase/functions/mcp/lib/programPersistence.ts
+++ b/supabase/functions/mcp/lib/programPersistence.ts
@@ -2,7 +2,13 @@
  * Port of `file:src/lib/programPersistence.ts` for Edge — keep in sync with the web module.
  * Parity: run `npx vitest run src/lib/programPersistence.test.ts` after edits; optionally
  * `deno test supabase/functions/mcp/lib/programPersistence_test.ts` (mirrors key cases).
+ *
+ * NOTE: the `applyDayUpdate` helper at the bottom is Edge-only — it has no
+ * web mirror by design (T80, Tech Plan: `update_program` is MCP-only).
  */
+
+import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.103.3"
+import type { ParsedExercise } from "./createProgramValidation.ts"
 
 export const AI_PROGRAM_DAY_EMOJIS = ["💪", "🔥", "⚡", "🏋️", "🎯", "🚀"] as const
 
@@ -170,4 +176,100 @@ function buildWorkoutExerciseInsertRow(
         : defaultSec + 15,
     duration_increment_seconds: isDuration ? 5 : null,
   }
+}
+
+/**
+ * Defaults applied to bare-string entries that lack an explicit prescription.
+ * Mirror of `createProgram.ts` constants — duplicated intentionally to keep
+ * `applyDayUpdate` self-contained on the Edge side.
+ */
+const APPLY_DEFAULT_SETS = 3
+const APPLY_DEFAULT_REPS = "10"
+const APPLY_DEFAULT_REST_SECONDS = 90
+
+/**
+ * Build the `GeneratedExerciseForProgram` shape for an `update_program` apply
+ * step. Mirror of the equivalent helper in `tools/createProgram.ts` —
+ * duplicated intentionally to keep the apply pipeline self-contained on the
+ * Edge side (no cross-tool import). Throws on catalog miss; callers MUST
+ * pre-flight via `catalogById.has(...)`.
+ */
+export function parsedExerciseToGeneratedForApply(
+  parsed: ParsedExercise,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+): GeneratedExerciseForProgram {
+  const catalogEx = catalogById.get(parsed.exerciseId)
+  if (!catalogEx) {
+    throw new Error(`Catalog miss for exercise_id ${parsed.exerciseId}`)
+  }
+
+  if (parsed.kind === "bare") {
+    const isDuration = catalogEx.measurement_type === "duration"
+    return {
+      exercise: catalogEx,
+      sets: APPLY_DEFAULT_SETS,
+      reps: isDuration ? "0" : APPLY_DEFAULT_REPS,
+      restSeconds: APPLY_DEFAULT_REST_SECONDS,
+      isCompound: false,
+    }
+  }
+
+  const bounds = parseRepsBounds(parsed.reps)
+  return {
+    exercise: catalogEx,
+    sets: parsed.sets,
+    reps: parsed.reps,
+    restSeconds: parsed.restSeconds,
+    isCompound: false,
+    weightKg: parsed.weightKg,
+    repRangeMin: bounds.min,
+    repRangeMax: bounds.max,
+    setRangeMin: parsed.sets,
+    setRangeMax: parsed.sets,
+    targetDurationSeconds: parsed.targetDurationSeconds ?? undefined,
+  }
+}
+
+/**
+ * Wipe-and-reinsert the `workout_exercises` rows for a single day. Used by
+ * the `update_program` apply orchestrator (T80) for every day touched by the
+ * patch — both UPDATE-day flows and (indirectly) INSERT-day flows when the
+ * orchestrator chooses to reuse this helper.
+ *
+ * Pre-flight: every `parsed.exerciseId` must be present in `catalogById`. If
+ * any miss, returns `{ ok: false }` BEFORE touching the database — we never
+ * DELETE rows we cannot then reinsert.
+ *
+ * RLS scopes both DELETE and INSERT to the caller; `userId` is accepted for
+ * interface symmetry with future helpers but is not used here (the
+ * `workout_exercises` table has no `user_id` column — RLS joins through
+ * `workout_days.user_id`).
+ */
+export async function applyDayUpdate(
+  supabase: SupabaseClient,
+  dayId: string,
+  parsedExercises: ParsedExercise[],
+  catalogById: Map<string, CatalogExerciseForProgram>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _userId: string,
+): Promise<{ ok: true; inserted_count: number } | { ok: false; error: string }> {
+  const missing = parsedExercises.find((p) => !catalogById.has(p.exerciseId))
+  if (missing) {
+    return { ok: false, error: `Catalog miss for exercise_id ${missing.exerciseId}` }
+  }
+
+  const generated = parsedExercises.map((p) => parsedExerciseToGeneratedForApply(p, catalogById))
+
+  const { error: deleteErr } = await supabase
+    .from("workout_exercises")
+    .delete()
+    .eq("workout_day_id", dayId)
+
+  if (deleteErr) return { ok: false, error: deleteErr.message }
+
+  const rows = buildWorkoutExerciseInsertRowsForDay(dayId, generated)
+  const { error: insertErr } = await supabase.from("workout_exercises").insert(rows)
+  if (insertErr) return { ok: false, error: insertErr.message }
+
+  return { ok: true, inserted_count: rows.length }
 }

--- a/supabase/functions/mcp/lib/programPersistence.ts
+++ b/supabase/functions/mcp/lib/programPersistence.ts
@@ -3,12 +3,11 @@
  * Parity: run `npx vitest run src/lib/programPersistence.test.ts` after edits; optionally
  * `deno test supabase/functions/mcp/lib/programPersistence_test.ts` (mirrors key cases).
  *
- * NOTE: the `applyDayUpdate` helper at the bottom is Edge-only — it has no
- * web mirror by design (T80, Tech Plan: `update_program` is MCP-only).
+ * Types-pure by design: this module MUST NOT import `supabase-js` (Edge-only
+ * apply helpers live in `applyDayUpdate.ts`). The Deno CI typecheck on
+ * `lib/*_test.ts` walks transitive type imports; reaching a `SupabaseClient`
+ * reference here would drag in `@types/node` and break the Node-less runner.
  */
-
-import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.103.3"
-import type { ParsedExercise } from "./createProgramValidation.ts"
 
 export const AI_PROGRAM_DAY_EMOJIS = ["💪", "🔥", "⚡", "🏋️", "🎯", "🚀"] as const
 
@@ -178,98 +177,3 @@ function buildWorkoutExerciseInsertRow(
   }
 }
 
-/**
- * Defaults applied to bare-string entries that lack an explicit prescription.
- * Mirror of `createProgram.ts` constants — duplicated intentionally to keep
- * `applyDayUpdate` self-contained on the Edge side.
- */
-const APPLY_DEFAULT_SETS = 3
-const APPLY_DEFAULT_REPS = "10"
-const APPLY_DEFAULT_REST_SECONDS = 90
-
-/**
- * Build the `GeneratedExerciseForProgram` shape for an `update_program` apply
- * step. Mirror of the equivalent helper in `tools/createProgram.ts` —
- * duplicated intentionally to keep the apply pipeline self-contained on the
- * Edge side (no cross-tool import). Throws on catalog miss; callers MUST
- * pre-flight via `catalogById.has(...)`.
- */
-export function parsedExerciseToGeneratedForApply(
-  parsed: ParsedExercise,
-  catalogById: Map<string, CatalogExerciseForProgram>,
-): GeneratedExerciseForProgram {
-  const catalogEx = catalogById.get(parsed.exerciseId)
-  if (!catalogEx) {
-    throw new Error(`Catalog miss for exercise_id ${parsed.exerciseId}`)
-  }
-
-  if (parsed.kind === "bare") {
-    const isDuration = catalogEx.measurement_type === "duration"
-    return {
-      exercise: catalogEx,
-      sets: APPLY_DEFAULT_SETS,
-      reps: isDuration ? "0" : APPLY_DEFAULT_REPS,
-      restSeconds: APPLY_DEFAULT_REST_SECONDS,
-      isCompound: false,
-    }
-  }
-
-  const bounds = parseRepsBounds(parsed.reps)
-  return {
-    exercise: catalogEx,
-    sets: parsed.sets,
-    reps: parsed.reps,
-    restSeconds: parsed.restSeconds,
-    isCompound: false,
-    weightKg: parsed.weightKg,
-    repRangeMin: bounds.min,
-    repRangeMax: bounds.max,
-    setRangeMin: parsed.sets,
-    setRangeMax: parsed.sets,
-    targetDurationSeconds: parsed.targetDurationSeconds ?? undefined,
-  }
-}
-
-/**
- * Wipe-and-reinsert the `workout_exercises` rows for a single day. Used by
- * the `update_program` apply orchestrator (T80) for every day touched by the
- * patch — both UPDATE-day flows and (indirectly) INSERT-day flows when the
- * orchestrator chooses to reuse this helper.
- *
- * Pre-flight: every `parsed.exerciseId` must be present in `catalogById`. If
- * any miss, returns `{ ok: false }` BEFORE touching the database — we never
- * DELETE rows we cannot then reinsert.
- *
- * RLS scopes both DELETE and INSERT to the caller; `userId` is accepted for
- * interface symmetry with future helpers but is not used here (the
- * `workout_exercises` table has no `user_id` column — RLS joins through
- * `workout_days.user_id`).
- */
-export async function applyDayUpdate(
-  supabase: SupabaseClient,
-  dayId: string,
-  parsedExercises: ParsedExercise[],
-  catalogById: Map<string, CatalogExerciseForProgram>,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _userId: string,
-): Promise<{ ok: true; inserted_count: number } | { ok: false; error: string }> {
-  const missing = parsedExercises.find((p) => !catalogById.has(p.exerciseId))
-  if (missing) {
-    return { ok: false, error: `Catalog miss for exercise_id ${missing.exerciseId}` }
-  }
-
-  const generated = parsedExercises.map((p) => parsedExerciseToGeneratedForApply(p, catalogById))
-
-  const { error: deleteErr } = await supabase
-    .from("workout_exercises")
-    .delete()
-    .eq("workout_day_id", dayId)
-
-  if (deleteErr) return { ok: false, error: deleteErr.message }
-
-  const rows = buildWorkoutExerciseInsertRowsForDay(dayId, generated)
-  const { error: insertErr } = await supabase.from("workout_exercises").insert(rows)
-  if (insertErr) return { ok: false, error: insertErr.message }
-
-  return { ok: true, inserted_count: rows.length }
-}

--- a/supabase/functions/mcp/lib/updateProgramApply.test.ts
+++ b/supabase/functions/mcp/lib/updateProgramApply.test.ts
@@ -1,0 +1,414 @@
+import { describe, expect, it } from "vitest"
+import { applyProgramDiff } from "./updateProgramApply"
+import type { CatalogExerciseForProgram } from "./programPersistence"
+import type { ParsedExercise } from "./createProgramValidation"
+import type {
+  DiffDayDelete,
+  DiffDayInsert,
+  DiffDayUpdate,
+  ProgramDiff,
+} from "./updateProgramTypes"
+
+// ---- Verbatim retry guidance string (acceptance criterion: must appear unchanged in
+// every partial-failure message). Pulled into a constant so any drift fails the test.
+const RETRY_GUIDANCE =
+  "To retry, submit a new patch containing only the remaining_days (with their `id`s) plus any corrections; applied_days are already up to date and should be omitted from `days[]` (or included with their existing `id` to be left unchanged)."
+
+// ---- Test fixtures ---------------------------------------------------------
+
+const ID_PROGRAM = "pppppppp-pppp-4ppp-8ppp-pppppppppppp"
+const ID_USER = "uuuuuuuu-uuuu-4uuu-8uuu-uuuuuuuuuuuu"
+const ID_BENCH = "11111111-1111-4111-8111-111111111111"
+const ID_DAY_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+const ID_DAY_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+const ID_DAY_C = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+const ID_DAY_D = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+
+const BENCH: CatalogExerciseForProgram = {
+  id: ID_BENCH,
+  name: "Bench Press",
+  muscle_group: "chest",
+  emoji: null,
+  equipment: "barbell",
+  measurement_type: "reps",
+  default_duration_seconds: null,
+}
+
+const catalog = new Map([[ID_BENCH, BENCH]])
+
+const benchObject: ParsedExercise = {
+  kind: "object",
+  exerciseId: ID_BENCH,
+  sets: 4,
+  reps: "8",
+  weightKg: 80,
+  restSeconds: 120,
+  targetDurationSeconds: null,
+}
+
+function emptyDiff(overrides: Partial<ProgramDiff> = {}): ProgramDiff {
+  return {
+    program_id: ID_PROGRAM,
+    name_change: null,
+    days_to_insert: [],
+    days_to_update: [],
+    days_to_delete: [],
+    days_unchanged: [],
+    apply_order: "default",
+    ...overrides,
+  }
+}
+
+function makeInsert(overrides: Partial<DiffDayInsert> = {}): DiffDayInsert {
+  return {
+    label: "New Day",
+    emoji: "🏋️",
+    sort_order: 0,
+    parsed_exercises: [benchObject],
+    ...overrides,
+  }
+}
+
+function makeUpdate(overrides: Partial<DiffDayUpdate> = {}): DiffDayUpdate {
+  return {
+    id: ID_DAY_A,
+    current: { label: "Old", emoji: "💪", sort_order: 0 },
+    label: "New",
+    emoji: "💪",
+    sort_order: 0,
+    parsed_exercises: [benchObject],
+    ...overrides,
+  }
+}
+
+function makeDelete(overrides: Partial<DiffDayDelete> = {}): DiffDayDelete {
+  return {
+    id: ID_DAY_A,
+    label: "Going away",
+    session_count: 0,
+    blocking: false,
+    ...overrides,
+  }
+}
+
+// ---- MockSupabase ----------------------------------------------------------
+
+interface CallEntry {
+  table: string
+  op: "update" | "delete" | "insert"
+  payload?: unknown
+  filter?: { col: string; val: unknown }[]
+  returning?: string
+}
+
+class MockSupabase {
+  callLog: CallEntry[] = []
+  scripted = new Map<number, string>()
+  private dayCounter = 0
+
+  failAt(callIndex: number, message: string): this {
+    this.scripted.set(callIndex, message)
+    return this
+  }
+
+  /** First INSERT into workout_days returns "mock-day-new-1", then "-2", etc. */
+  nextDayId(): string {
+    this.dayCounter += 1
+    return `mock-day-new-${this.dayCounter}`
+  }
+
+  from(table: string): MockBuilder {
+    return new MockBuilder(this, table)
+  }
+}
+
+class MockBuilder {
+  constructor(
+    private mock: MockSupabase,
+    private table: string,
+  ) {}
+
+  update(payload: unknown) {
+    this.mock.callLog.push({ table: this.table, op: "update", payload })
+    return this
+  }
+
+  delete() {
+    this.mock.callLog.push({ table: this.table, op: "delete" })
+    return this
+  }
+
+  insert(payload: unknown) {
+    this.mock.callLog.push({ table: this.table, op: "insert", payload })
+    return this
+  }
+
+  eq(col: string, val: unknown) {
+    const idx = this.mock.callLog.length - 1
+    const last = this.mock.callLog[idx]
+    last.filter = [...(last.filter ?? []), { col, val }]
+    const message = this.mock.scripted.get(idx)
+    return Promise.resolve(message ? { data: null, error: { message } } : { data: null, error: null })
+  }
+
+  select(cols: string) {
+    const idx = this.mock.callLog.length - 1
+    this.mock.callLog[idx].returning = cols
+    return this
+  }
+
+  single() {
+    const idx = this.mock.callLog.length - 1
+    const last = this.mock.callLog[idx]
+    const message = this.mock.scripted.get(idx)
+    if (message) return Promise.resolve({ data: null, error: { message } })
+    if (last.op === "insert" && last.table === "workout_days") {
+      const id = this.mock.nextDayId()
+      return Promise.resolve({ data: { id }, error: null })
+    }
+    return Promise.resolve({ data: null, error: null })
+  }
+
+  // Thenable: enables `await mockBuilder` after a bulk INSERT (no .select chain).
+  then(resolve: (v: { data: null; error: null | { message: string } }) => void) {
+    const idx = this.mock.callLog.length - 1
+    const message = this.mock.scripted.get(idx)
+    resolve({ data: null, error: message ? { message } : null })
+  }
+}
+
+// ---- Tests -----------------------------------------------------------------
+
+describe("applyProgramDiff", () => {
+  it("renames the program and reports zero days touched when the diff carries only a name_change", async () => {
+    const supabase = new MockSupabase()
+    const diff = emptyDiff({ name_change: { from: "Old", to: "PPL v2" } })
+
+    const result = await applyProgramDiff(supabase as never, diff, catalog, ID_USER)
+
+    expect(result.failed_at).toBeNull()
+    expect(result.applied_days).toEqual([])
+    expect(result.remaining_days).toEqual([])
+    expect(result.message).toBe("Updated 0 day(s).")
+    expect(supabase.callLog).toHaveLength(1)
+    expect(supabase.callLog[0]).toMatchObject({
+      table: "programs",
+      op: "update",
+      payload: { name: "PPL v2" },
+    })
+    expect(supabase.callLog[0].filter).toEqual([{ col: "id", val: ID_PROGRAM }])
+  })
+
+  it("reports the rename failure with the synthetic '<program rename>' label and lists EVERY planned day in remaining_days, never touching workout_days/exercises", async () => {
+    const supabase = new MockSupabase().failAt(0, "rename UPDATE blew up")
+    const diff = emptyDiff({
+      name_change: { from: "Old", to: "PPL v2" },
+      days_to_delete: [makeDelete({ id: ID_DAY_A, label: "Drop me" })],
+      days_to_update: [makeUpdate({ id: ID_DAY_B, label: "Edit me" })],
+      days_to_insert: [makeInsert({ label: "Add me" })],
+    })
+
+    const result = await applyProgramDiff(supabase as never, diff, catalog, ID_USER)
+
+    expect(result.applied_days).toEqual([])
+    expect(result.failed_at).toEqual({
+      day_label: "<program rename>",
+      error: "rename UPDATE blew up",
+    })
+    expect(result.remaining_days).toEqual([
+      { label: "Drop me", intent: "delete" },
+      { label: "Edit me", intent: "update" },
+      { label: "Add me", intent: "insert" },
+    ])
+    expect(result.message).toContain("rename UPDATE blew up")
+    expect(result.message).toContain(RETRY_GUIDANCE)
+    // Strict: only the rename UPDATE happened — no day ops.
+    expect(supabase.callLog).toHaveLength(1)
+    expect(supabase.callLog[0].table).toBe("programs")
+  })
+
+  it("inserts a new day, captures its returned id, and bulk-inserts its exercises", async () => {
+    const supabase = new MockSupabase()
+    const diff = emptyDiff({
+      days_to_insert: [makeInsert({ label: "Cardio Light", emoji: "🏃", sort_order: 3 })],
+    })
+
+    const result = await applyProgramDiff(supabase as never, diff, catalog, ID_USER)
+
+    expect(result.failed_at).toBeNull()
+    expect(result.applied_days).toEqual([
+      { id: "mock-day-new-1", label: "Cardio Light", ops: ["inserted"] },
+    ])
+    expect(result.message).toBe("Updated 1 day(s).")
+    // Day INSERT precedes exercise INSERT.
+    const dayIdx = supabase.callLog.findIndex(
+      (c) => c.table === "workout_days" && c.op === "insert",
+    )
+    const exIdx = supabase.callLog.findIndex(
+      (c) => c.table === "workout_exercises" && c.op === "insert",
+    )
+    expect(dayIdx).toBeGreaterThanOrEqual(0)
+    expect(exIdx).toBeGreaterThan(dayIdx)
+    expect(supabase.callLog[dayIdx].payload).toMatchObject({
+      program_id: ID_PROGRAM,
+      user_id: ID_USER,
+      label: "Cardio Light",
+      emoji: "🏃",
+      sort_order: 3,
+    })
+  })
+
+  it("updates day metadata and replaces its exercises, recording both ops when label changed", async () => {
+    const supabase = new MockSupabase()
+    const diff = emptyDiff({
+      days_to_update: [
+        makeUpdate({
+          id: ID_DAY_A,
+          current: { label: "Lundi", emoji: "💪", sort_order: 0 },
+          label: "Push",
+          emoji: "💪",
+          sort_order: 0,
+        }),
+      ],
+    })
+
+    const result = await applyProgramDiff(supabase as never, diff, catalog, ID_USER)
+
+    expect(result.failed_at).toBeNull()
+    expect(result.applied_days).toEqual([
+      { id: ID_DAY_A, label: "Push", ops: ["meta_changed", "exercises_replaced"] },
+    ])
+  })
+
+  it("records ONLY 'exercises_replaced' when label/emoji/sort_order are unchanged (idempotent wipe-and-reinsert)", async () => {
+    const supabase = new MockSupabase()
+    const diff = emptyDiff({
+      days_to_update: [
+        makeUpdate({
+          id: ID_DAY_A,
+          current: { label: "Push", emoji: "💪", sort_order: 0 },
+          label: "Push",
+          emoji: "💪",
+          sort_order: 0,
+        }),
+      ],
+    })
+
+    const result = await applyProgramDiff(supabase as never, diff, catalog, ID_USER)
+
+    expect(result.applied_days).toEqual([
+      { id: ID_DAY_A, label: "Push", ops: ["exercises_replaced"] },
+    ])
+    // No UPDATE on workout_days when meta is unchanged.
+    expect(supabase.callLog.some((c) => c.table === "workout_days" && c.op === "update")).toBe(false)
+  })
+
+  it("deletes a day by clearing workout_exercises then workout_days and tagging the entry as 'deleted'", async () => {
+    const supabase = new MockSupabase()
+    const diff = emptyDiff({
+      days_to_delete: [makeDelete({ id: ID_DAY_A, label: "Saturday Cardio" })],
+    })
+
+    const result = await applyProgramDiff(supabase as never, diff, catalog, ID_USER)
+
+    expect(result.failed_at).toBeNull()
+    expect(result.applied_days).toEqual([
+      { id: ID_DAY_A, label: "Saturday Cardio", ops: ["deleted"] },
+    ])
+    // Order: delete workout_exercises (defensive), then delete workout_days.
+    const exIdx = supabase.callLog.findIndex(
+      (c) => c.table === "workout_exercises" && c.op === "delete",
+    )
+    const dayIdx = supabase.callLog.findIndex(
+      (c) => c.table === "workout_days" && c.op === "delete",
+    )
+    expect(exIdx).toBeGreaterThanOrEqual(0)
+    expect(dayIdx).toBeGreaterThan(exIdx)
+  })
+
+  it("returns a partial-success report with the verbatim retry guidance string when a day fails mid-flight", async () => {
+    // Plan = 4 deletes (default order). Each delete = 2 calls (workout_exercises + workout_days).
+    // Fail call index 2 → second delete fails on its workout_exercises step.
+    const supabase = new MockSupabase().failAt(2, "transient connection blip")
+    const diff = emptyDiff({
+      days_to_delete: [
+        makeDelete({ id: ID_DAY_A, label: "Day A" }),
+        makeDelete({ id: ID_DAY_B, label: "Day B" }),
+        makeDelete({ id: ID_DAY_C, label: "Day C" }),
+        makeDelete({ id: ID_DAY_D, label: "Day D" }),
+      ],
+    })
+
+    const result = await applyProgramDiff(supabase as never, diff, catalog, ID_USER)
+
+    expect(result.applied_days).toEqual([
+      { id: ID_DAY_A, label: "Day A", ops: ["deleted"] },
+    ])
+    expect(result.failed_at).toEqual({
+      day_label: "Day B",
+      error: "transient connection blip",
+    })
+    expect(result.remaining_days).toEqual([
+      { label: "Day C", intent: "delete" },
+      { label: "Day D", intent: "delete" },
+    ])
+    expect(result.message).toContain("Updated 1 day(s)")
+    expect(result.message).toContain("Failed at day 'Day B'")
+    expect(result.message).toContain("transient connection blip")
+    expect(result.message).toContain("2 day(s) remaining")
+    expect(result.message).toContain(RETRY_GUIDANCE)
+    // No further DB ops after the failure.
+    expect(supabase.callLog.length).toBe(3) // op0 (2 calls) + op1 (1 call that failed)
+  })
+
+  it("smart re-order: applies INSERTs BEFORE DELETEs when the diff carries apply_order='insert_first' (drain-to-0 + refill scenario)", async () => {
+    const supabase = new MockSupabase()
+    const diff = emptyDiff({
+      apply_order: "insert_first",
+      days_to_delete: [makeDelete({ id: ID_DAY_A, label: "Old A" })],
+      days_to_insert: [makeInsert({ label: "Brand new", sort_order: 0 })],
+    })
+
+    const result = await applyProgramDiff(supabase as never, diff, catalog, ID_USER)
+
+    expect(result.failed_at).toBeNull()
+    expect(result.applied_days).toHaveLength(2)
+    expect(result.applied_days[0].ops).toEqual(["inserted"])
+    expect(result.applied_days[1].ops).toEqual(["deleted"])
+
+    // Strict: every workout_days INSERT precedes any workout_days DELETE.
+    const firstInsertIdx = supabase.callLog.findIndex(
+      (c) => c.table === "workout_days" && c.op === "insert",
+    )
+    const firstDeleteIdx = supabase.callLog.findIndex(
+      (c) => c.table === "workout_days" && c.op === "delete",
+    )
+    expect(firstInsertIdx).toBeGreaterThanOrEqual(0)
+    expect(firstDeleteIdx).toBeGreaterThan(firstInsertIdx)
+  })
+
+  it("default order: applies DELETEs BEFORE INSERTs when apply_order='default' (partial drain, no risk of empty intermediate state)", async () => {
+    const supabase = new MockSupabase()
+    const diff = emptyDiff({
+      apply_order: "default",
+      days_to_delete: [makeDelete({ id: ID_DAY_A, label: "Old A" })],
+      days_to_insert: [makeInsert({ label: "Brand new", sort_order: 0 })],
+    })
+
+    const result = await applyProgramDiff(supabase as never, diff, catalog, ID_USER)
+
+    expect(result.failed_at).toBeNull()
+    expect(result.applied_days).toHaveLength(2)
+    expect(result.applied_days[0].ops).toEqual(["deleted"])
+    expect(result.applied_days[1].ops).toEqual(["inserted"])
+
+    const firstDeleteIdx = supabase.callLog.findIndex(
+      (c) => c.table === "workout_days" && c.op === "delete",
+    )
+    const firstInsertIdx = supabase.callLog.findIndex(
+      (c) => c.table === "workout_days" && c.op === "insert",
+    )
+    expect(firstDeleteIdx).toBeGreaterThanOrEqual(0)
+    expect(firstInsertIdx).toBeGreaterThan(firstDeleteIdx)
+  })
+})

--- a/supabase/functions/mcp/lib/updateProgramApply.ts
+++ b/supabase/functions/mcp/lib/updateProgramApply.ts
@@ -1,0 +1,283 @@
+/**
+ * Per-day apply orchestrator for `update_program` (T80, Epic C #280).
+ *
+ * Walks a `ProgramDiff` and mutates supabase one day at a time. No cross-day
+ * rollback — on failure, returns a partial-success report enumerating what
+ * landed (`applied_days`), what blew up (`failed_at`), and what remains
+ * (`remaining_days`), plus an explicit retry-guidance message so the agent
+ * can resume cleanly.
+ *
+ * Apply order honours `diff.apply_order`:
+ *   - "default":      [...deletes, ...updates, ...inserts]
+ *   - "insert_first": [...inserts, ...deletes, ...updates]   (drain-to-0 escape hatch)
+ *
+ * Every UPDATE-day flow ALWAYS replaces its exercises (idempotent
+ * wipe-and-reinsert via `applyDayUpdate`); meta is updated only when the
+ * label/emoji/sort_order actually changed. Every INSERT-day flow inserts
+ * `workout_days` first, captures the returned id, then bulk-inserts the
+ * exercise rows directly (no DELETE needed for a fresh day).
+ */
+
+import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.103.3"
+import {
+  applyDayUpdate,
+  buildWorkoutExerciseInsertRowsForDay,
+  parsedExerciseToGeneratedForApply,
+  type CatalogExerciseForProgram,
+} from "./programPersistence.ts"
+import type {
+  DiffDayDelete,
+  DiffDayInsert,
+  DiffDayUpdate,
+  ProgramDiff,
+} from "./updateProgramTypes.ts"
+
+export type AppliedDayOp = "meta_changed" | "exercises_replaced" | "inserted" | "deleted"
+
+export interface AppliedDay {
+  /** `workout_days.id` — for an INSERT op, this is the freshly-returned id. */
+  id: string
+  label: string
+  ops: AppliedDayOp[]
+}
+
+export type RemainingDayIntent = "delete" | "update" | "insert"
+
+export interface RemainingDay {
+  label: string
+  intent: RemainingDayIntent
+}
+
+export interface ApplyResult {
+  applied_days: AppliedDay[]
+  failed_at: { day_label: string; error: string } | null
+  remaining_days: RemainingDay[]
+  message: string
+}
+
+const PROGRAM_RENAME_LABEL = "<program rename>"
+
+const RETRY_GUIDANCE =
+  "To retry, submit a new patch containing only the remaining_days (with their `id`s) plus any corrections; applied_days are already up to date and should be omitted from `days[]` (or included with their existing `id` to be left unchanged)."
+
+type PlanOp =
+  | { intent: "delete"; entry: DiffDayDelete }
+  | { intent: "update"; entry: DiffDayUpdate }
+  | { intent: "insert"; entry: DiffDayInsert }
+
+function planOpLabel(op: PlanOp): string {
+  return op.intent === "insert" ? op.entry.label : op.entry.label
+}
+
+function buildApplyPlan(diff: ProgramDiff): PlanOp[] {
+  const deletes: PlanOp[] = diff.days_to_delete.map((entry) => ({ intent: "delete", entry }))
+  const updates: PlanOp[] = diff.days_to_update.map((entry) => ({ intent: "update", entry }))
+  const inserts: PlanOp[] = diff.days_to_insert.map((entry) => ({ intent: "insert", entry }))
+
+  return diff.apply_order === "insert_first"
+    ? [...inserts, ...deletes, ...updates]
+    : [...deletes, ...updates, ...inserts]
+}
+
+function buildSuccessMessage(appliedCount: number): string {
+  return `Updated ${appliedCount} day(s).`
+}
+
+function buildPartialMessage(
+  appliedCount: number,
+  failedLabel: string,
+  failureError: string,
+  remainingCount: number,
+): string {
+  return [
+    `Updated ${appliedCount} day(s).`,
+    `Failed at day '${failedLabel}': ${failureError}.`,
+    `${remainingCount} day(s) remaining.`,
+    RETRY_GUIDANCE,
+  ].join(" ")
+}
+
+interface OpSuccess {
+  ok: true
+  applied: AppliedDay
+}
+
+interface OpFailure {
+  ok: false
+  error: string
+}
+
+type OpResult = OpSuccess | OpFailure
+
+async function executeDelete(
+  supabase: SupabaseClient,
+  entry: DiffDayDelete,
+): Promise<OpResult> {
+  // Defensive DELETE on workout_exercises even though `workout_days` ON DELETE
+  // CASCADE would handle it — keeps the call sequence explicit and makes any
+  // FK regression surface immediately at this layer instead of cascading.
+  const { error: exErr } = await supabase
+    .from("workout_exercises")
+    .delete()
+    .eq("workout_day_id", entry.id)
+  if (exErr) return { ok: false, error: exErr.message }
+
+  const { error: dayErr } = await supabase
+    .from("workout_days")
+    .delete()
+    .eq("id", entry.id)
+  if (dayErr) return { ok: false, error: dayErr.message }
+
+  return { ok: true, applied: { id: entry.id, label: entry.label, ops: ["deleted"] } }
+}
+
+async function executeUpdate(
+  supabase: SupabaseClient,
+  entry: DiffDayUpdate,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+  userId: string,
+): Promise<OpResult> {
+  const ops: AppliedDayOp[] = []
+
+  const metaChanged =
+    entry.label !== entry.current.label ||
+    entry.emoji !== entry.current.emoji ||
+    entry.sort_order !== entry.current.sort_order
+
+  if (metaChanged) {
+    const { error } = await supabase
+      .from("workout_days")
+      .update({ label: entry.label, emoji: entry.emoji, sort_order: entry.sort_order })
+      .eq("id", entry.id)
+    if (error) return { ok: false, error: error.message }
+    ops.push("meta_changed")
+  }
+
+  const dayResult = await applyDayUpdate(
+    supabase,
+    entry.id,
+    entry.parsed_exercises,
+    catalogById,
+    userId,
+  )
+  if (!dayResult.ok) return { ok: false, error: dayResult.error }
+
+  ops.push("exercises_replaced")
+  return { ok: true, applied: { id: entry.id, label: entry.label, ops } }
+}
+
+async function executeInsert(
+  supabase: SupabaseClient,
+  entry: DiffDayInsert,
+  programId: string,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+  userId: string,
+): Promise<OpResult> {
+  // Pre-flight catalog presence check: never INSERT a workout_day we cannot
+  // then back-fill with exercises. Mirrors the safety pattern in applyDayUpdate.
+  const missing = entry.parsed_exercises.find((p) => !catalogById.has(p.exerciseId))
+  if (missing) {
+    return { ok: false, error: `Catalog miss for exercise_id ${missing.exerciseId}` }
+  }
+
+  const { data, error } = await supabase
+    .from("workout_days")
+    .insert({
+      program_id: programId,
+      user_id: userId,
+      label: entry.label,
+      emoji: entry.emoji ?? "🏋️",
+      sort_order: entry.sort_order,
+    })
+    .select("id")
+    .single()
+
+  if (error) return { ok: false, error: error.message }
+  const newId = (data as { id?: string } | null)?.id
+  if (!newId) {
+    return { ok: false, error: "workout_days insert returned no id" }
+  }
+
+  const generated = entry.parsed_exercises.map((p) =>
+    parsedExerciseToGeneratedForApply(p, catalogById),
+  )
+  const rows = buildWorkoutExerciseInsertRowsForDay(newId, generated)
+
+  const { error: insertErr } = await supabase.from("workout_exercises").insert(rows)
+  if (insertErr) return { ok: false, error: insertErr.message }
+
+  return { ok: true, applied: { id: newId, label: entry.label, ops: ["inserted"] } }
+}
+
+async function executeOp(
+  op: PlanOp,
+  supabase: SupabaseClient,
+  programId: string,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+  userId: string,
+): Promise<OpResult> {
+  if (op.intent === "delete") return executeDelete(supabase, op.entry)
+  if (op.intent === "update") return executeUpdate(supabase, op.entry, catalogById, userId)
+  return executeInsert(supabase, op.entry, programId, catalogById, userId)
+}
+
+/**
+ * Apply a `ProgramDiff` to the database. Returns the apply result with
+ * partial-success tracking; never throws.
+ */
+export async function applyProgramDiff(
+  supabase: SupabaseClient,
+  diff: ProgramDiff,
+  catalogById: Map<string, CatalogExerciseForProgram>,
+  userId: string,
+): Promise<ApplyResult> {
+  const plan = buildApplyPlan(diff)
+
+  // Step 0 — program rename. Failure here aborts BEFORE touching any day.
+  if (diff.name_change) {
+    const { error } = await supabase
+      .from("programs")
+      .update({ name: diff.name_change.to })
+      .eq("id", diff.program_id)
+
+    if (error) {
+      const remaining = plan.map<RemainingDay>((op) => ({
+        label: planOpLabel(op),
+        intent: op.intent,
+      }))
+      return {
+        applied_days: [],
+        failed_at: { day_label: PROGRAM_RENAME_LABEL, error: error.message },
+        remaining_days: remaining,
+        message: buildPartialMessage(0, PROGRAM_RENAME_LABEL, error.message, remaining.length),
+      }
+    }
+  }
+
+  // Step 1+2 — per-day loop. Stops at first failure, reports partial success.
+  const applied: AppliedDay[] = []
+  for (let i = 0; i < plan.length; i += 1) {
+    const op = plan[i]
+    const result = await executeOp(op, supabase, diff.program_id, catalogById, userId)
+    if (!result.ok) {
+      const remaining = plan.slice(i + 1).map<RemainingDay>((rest) => ({
+        label: planOpLabel(rest),
+        intent: rest.intent,
+      }))
+      return {
+        applied_days: applied,
+        failed_at: { day_label: planOpLabel(op), error: result.error },
+        remaining_days: remaining,
+        message: buildPartialMessage(applied.length, planOpLabel(op), result.error, remaining.length),
+      }
+    }
+    applied.push(result.applied)
+  }
+
+  return {
+    applied_days: applied,
+    failed_at: null,
+    remaining_days: [],
+    message: buildSuccessMessage(applied.length),
+  }
+}

--- a/supabase/functions/mcp/lib/updateProgramApply.ts
+++ b/supabase/functions/mcp/lib/updateProgramApply.ts
@@ -19,10 +19,9 @@
  */
 
 import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.103.3"
+import { applyDayUpdate, parsedExerciseToGeneratedForApply } from "./applyDayUpdate.ts"
 import {
-  applyDayUpdate,
   buildWorkoutExerciseInsertRowsForDay,
-  parsedExerciseToGeneratedForApply,
   type CatalogExerciseForProgram,
 } from "./programPersistence.ts"
 import type {

--- a/supabase/functions/mcp/lib/updateProgramDiff.test.ts
+++ b/supabase/functions/mcp/lib/updateProgramDiff.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import fixtures from "./updateProgram_fixtures.json"
+import { computeProgramDiff } from "./updateProgramDiff"
+import type {
+  CurrentProgramSnapshot,
+  ParsedPatch,
+  ProgramDiff,
+} from "./updateProgramTypes"
+
+interface Scenario {
+  name: string
+  current: CurrentProgramSnapshot
+  patch: ParsedPatch
+  expected: ProgramDiff
+}
+
+describe("computeProgramDiff", () => {
+  for (const scenario of fixtures as unknown as Scenario[]) {
+    it(scenario.name, () => {
+      const result = computeProgramDiff(scenario.current, scenario.patch)
+      expect(result).toEqual(scenario.expected)
+    })
+  }
+
+  it("does not mutate input current or patch", () => {
+    // Use the busiest fixture to maximise the surface area we'd notice mutating.
+    const scenario = (fixtures as unknown as Scenario[]).find(
+      (s) => s.name === "mixed (add + remove + update)",
+    )
+    if (!scenario) throw new Error("expected 'mixed' fixture to exist")
+
+    const currentClone: CurrentProgramSnapshot = JSON.parse(
+      JSON.stringify(scenario.current),
+    )
+    const patchClone: ParsedPatch = JSON.parse(JSON.stringify(scenario.patch))
+
+    computeProgramDiff(scenario.current, scenario.patch)
+
+    expect(scenario.current).toEqual(currentClone)
+    expect(scenario.patch).toEqual(patchClone)
+  })
+})

--- a/supabase/functions/mcp/lib/updateProgramDiff.ts
+++ b/supabase/functions/mcp/lib/updateProgramDiff.ts
@@ -1,0 +1,107 @@
+import type {
+  CurrentProgramSnapshot,
+  CurrentProgramSnapshotDay,
+  DiffDayInsert,
+  DiffDayUpdate,
+  ParsedPatch,
+  ParsedPatchDay,
+  ProgramDiff,
+} from "./updateProgramTypes.ts"
+
+/**
+ * Pure structural diff between the current program state and a parsed patch.
+ * Decides which days are inserted, updated, deleted, or unchanged, and sets
+ * the apply_order flag for the smart-reorder escape hatch.
+ *
+ * Pre-condition: parsedPatch.days has already passed validateDayIdentities
+ * (i.e. all provided ids exist in current.days; no duplicate ids).
+ */
+export function computeProgramDiff(
+  current: CurrentProgramSnapshot,
+  patch: ParsedPatch,
+): ProgramDiff {
+  const name_change =
+    patch.name !== undefined && patch.name !== current.name
+      ? { from: current.name, to: patch.name }
+      : null
+
+  if (patch.days === undefined) {
+    return {
+      program_id: patch.program_id,
+      name_change,
+      days_to_insert: [],
+      days_to_update: [],
+      days_to_delete: [],
+      days_unchanged: current.days.map((d) => ({ id: d.id, label: d.label })),
+      apply_order: "default",
+    }
+  }
+
+  const currentById = new Map<string, CurrentProgramSnapshotDay>(
+    current.days.map((d) => [d.id, d]),
+  )
+
+  const positioned = patch.days.map((day, position) => ({ day, position }))
+
+  const days_to_insert: DiffDayInsert[] = positioned
+    .filter(({ day }) => day.id === undefined)
+    .map(({ day, position }) => buildInsert(day, position))
+
+  const days_to_update: DiffDayUpdate[] = positioned
+    .filter(({ day }) => day.id !== undefined)
+    .map(({ day, position }) => buildUpdate(day, position, currentById))
+
+  const updateIds = new Set(days_to_update.map((u) => u.id))
+  const days_to_delete = current.days
+    .filter((d) => !updateIds.has(d.id))
+    .map((d) => ({
+      id: d.id,
+      label: d.label,
+      session_count: 0,
+      blocking: false,
+    }))
+
+  const transitsThroughZero =
+    current.days.length - days_to_delete.length === 0 &&
+    days_to_insert.length > 0
+
+  return {
+    program_id: patch.program_id,
+    name_change,
+    days_to_insert,
+    days_to_update,
+    days_to_delete,
+    days_unchanged: [],
+    apply_order: transitsThroughZero ? "insert_first" : "default",
+  }
+}
+
+function buildInsert(day: ParsedPatchDay, position: number): DiffDayInsert {
+  const base: DiffDayInsert = {
+    label: day.label,
+    sort_order: position,
+    parsed_exercises: day.parsed_exercises,
+  }
+  return day.emoji !== undefined ? { ...base, emoji: day.emoji } : base
+}
+
+function buildUpdate(
+  day: ParsedPatchDay,
+  position: number,
+  currentById: Map<string, CurrentProgramSnapshotDay>,
+): DiffDayUpdate {
+  // Pre-validated by validateDayIdentities: id exists in current.days.
+  const cur = currentById.get(day.id!)!
+  return {
+    id: day.id!,
+    current: {
+      label: cur.label,
+      emoji: cur.emoji,
+      sort_order: cur.sort_order,
+    },
+    label: day.label,
+    emoji: day.emoji ?? cur.emoji,
+    sort_order: position,
+    parsed_exercises: day.parsed_exercises,
+  }
+}

--- a/supabase/functions/mcp/lib/updateProgramTypes.ts
+++ b/supabase/functions/mcp/lib/updateProgramTypes.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared type contracts for the MCP `update_program` tool (Epic C, #280).
+ *
+ * Types-only module — zero runtime code, zero side effects. Imported by
+ * `lib/updateProgramDiff.ts` (T78), `lib/updateProgramValidation.ts` (T79),
+ * `lib/updateProgramApply.ts` (T80), and the handler `tools/updateProgram.ts`
+ * (T81). Lives here (vs in any of those modules) so T78/T79 can be developed
+ * in parallel against a single shared type contract.
+ */
+
+import type { ParsedExercise } from "./createProgramValidation.ts"
+
+export interface CurrentProgramSnapshotExercise {
+  exercise_id: string
+  name_snapshot: string
+  sets: number
+  reps: string
+  weight: string
+  rest_seconds: number
+  target_duration_seconds: number | null
+  sort_order: number
+}
+
+export interface CurrentProgramSnapshotDay {
+  id: string
+  label: string
+  emoji: string
+  sort_order: number
+  workout_exercises: CurrentProgramSnapshotExercise[]
+}
+
+export interface CurrentProgramSnapshot {
+  id: string
+  name: string
+  days: CurrentProgramSnapshotDay[]
+}
+
+export interface ParsedPatchDay {
+  /** Present → UPDATE existing day. Absent → INSERT new day. */
+  id?: string
+  label: string
+  emoji?: string
+  parsed_exercises: ParsedExercise[]
+}
+
+export interface ParsedPatch {
+  program_id: string
+  name?: string
+  days?: ParsedPatchDay[]
+  /** Resolved (default true). */
+  dry_run: boolean
+  /** Resolved (default false). Required when patch removes ≥1 day. */
+  confirm: boolean
+}
+
+export interface DiffDayInsert {
+  label: string
+  emoji?: string
+  sort_order: number
+  parsed_exercises: ParsedExercise[]
+}
+
+export interface DiffDayUpdate {
+  id: string
+  current: { label: string; emoji: string; sort_order: number }
+  label: string
+  emoji: string
+  sort_order: number
+  parsed_exercises: ParsedExercise[]
+}
+
+export interface DiffDayDelete {
+  id: string
+  label: string
+  /** Populated post-FK-precheck (initially 0 from `computeProgramDiff`). */
+  session_count: number
+  /** Populated post-FK-precheck (initially false). True iff session_count > 0. */
+  blocking: boolean
+}
+
+export interface DiffDayUnchanged {
+  id: string
+  label: string
+}
+
+export interface ProgramDiff {
+  program_id: string
+  name_change: { from: string; to: string } | null
+  days_to_insert: DiffDayInsert[]
+  days_to_update: DiffDayUpdate[]
+  days_to_delete: DiffDayDelete[]
+  days_unchanged: DiffDayUnchanged[]
+  /**
+   * `"insert_first"` is set by `computeProgramDiff` ONLY when the patch would
+   * transit through a 0-days state (current.days.length - days_to_delete.length
+   * === 0 AND days_to_insert.length > 0). Otherwise `"default"`.
+   */
+  apply_order: "default" | "insert_first"
+}

--- a/supabase/functions/mcp/lib/updateProgramValidation.test.ts
+++ b/supabase/functions/mcp/lib/updateProgramValidation.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest"
+import {
+  parsePatchShape,
+  requireConfirmForDestructive,
+  validateDayIdentities,
+} from "./updateProgramValidation"
+import type { ParsedPatchDay, ProgramDiff } from "./updateProgramTypes"
+
+const PROGRAM_ID = "11111111-2222-4333-8444-555555555555"
+const DAY_ID_1 = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+const DAY_ID_2 = "cccccccc-dddd-4eee-8fff-000000000000"
+const EX_ID = "22222222-3333-4444-8555-666666666666"
+
+function makeDayInput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    label: "Push",
+    exercises: [EX_ID],
+    ...overrides,
+  }
+}
+
+function makePatchDay(overrides: Partial<ParsedPatchDay> = {}): ParsedPatchDay {
+  return {
+    label: "Push",
+    parsed_exercises: [],
+    ...overrides,
+  }
+}
+
+function makeDiff(overrides: Partial<ProgramDiff> = {}): ProgramDiff {
+  return {
+    program_id: PROGRAM_ID,
+    name_change: null,
+    days_to_insert: [],
+    days_to_update: [],
+    days_to_delete: [],
+    days_unchanged: [],
+    apply_order: "default",
+    ...overrides,
+  }
+}
+
+describe("parsePatchShape", () => {
+  it("rejects `is_active` with a pointer to set_active_program (BEFORE generic shape errors)", () => {
+    // Even with a malformed program_id, the is_active rejection wins because
+    // it leads the agent to the right tool instead of a dead-end.
+    const result = parsePatchShape({ program_id: "not-a-uuid", is_active: true })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe(
+      "`is_active` is not editable via update_program. Use the dedicated `set_active_program` tool (coming soon).",
+    )
+  })
+
+  it("rejects a non-UUID program_id", () => {
+    const result = parsePatchShape({ program_id: "not-a-uuid" })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe("Invalid program_id format (expected UUID).")
+  })
+
+  it("rejects an empty `name`", () => {
+    const result = parsePatchShape({ program_id: PROGRAM_ID, name: "  " })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe("`name` must be a non-empty string when provided.")
+  })
+
+  it("rejects an empty `days` array (with omit-the-field hint)", () => {
+    const result = parsePatchShape({ program_id: PROGRAM_ID, days: [] })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe(
+      "`days` must be a non-empty array when provided. Omit the field entirely to leave days unchanged, or pass at least one day.",
+    )
+  })
+
+  it("rejects more than 14 days", () => {
+    const fifteen = Array.from({ length: 15 }, () => makeDayInput())
+    const result = parsePatchShape({ program_id: PROGRAM_ID, days: fifteen })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe("days: too many entries (max 14).")
+  })
+
+  it("rejects a day missing its label", () => {
+    const result = parsePatchShape({
+      program_id: PROGRAM_ID,
+      days: [{ exercises: [EX_ID] }],
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe("days[0].label must be a non-empty string.")
+  })
+
+  it("rejects a day with an empty `exercises` array", () => {
+    const result = parsePatchShape({
+      program_id: PROGRAM_ID,
+      days: [{ label: "Push", exercises: [] }],
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe(
+      "days[0].exercises must be a non-empty array (≥1 exercise per day).",
+    )
+  })
+
+  it("rejects a day whose `id` is not a UUID", () => {
+    const result = parsePatchShape({
+      program_id: PROGRAM_ID,
+      days: [makeDayInput({ id: "not-a-uuid" })],
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe("days[0].id must be a UUID when provided.")
+  })
+
+  it("rejects a non-boolean `dry_run`", () => {
+    const result = parsePatchShape({ program_id: PROGRAM_ID, dry_run: "yes" })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe("`dry_run` must be a boolean.")
+  })
+
+  it("rejects a non-boolean `confirm`", () => {
+    const result = parsePatchShape({ program_id: PROGRAM_ID, confirm: 1 })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe("`confirm` must be a boolean.")
+  })
+
+  it("happy path: resolves dry_run=true and confirm=false defaults when omitted", () => {
+    const result = parsePatchShape({ program_id: PROGRAM_ID })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.program_id).toBe(PROGRAM_ID)
+    expect(result.value.dry_run).toBe(true)
+    expect(result.value.confirm).toBe(false)
+    expect(result.value.name).toBeUndefined()
+    expect(result.value.days).toBeUndefined()
+  })
+
+  it("happy path with full payload: trims name, preserves day id, and stubs parsed_exercises (filled by handler)", () => {
+    const result = parsePatchShape({
+      program_id: PROGRAM_ID,
+      name: "  PPL 6w  ",
+      days: [makeDayInput({ id: DAY_ID_1, emoji: "💪" })],
+      dry_run: false,
+      confirm: true,
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.name).toBe("PPL 6w")
+    expect(result.value.dry_run).toBe(false)
+    expect(result.value.confirm).toBe(true)
+    expect(result.value.days).toEqual([
+      { id: DAY_ID_1, label: "Push", emoji: "💪", parsed_exercises: [] },
+    ])
+  })
+})
+
+describe("validateDayIdentities", () => {
+  it("rejects two patch days that share the same id and names BOTH positions", () => {
+    const result = validateDayIdentities(
+      [
+        makePatchDay({ id: DAY_ID_1, label: "Push" }),
+        makePatchDay({ id: DAY_ID_1, label: "Push (dup)" }),
+      ],
+      new Set([DAY_ID_1]),
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe(
+      `days[0] and days[1] both reference id '${DAY_ID_1}'. Each day id may appear at most once in the patch.`,
+    )
+  })
+
+  it("rejects a day id that is not in the current program", () => {
+    const result = validateDayIdentities(
+      [makePatchDay({ id: DAY_ID_2 })],
+      new Set([DAY_ID_1]),
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe(
+      `days[0].id '${DAY_ID_2}' is not a day of the current program. Omit the id to create a new day, or check the id.`,
+    )
+  })
+
+  it("accepts a mix of new-day (no id) and existing-day (id in current program)", () => {
+    const result = validateDayIdentities(
+      [makePatchDay({ label: "New" }), makePatchDay({ id: DAY_ID_1, label: "Existing" })],
+      new Set([DAY_ID_1]),
+    )
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe("requireConfirmForDestructive", () => {
+  it("rejects a destructive patch when confirm is false, listing each removed day's label", () => {
+    const diff = makeDiff({
+      days_to_delete: [
+        { id: DAY_ID_1, label: "Cardio", session_count: 0, blocking: false },
+      ],
+    })
+    const result = requireConfirmForDestructive(diff, false)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe(
+      "Patch removes 1 day(s): Cardio. Pass `confirm: true` along with `dry_run: false` to apply, or revise the payload to keep these days.",
+    )
+  })
+
+  it("accepts a destructive patch when confirm is true", () => {
+    const diff = makeDiff({
+      days_to_delete: [
+        { id: DAY_ID_1, label: "Cardio", session_count: 0, blocking: false },
+      ],
+    })
+    expect(requireConfirmForDestructive(diff, true)).toEqual({ ok: true })
+  })
+
+  it("accepts a non-destructive patch regardless of confirm", () => {
+    const diff = makeDiff({ days_to_delete: [] })
+    expect(requireConfirmForDestructive(diff, false)).toEqual({ ok: true })
+  })
+})

--- a/supabase/functions/mcp/lib/updateProgramValidation.ts
+++ b/supabase/functions/mcp/lib/updateProgramValidation.ts
@@ -1,0 +1,219 @@
+/**
+ * Pure validation gate for the `update_program` MCP tool (T79).
+ *
+ * Three side-effect-free validators consumed by the handler in
+ * `tools/updateProgram.ts` (T81), in this order:
+ *
+ *   1. `parsePatchShape(args)` — top-level patch shape, `is_active` rejection,
+ *      defaults resolution. Per-exercise validation is delegated to T77's
+ *      `validateDayExercises` (called by the handler after catalog fetch).
+ *   2. `validateDayIdentities(patchDays, currentDayIds)` — no duplicate ids,
+ *      every provided id exists in the current program.
+ *   3. `requireConfirmForDestructive(diff, confirm)` — destructive-guard,
+ *      run AFTER the diff is computed by T78's `computeProgramDiff`.
+ *
+ * All three return `{ ok: true, ... } | { ok: false, error: string }`.
+ * Error strings are purpose-crafted fixtures — see the test file for the
+ * exact wording the agent will receive on each failure mode.
+ */
+
+import type { ParsedPatch, ParsedPatchDay, ProgramDiff } from "./updateProgramTypes.ts"
+import { isUuid } from "./uuid.ts"
+
+const MAX_DAYS = 14
+const MAX_EXERCISES_PER_DAY = 40
+
+export function parsePatchShape(
+  args: Record<string, unknown>,
+): { ok: true; value: ParsedPatch } | { ok: false; error: string } {
+  // is_active rejection MUST come before any "unknown field" check so the
+  // agent gets a pointer to the dedicated tool instead of a generic "stop
+  // sending unknown fields" hint.
+  if (args.is_active !== undefined) {
+    return {
+      ok: false,
+      error:
+        "`is_active` is not editable via update_program. Use the dedicated `set_active_program` tool (coming soon).",
+    }
+  }
+
+  const programId = args.program_id
+  if (typeof programId !== "string" || !isUuid(programId)) {
+    return { ok: false, error: "Invalid program_id format (expected UUID)." }
+  }
+
+  let name: string | undefined
+  if (args.name !== undefined) {
+    if (typeof args.name !== "string" || args.name.trim().length === 0) {
+      return { ok: false, error: "`name` must be a non-empty string when provided." }
+    }
+    name = args.name.trim()
+  }
+
+  let days: ParsedPatchDay[] | undefined
+  if (args.days !== undefined) {
+    if (!Array.isArray(args.days)) {
+      return {
+        ok: false,
+        error:
+          "`days` must be a non-empty array when provided. Omit the field entirely to leave days unchanged, or pass at least one day.",
+      }
+    }
+    if (args.days.length === 0) {
+      return {
+        ok: false,
+        error:
+          "`days` must be a non-empty array when provided. Omit the field entirely to leave days unchanged, or pass at least one day.",
+      }
+    }
+    if (args.days.length > MAX_DAYS) {
+      return { ok: false, error: `days: too many entries (max ${MAX_DAYS}).` }
+    }
+
+    const parsedDaysResult = args.days.map((rawDay, i) => parseDayShape(rawDay, i))
+    const firstError = parsedDaysResult.find((r) => !r.ok)
+    if (firstError && !firstError.ok) {
+      return { ok: false, error: firstError.error }
+    }
+    days = parsedDaysResult.map((r) => (r as { ok: true; value: ParsedPatchDay }).value)
+  }
+
+  let dryRun = true
+  if (args.dry_run !== undefined) {
+    if (typeof args.dry_run !== "boolean") {
+      return { ok: false, error: "`dry_run` must be a boolean." }
+    }
+    dryRun = args.dry_run
+  }
+
+  let confirm = false
+  if (args.confirm !== undefined) {
+    if (typeof args.confirm !== "boolean") {
+      return { ok: false, error: "`confirm` must be a boolean." }
+    }
+    confirm = args.confirm
+  }
+
+  return {
+    ok: true,
+    value: {
+      program_id: programId,
+      ...(name !== undefined ? { name } : {}),
+      ...(days !== undefined ? { days } : {}),
+      dry_run: dryRun,
+      confirm,
+    },
+  }
+}
+
+function parseDayShape(
+  rawDay: unknown,
+  i: number,
+): { ok: true; value: ParsedPatchDay } | { ok: false; error: string } {
+  if (rawDay === null || typeof rawDay !== "object" || Array.isArray(rawDay)) {
+    return { ok: false, error: `days[${i}] must be an object.` }
+  }
+  const day = rawDay as Record<string, unknown>
+
+  if (typeof day.label !== "string" || day.label.trim().length === 0) {
+    return { ok: false, error: `days[${i}].label must be a non-empty string.` }
+  }
+  const label = day.label.trim()
+
+  let emoji: string | undefined
+  if (day.emoji !== undefined) {
+    if (typeof day.emoji !== "string") {
+      return { ok: false, error: `days[${i}].emoji must be a string when provided.` }
+    }
+    emoji = day.emoji
+  }
+
+  let id: string | undefined
+  if (day.id !== undefined) {
+    if (typeof day.id !== "string" || !isUuid(day.id)) {
+      return { ok: false, error: `days[${i}].id must be a UUID when provided.` }
+    }
+    id = day.id
+  }
+
+  if (!Array.isArray(day.exercises)) {
+    return {
+      ok: false,
+      error: `days[${i}].exercises must be a non-empty array (≥1 exercise per day).`,
+    }
+  }
+  if (day.exercises.length === 0) {
+    return {
+      ok: false,
+      error: `days[${i}].exercises must be a non-empty array (≥1 exercise per day).`,
+    }
+  }
+  if (day.exercises.length > MAX_EXERCISES_PER_DAY) {
+    return {
+      ok: false,
+      error: `days[${i}].exercises: too many entries (max ${MAX_EXERCISES_PER_DAY}).`,
+    }
+  }
+
+  // Per-exercise validation is delegated to T77's `validateDayExercises`,
+  // called by the T81 handler AFTER the catalog fetch. We only check the
+  // array shape here; the handler fills `parsed_exercises` with the result.
+  return {
+    ok: true,
+    value: {
+      ...(id !== undefined ? { id } : {}),
+      label,
+      ...(emoji !== undefined ? { emoji } : {}),
+      parsed_exercises: [],
+    },
+  }
+}
+
+export function validateDayIdentities(
+  patchDays: ParsedPatchDay[],
+  currentDayIds: Set<string>,
+): { ok: true } | { ok: false; error: string } {
+  const idsWithIndex = patchDays
+    .map((d, i) => ({ id: d.id, i }))
+    .filter((entry): entry is { id: string; i: number } => entry.id !== undefined)
+
+  // Duplicate-id check first (cheaper than the existence lookup below) so
+  // the error always names BOTH offending positions deterministically.
+  const firstSeenAt = new Map<string, number>()
+  const collision = idsWithIndex.find(({ id, i }) => {
+    if (firstSeenAt.has(id)) return true
+    firstSeenAt.set(id, i)
+    return false
+  })
+  if (collision) {
+    const firstIdx = firstSeenAt.get(collision.id)
+    return {
+      ok: false,
+      error: `days[${firstIdx}] and days[${collision.i}] both reference id '${collision.id}'. Each day id may appear at most once in the patch.`,
+    }
+  }
+
+  const unknown = idsWithIndex.find(({ id }) => !currentDayIds.has(id))
+  if (unknown) {
+    return {
+      ok: false,
+      error: `days[${unknown.i}].id '${unknown.id}' is not a day of the current program. Omit the id to create a new day, or check the id.`,
+    }
+  }
+
+  return { ok: true }
+}
+
+export function requireConfirmForDestructive(
+  diff: ProgramDiff,
+  confirm: boolean,
+): { ok: true } | { ok: false; error: string } {
+  if (diff.days_to_delete.length === 0 || confirm === true) {
+    return { ok: true }
+  }
+  const labels = diff.days_to_delete.map((d) => d.label).join(", ")
+  return {
+    ok: false,
+    error: `Patch removes ${diff.days_to_delete.length} day(s): ${labels}. Pass \`confirm: true\` along with \`dry_run: false\` to apply, or revise the payload to keep these days.`,
+  }
+}

--- a/supabase/functions/mcp/lib/updateProgram_fixtures.json
+++ b/supabase/functions/mcp/lib/updateProgram_fixtures.json
@@ -1,0 +1,806 @@
+[
+  {
+    "name": "rename only",
+    "current": {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "name": "PPL",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "workout_exercises": []
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "emoji": "🪝",
+          "sort_order": 1,
+          "workout_exercises": []
+        }
+      ]
+    },
+    "patch": {
+      "program_id": "00000000-0000-4000-8000-000000000001",
+      "name": "PPL v2",
+      "dry_run": true,
+      "confirm": false
+    },
+    "expected": {
+      "program_id": "00000000-0000-4000-8000-000000000001",
+      "name_change": { "from": "PPL", "to": "PPL v2" },
+      "days_to_insert": [],
+      "days_to_update": [],
+      "days_to_delete": [],
+      "days_unchanged": [
+        { "id": "aaaaaaa1-0000-4000-8000-000000000001", "label": "Push" },
+        { "id": "aaaaaaa2-0000-4000-8000-000000000002", "label": "Pull" }
+      ],
+      "apply_order": "default"
+    }
+  },
+  {
+    "name": "noop name",
+    "current": {
+      "id": "00000000-0000-4000-8000-000000000002",
+      "name": "PPL",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "workout_exercises": []
+        }
+      ]
+    },
+    "patch": {
+      "program_id": "00000000-0000-4000-8000-000000000002",
+      "name": "PPL",
+      "dry_run": true,
+      "confirm": false
+    },
+    "expected": {
+      "program_id": "00000000-0000-4000-8000-000000000002",
+      "name_change": null,
+      "days_to_insert": [],
+      "days_to_update": [],
+      "days_to_delete": [],
+      "days_unchanged": [
+        { "id": "aaaaaaa1-0000-4000-8000-000000000001", "label": "Push" }
+      ],
+      "apply_order": "default"
+    }
+  },
+  {
+    "name": "add one day",
+    "current": {
+      "id": "00000000-0000-4000-8000-000000000003",
+      "name": "PPL",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "workout_exercises": []
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "emoji": "🪝",
+          "sort_order": 1,
+          "workout_exercises": []
+        }
+      ]
+    },
+    "patch": {
+      "program_id": "00000000-0000-4000-8000-000000000003",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "emoji": "🪝",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "22222222-2222-4222-8222-222222222222" }
+          ]
+        },
+        {
+          "label": "Legs",
+          "emoji": "🦵",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "33333333-3333-4333-8333-333333333333" }
+          ]
+        }
+      ],
+      "dry_run": true,
+      "confirm": false
+    },
+    "expected": {
+      "program_id": "00000000-0000-4000-8000-000000000003",
+      "name_change": null,
+      "days_to_insert": [
+        {
+          "label": "Legs",
+          "emoji": "🦵",
+          "sort_order": 2,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "33333333-3333-4333-8333-333333333333" }
+          ]
+        }
+      ],
+      "days_to_update": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "current": { "label": "Push", "emoji": "💪", "sort_order": 0 },
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "current": { "label": "Pull", "emoji": "🪝", "sort_order": 1 },
+          "label": "Pull",
+          "emoji": "🪝",
+          "sort_order": 1,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "22222222-2222-4222-8222-222222222222" }
+          ]
+        }
+      ],
+      "days_to_delete": [],
+      "days_unchanged": [],
+      "apply_order": "default"
+    }
+  },
+  {
+    "name": "remove one day",
+    "current": {
+      "id": "00000000-0000-4000-8000-000000000004",
+      "name": "PPL",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "workout_exercises": []
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "emoji": "🪝",
+          "sort_order": 1,
+          "workout_exercises": []
+        },
+        {
+          "id": "aaaaaaa3-0000-4000-8000-000000000003",
+          "label": "Legs",
+          "emoji": "🦵",
+          "sort_order": 2,
+          "workout_exercises": []
+        }
+      ]
+    },
+    "patch": {
+      "program_id": "00000000-0000-4000-8000-000000000004",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "emoji": "🪝",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "22222222-2222-4222-8222-222222222222" }
+          ]
+        }
+      ],
+      "dry_run": true,
+      "confirm": false
+    },
+    "expected": {
+      "program_id": "00000000-0000-4000-8000-000000000004",
+      "name_change": null,
+      "days_to_insert": [],
+      "days_to_update": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "current": { "label": "Push", "emoji": "💪", "sort_order": 0 },
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "current": { "label": "Pull", "emoji": "🪝", "sort_order": 1 },
+          "label": "Pull",
+          "emoji": "🪝",
+          "sort_order": 1,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "22222222-2222-4222-8222-222222222222" }
+          ]
+        }
+      ],
+      "days_to_delete": [
+        {
+          "id": "aaaaaaa3-0000-4000-8000-000000000003",
+          "label": "Legs",
+          "session_count": 0,
+          "blocking": false
+        }
+      ],
+      "days_unchanged": [],
+      "apply_order": "default"
+    }
+  },
+  {
+    "name": "rename day",
+    "current": {
+      "id": "00000000-0000-4000-8000-000000000005",
+      "name": "PPL",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "workout_exercises": []
+        }
+      ]
+    },
+    "patch": {
+      "program_id": "00000000-0000-4000-8000-000000000005",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Pousser",
+          "emoji": "💪",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        }
+      ],
+      "dry_run": true,
+      "confirm": false
+    },
+    "expected": {
+      "program_id": "00000000-0000-4000-8000-000000000005",
+      "name_change": null,
+      "days_to_insert": [],
+      "days_to_update": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "current": { "label": "Push", "emoji": "💪", "sort_order": 0 },
+          "label": "Pousser",
+          "emoji": "💪",
+          "sort_order": 0,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        }
+      ],
+      "days_to_delete": [],
+      "days_unchanged": [],
+      "apply_order": "default"
+    }
+  },
+  {
+    "name": "swap exercise",
+    "current": {
+      "id": "00000000-0000-4000-8000-000000000006",
+      "name": "PPL",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "workout_exercises": [
+            {
+              "exercise_id": "11111111-1111-4111-8111-111111111111",
+              "name_snapshot": "Bench Press",
+              "sets": 3,
+              "reps": "10",
+              "weight": "60",
+              "rest_seconds": 90,
+              "target_duration_seconds": null,
+              "sort_order": 0
+            }
+          ]
+        }
+      ]
+    },
+    "patch": {
+      "program_id": "00000000-0000-4000-8000-000000000006",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "parsed_exercises": [
+            {
+              "kind": "object",
+              "exerciseId": "22222222-2222-4222-8222-222222222222",
+              "sets": 4,
+              "reps": "8",
+              "weightKg": 50,
+              "restSeconds": 120,
+              "targetDurationSeconds": null
+            }
+          ]
+        }
+      ],
+      "dry_run": true,
+      "confirm": false
+    },
+    "expected": {
+      "program_id": "00000000-0000-4000-8000-000000000006",
+      "name_change": null,
+      "days_to_insert": [],
+      "days_to_update": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "current": { "label": "Push", "emoji": "💪", "sort_order": 0 },
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "parsed_exercises": [
+            {
+              "kind": "object",
+              "exerciseId": "22222222-2222-4222-8222-222222222222",
+              "sets": 4,
+              "reps": "8",
+              "weightKg": 50,
+              "restSeconds": 120,
+              "targetDurationSeconds": null
+            }
+          ]
+        }
+      ],
+      "days_to_delete": [],
+      "days_unchanged": [],
+      "apply_order": "default"
+    }
+  },
+  {
+    "name": "reorder days",
+    "current": {
+      "id": "00000000-0000-4000-8000-000000000007",
+      "name": "PPL",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "workout_exercises": []
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "emoji": "🪝",
+          "sort_order": 1,
+          "workout_exercises": []
+        },
+        {
+          "id": "aaaaaaa3-0000-4000-8000-000000000003",
+          "label": "Legs",
+          "emoji": "🦵",
+          "sort_order": 2,
+          "workout_exercises": []
+        }
+      ]
+    },
+    "patch": {
+      "program_id": "00000000-0000-4000-8000-000000000007",
+      "days": [
+        {
+          "id": "aaaaaaa3-0000-4000-8000-000000000003",
+          "label": "Legs",
+          "emoji": "🦵",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "33333333-3333-4333-8333-333333333333" }
+          ]
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "emoji": "🪝",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "22222222-2222-4222-8222-222222222222" }
+          ]
+        },
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        }
+      ],
+      "dry_run": true,
+      "confirm": false
+    },
+    "expected": {
+      "program_id": "00000000-0000-4000-8000-000000000007",
+      "name_change": null,
+      "days_to_insert": [],
+      "days_to_update": [
+        {
+          "id": "aaaaaaa3-0000-4000-8000-000000000003",
+          "current": { "label": "Legs", "emoji": "🦵", "sort_order": 2 },
+          "label": "Legs",
+          "emoji": "🦵",
+          "sort_order": 0,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "33333333-3333-4333-8333-333333333333" }
+          ]
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "current": { "label": "Pull", "emoji": "🪝", "sort_order": 1 },
+          "label": "Pull",
+          "emoji": "🪝",
+          "sort_order": 1,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "22222222-2222-4222-8222-222222222222" }
+          ]
+        },
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "current": { "label": "Push", "emoji": "💪", "sort_order": 0 },
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 2,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        }
+      ],
+      "days_to_delete": [],
+      "days_unchanged": [],
+      "apply_order": "default"
+    }
+  },
+  {
+    "name": "mixed (add + remove + update)",
+    "current": {
+      "id": "00000000-0000-4000-8000-000000000008",
+      "name": "PPL",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "workout_exercises": []
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "emoji": "🪝",
+          "sort_order": 1,
+          "workout_exercises": []
+        },
+        {
+          "id": "aaaaaaa3-0000-4000-8000-000000000003",
+          "label": "Legs",
+          "emoji": "🦵",
+          "sort_order": 2,
+          "workout_exercises": []
+        }
+      ]
+    },
+    "patch": {
+      "program_id": "00000000-0000-4000-8000-000000000008",
+      "name": "PPL v2",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Pousser",
+          "emoji": "💪",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        },
+        {
+          "label": "Cardio",
+          "emoji": "🏃",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "44444444-4444-4444-8444-444444444444" }
+          ]
+        },
+        {
+          "id": "aaaaaaa3-0000-4000-8000-000000000003",
+          "label": "Legs",
+          "emoji": "🦵",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "33333333-3333-4333-8333-333333333333" }
+          ]
+        }
+      ],
+      "dry_run": true,
+      "confirm": false
+    },
+    "expected": {
+      "program_id": "00000000-0000-4000-8000-000000000008",
+      "name_change": { "from": "PPL", "to": "PPL v2" },
+      "days_to_insert": [
+        {
+          "label": "Cardio",
+          "emoji": "🏃",
+          "sort_order": 1,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "44444444-4444-4444-8444-444444444444" }
+          ]
+        }
+      ],
+      "days_to_update": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "current": { "label": "Push", "emoji": "💪", "sort_order": 0 },
+          "label": "Pousser",
+          "emoji": "💪",
+          "sort_order": 0,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        },
+        {
+          "id": "aaaaaaa3-0000-4000-8000-000000000003",
+          "current": { "label": "Legs", "emoji": "🦵", "sort_order": 2 },
+          "label": "Legs",
+          "emoji": "🦵",
+          "sort_order": 2,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "33333333-3333-4333-8333-333333333333" }
+          ]
+        }
+      ],
+      "days_to_delete": [
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "session_count": 0,
+          "blocking": false
+        }
+      ],
+      "days_unchanged": [],
+      "apply_order": "default"
+    }
+  },
+  {
+    "name": "drain-to-0 + refill",
+    "current": {
+      "id": "00000000-0000-4000-8000-000000000009",
+      "name": "PPL",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "workout_exercises": []
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "emoji": "🪝",
+          "sort_order": 1,
+          "workout_exercises": []
+        }
+      ]
+    },
+    "patch": {
+      "program_id": "00000000-0000-4000-8000-000000000009",
+      "days": [
+        {
+          "label": "Cardio",
+          "emoji": "🏃",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "44444444-4444-4444-8444-444444444444" }
+          ]
+        },
+        {
+          "label": "Mobility",
+          "emoji": "🧘",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "55555555-5555-4555-8555-555555555555" }
+          ]
+        }
+      ],
+      "dry_run": true,
+      "confirm": true
+    },
+    "expected": {
+      "program_id": "00000000-0000-4000-8000-000000000009",
+      "name_change": null,
+      "days_to_insert": [
+        {
+          "label": "Cardio",
+          "emoji": "🏃",
+          "sort_order": 0,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "44444444-4444-4444-8444-444444444444" }
+          ]
+        },
+        {
+          "label": "Mobility",
+          "emoji": "🧘",
+          "sort_order": 1,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "55555555-5555-4555-8555-555555555555" }
+          ]
+        }
+      ],
+      "days_to_update": [],
+      "days_to_delete": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "session_count": 0,
+          "blocking": false
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "session_count": 0,
+          "blocking": false
+        }
+      ],
+      "days_unchanged": [],
+      "apply_order": "insert_first"
+    }
+  },
+  {
+    "name": "emoji preserved when not in patch",
+    "current": {
+      "id": "00000000-0000-4000-8000-00000000000a",
+      "name": "PPL",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "workout_exercises": []
+        }
+      ]
+    },
+    "patch": {
+      "program_id": "00000000-0000-4000-8000-00000000000a",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        }
+      ],
+      "dry_run": true,
+      "confirm": false
+    },
+    "expected": {
+      "program_id": "00000000-0000-4000-8000-00000000000a",
+      "name_change": null,
+      "days_to_insert": [],
+      "days_to_update": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "current": { "label": "Push", "emoji": "💪", "sort_order": 0 },
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        }
+      ],
+      "days_to_delete": [],
+      "days_unchanged": [],
+      "apply_order": "default"
+    }
+  },
+  {
+    "name": "no apply_order swap when partial drain",
+    "current": {
+      "id": "00000000-0000-4000-8000-00000000000b",
+      "name": "PPL",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "workout_exercises": []
+        },
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "emoji": "🪝",
+          "sort_order": 1,
+          "workout_exercises": []
+        },
+        {
+          "id": "aaaaaaa3-0000-4000-8000-000000000003",
+          "label": "Legs",
+          "emoji": "🦵",
+          "sort_order": 2,
+          "workout_exercises": []
+        }
+      ]
+    },
+    "patch": {
+      "program_id": "00000000-0000-4000-8000-00000000000b",
+      "days": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "label": "Push",
+          "emoji": "💪",
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        }
+      ],
+      "dry_run": true,
+      "confirm": true
+    },
+    "expected": {
+      "program_id": "00000000-0000-4000-8000-00000000000b",
+      "name_change": null,
+      "days_to_insert": [],
+      "days_to_update": [
+        {
+          "id": "aaaaaaa1-0000-4000-8000-000000000001",
+          "current": { "label": "Push", "emoji": "💪", "sort_order": 0 },
+          "label": "Push",
+          "emoji": "💪",
+          "sort_order": 0,
+          "parsed_exercises": [
+            { "kind": "bare", "exerciseId": "11111111-1111-4111-8111-111111111111" }
+          ]
+        }
+      ],
+      "days_to_delete": [
+        {
+          "id": "aaaaaaa2-0000-4000-8000-000000000002",
+          "label": "Pull",
+          "session_count": 0,
+          "blocking": false
+        },
+        {
+          "id": "aaaaaaa3-0000-4000-8000-000000000003",
+          "label": "Legs",
+          "session_count": 0,
+          "blocking": false
+        }
+      ],
+      "days_unchanged": [],
+      "apply_order": "default"
+    }
+  }
+]

--- a/supabase/functions/mcp/tools/createProgram.ts
+++ b/supabase/functions/mcp/tools/createProgram.ts
@@ -1,4 +1,3 @@
-import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.103.3"
 import type { ToolDefinition } from "./registry.ts"
 import {
   buildWorkoutExerciseInsertRowsForDay,
@@ -11,10 +10,32 @@ import { formatPrescriptionLine, formatWeightConvention } from "../lib/format.ts
 import {
   detectLegacyExerciseIds,
   LEGACY_MIGRATION_ERROR_MESSAGE,
-  parseExerciseInput,
-  validateExerciseCrossFields,
+  validateDayExercises,
   type ParsedExercise,
 } from "../lib/createProgramValidation.ts"
+import { fetchExercisesByIds } from "../lib/catalogLookup.ts"
+import { isUuid } from "../lib/uuid.ts"
+
+/**
+ * Walk a raw `exercises[]` payload and extract every entry that LOOKS like a
+ * catalog id (bare UUID string or an object with an `exercise_id: <uuid>`).
+ * Non-UUID inputs are dropped — they're surfaced later by `validateDayExercises`
+ * via `parseExerciseInput`'s locator-aware error message. This keeps the
+ * catalog fetch from leaking Postgres "invalid input syntax for type uuid"
+ * errors to the agent.
+ */
+function collectCandidateExerciseIds(raw: unknown[]): string[] {
+  return raw.flatMap((entry) => {
+    if (typeof entry === "string") {
+      return isUuid(entry) ? [entry] : []
+    }
+    if (entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
+      const id = (entry as Record<string, unknown>).exercise_id
+      return typeof id === "string" && isUuid(id) ? [id] : []
+    }
+    return []
+  })
+}
 
 const DEFAULT_SETS = 3
 const DEFAULT_REPS = "10"
@@ -30,26 +51,6 @@ type DayInput = {
 type ParsedDay = {
   label: string
   exercises: ParsedExercise[]
-}
-
-function catalogRowToExercise(row: Record<string, unknown>): CatalogExerciseForProgram {
-  const mt = row.measurement_type
-  const measurement_type: "reps" | "duration" = mt === "duration" ? "duration" : "reps"
-  const rawDur = row.default_duration_seconds
-  let default_duration_seconds: number | null = null
-  if (rawDur != null && rawDur !== "") {
-    const n = Number(rawDur)
-    default_duration_seconds = Number.isFinite(n) ? n : null
-  }
-  return {
-    id: String(row.id),
-    name: String(row.name),
-    muscle_group: String(row.muscle_group),
-    emoji: row.emoji != null ? String(row.emoji) : null,
-    equipment: String(row.equipment),
-    measurement_type,
-    default_duration_seconds,
-  }
 }
 
 function defaultGeneratedExercise(ex: CatalogExerciseForProgram): GeneratedExerciseForProgram {
@@ -94,30 +95,6 @@ function geFromParsed(
   ex: CatalogExerciseForProgram,
 ): GeneratedExerciseForProgram {
   return parsed.kind === "bare" ? defaultGeneratedExercise(ex) : geFromParsedObject(parsed, ex)
-}
-
-async function fetchExercisesByIds(
-  supabase: SupabaseClient,
-  ids: string[],
-): Promise<{ data: CatalogExerciseForProgram[]; error: string | null }> {
-  const unique = [...new Set(ids)]
-  const { data, error } = await supabase
-    .from("exercises")
-    .select("id, name, muscle_group, emoji, equipment, measurement_type, default_duration_seconds")
-    .in("id", unique)
-
-  if (error) return { data: [], error: error.message }
-  const rows = (data ?? []) as Record<string, unknown>[]
-  const mapped = rows.map(catalogRowToExercise)
-  if (mapped.length !== unique.length) {
-    const found = new Set(mapped.map((e) => e.id))
-    const missing = unique.filter((id) => !found.has(id))
-    return {
-      data: [],
-      error: `Unknown or inaccessible exercise_id(s): ${missing.join(", ")}`,
-    }
-  }
-  return { data: mapped, error: null }
 }
 
 const TOOL_DESCRIPTION = `Create a multi-day training program in the user's GymLogic account (same persistence as the in-app AI program flow).
@@ -266,8 +243,9 @@ export const createProgram: ToolDefinition = {
       }
     }
 
-    // Phase 1 — pure shape/bounds/regex validation per exercise
-    const parsedDays: ParsedDay[] = []
+    // Phase 1 — day-level shape (label + exercises array bounds). Per-exercise
+    // parse + cross-field is consolidated into Phase 3 via validateDayExercises.
+    const rawDays: { label: string; exercises: unknown[] }[] = []
     for (const [i, d] of days.entries()) {
       const label = typeof d?.label === "string" ? d.label.trim() : ""
       const exercisesArr = Array.isArray(d?.exercises) ? d.exercises : null
@@ -289,24 +267,15 @@ export const createProgram: ToolDefinition = {
           isError: true,
         }
       }
-
-      const parsedExercises: ParsedExercise[] = []
-      for (const [j, raw] of exercisesArr.entries()) {
-        const result = parseExerciseInput(raw, label, j)
-        if (!result.ok) {
-          return {
-            content: [{ type: "text", text: `Invalid input: ${result.error}` }],
-            isError: true,
-          }
-        }
-        parsedExercises.push(result.value)
-      }
-      parsedDays.push({ label, exercises: parsedExercises })
+      rawDays.push({ label, exercises: exercisesArr })
     }
 
-    // Phase 2 — catalog fetch (Supabase, RLS-scoped to caller)
+    // Phase 2 — catalog fetch (Supabase, RLS-scoped to caller). Candidate IDs
+    // are pre-filtered to syntactically-valid UUIDs so a malformed input
+    // surfaces via validateDayExercises (locator-aware) rather than as a
+    // Postgres syntax error from the IN clause.
     const allIds = [
-      ...new Set(parsedDays.flatMap((d) => d.exercises.map((e) => e.exerciseId))),
+      ...new Set(rawDays.flatMap((d) => collectCandidateExerciseIds(d.exercises))),
     ]
     const { data: exercises, error: fetchErr } = await fetchExercisesByIds(supabase, allIds)
     if (fetchErr) {
@@ -315,18 +284,17 @@ export const createProgram: ToolDefinition = {
 
     const byId = new Map(exercises.map((e) => [e.id, e] as const))
 
-    // Phase 3 — cross-field validation (T75 superset: R1-R5)
-    for (const day of parsedDays) {
-      for (const [j, parsed] of day.exercises.entries()) {
-        const ex = byId.get(parsed.exerciseId)!
-        const cfResult = validateExerciseCrossFields(parsed, ex, day.label, j)
-        if (!cfResult.ok) {
-          return {
-            content: [{ type: "text", text: `Invalid input: ${cfResult.error}` }],
-            isError: true,
-          }
+    // Phase 3 — full per-day validation: parse + cross-field (T75 superset).
+    const parsedDays: ParsedDay[] = []
+    for (const day of rawDays) {
+      const result = validateDayExercises(day.exercises, day.label, byId)
+      if (!result.ok) {
+        return {
+          content: [{ type: "text", text: `Invalid input: ${result.error}` }],
+          isError: true,
         }
       }
+      parsedDays.push({ label: day.label, exercises: result.parsed })
     }
 
     const { data: userData, error: userErr } = await supabase.auth.getUser()

--- a/supabase/functions/mcp/tools/getProgramDetails.ts
+++ b/supabase/functions/mcp/tools/getProgramDetails.ts
@@ -19,6 +19,7 @@ interface WorkoutDayRow {
 
 interface WorkoutExerciseRow {
   id: string
+  exercise_id: string
   name_snapshot: string
   sets: number
   reps: string
@@ -66,7 +67,7 @@ export const getProgramDetails: ToolDefinition = {
     const { data, error } = await supabase
       .from("programs")
       .select(
-        "id, name, archived_at, workout_days(id, label, emoji, sort_order, workout_exercises(id, name_snapshot, sets, reps, weight, rest_seconds, target_duration_seconds, sort_order))",
+        "id, name, archived_at, workout_days(id, label, emoji, sort_order, workout_exercises(id, exercise_id, name_snapshot, sets, reps, weight, rest_seconds, target_duration_seconds, sort_order))",
       )
       .eq("id", programId)
       .maybeSingle()

--- a/supabase/functions/mcp/tools/registry.ts
+++ b/supabase/functions/mcp/tools/registry.ts
@@ -5,6 +5,7 @@ import { getWorkoutHistory } from "./getWorkoutHistory.ts"
 import { getTrainingStats } from "./getTrainingStats.ts"
 import { getUpcomingWorkouts } from "./getUpcomingWorkouts.ts"
 import { createProgram } from "./createProgram.ts"
+import { updateProgram } from "./updateProgram.ts"
 import { listPrograms } from "./listPrograms.ts"
 import { getProgramDetails } from "./getProgramDetails.ts"
 
@@ -29,6 +30,7 @@ const tools: ToolDefinition[] = [
   getTrainingStats,
   getUpcomingWorkouts,
   createProgram,
+  updateProgram,
   listPrograms,
   getProgramDetails,
 ]

--- a/supabase/functions/mcp/tools/updateProgram.ts
+++ b/supabase/functions/mcp/tools/updateProgram.ts
@@ -151,7 +151,7 @@ Each item in a day's \`exercises\` array can be EITHER:
 
 Atomicity: per-day, no cross-day rollback. If a mid-flight INSERT fails, prior days are already persisted; the response includes \`applied_days\`, \`failed_at\`, and \`remaining_days\` plus retry guidance.
 
-Always call with \`dry_run: true\` first (the default) — review \`preview.rendered\` and the \`removed_days\`/\`added_days\`/\`warnings\` arrays. Re-call with \`dry_run: false\` to apply.
+Always call with \`dry_run: true\` first (the default) — review the top-level \`rendered\` markdown plus the \`removed_days\`/\`added_days\`/\`warnings\` arrays. Re-call with \`dry_run: false\` to apply.
 
 Destructive guard: removing ≥1 day requires \`confirm: true\` along with \`dry_run: false\`. The handler also blocks deletion of any day with logged sessions (returns a structured error).
 

--- a/supabase/functions/mcp/tools/updateProgram.ts
+++ b/supabase/functions/mcp/tools/updateProgram.ts
@@ -1,0 +1,412 @@
+/**
+ * MCP `update_program` tool — in-place program editing (Epic C, #280).
+ *
+ * Wires the four pure modules from T77-T80 into a single handler:
+ *
+ *   parsePatchShape (T79)         → top-level shape, defaults, is_active rejection
+ *   ↓
+ *   fetch current program (RLS)   → CurrentProgramSnapshot
+ *   ↓
+ *   validateDayIdentities (T79)   → no dup ids, every id ∈ current
+ *   ↓
+ *   fetchExercisesByIds (T77)     → catalog (union of patch + unchanged ids)
+ *   ↓
+ *   validateDayExercises (T77)    → per-day parse + cross-field
+ *   ↓
+ *   computeProgramDiff (T78)      → structural diff + apply_order
+ *   ↓
+ *   FK pre-check (sessions)       → annotates days_to_delete with session_count
+ *   ↓
+ *   active-cycle check            → optional warning string
+ *   ↓
+ *   ┌─ dry_run=true  → render + structured preview (errors[] when blocking)
+ *   └─ dry_run=false → requireConfirmForDestructive + applyProgramDiff (T80)
+ */
+
+import type { ToolDefinition } from "./registry.ts"
+import { isUuid } from "../lib/uuid.ts"
+import { fetchExercisesByIds } from "../lib/catalogLookup.ts"
+import { validateDayExercises } from "../lib/createProgramValidation.ts"
+import {
+  parsePatchShape,
+  requireConfirmForDestructive,
+  validateDayIdentities,
+} from "../lib/updateProgramValidation.ts"
+import { computeProgramDiff } from "../lib/updateProgramDiff.ts"
+import { applyProgramDiff } from "../lib/updateProgramApply.ts"
+import {
+  formatActiveCycleWarning,
+  formatProgramAfterUpdate,
+} from "../lib/format.ts"
+import type {
+  CurrentProgramSnapshot,
+  CurrentProgramSnapshotDay,
+  CurrentProgramSnapshotExercise,
+  ParsedPatchDay,
+} from "../lib/updateProgramTypes.ts"
+
+type ErrorReply = { content: [{ type: "text"; text: string }]; isError: true }
+type SuccessReply = { content: [{ type: "text"; text: string }]; isError?: false }
+type ToolReply = ErrorReply | SuccessReply
+
+function err(text: string): ErrorReply {
+  return { content: [{ type: "text", text }], isError: true }
+}
+
+function ok(text: string, isError = false): ToolReply {
+  return isError
+    ? { content: [{ type: "text", text }], isError: true }
+    : { content: [{ type: "text", text }] }
+}
+
+function jsonReply(payload: unknown, isError = false): ToolReply {
+  return ok(JSON.stringify(payload, null, 2), isError)
+}
+
+/**
+ * Filter raw exercise inputs to syntactically-valid UUIDs so the catalog
+ * fetch never leaks Postgres "invalid input syntax for type uuid". Mirrors
+ * the helper used by `create_program` — duplicated here on purpose to keep
+ * this ticket's scope surgical.
+ */
+function collectCandidateExerciseIds(raw: unknown[]): string[] {
+  return raw.flatMap((entry) => {
+    if (typeof entry === "string") {
+      return isUuid(entry) ? [entry] : []
+    }
+    if (entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
+      const id = (entry as Record<string, unknown>).exercise_id
+      return typeof id === "string" && isUuid(id) ? [id] : []
+    }
+    return []
+  })
+}
+
+interface RawProgramRow {
+  id: string
+  name: string
+  workout_days: RawWorkoutDayRow[] | null
+}
+
+interface RawWorkoutDayRow {
+  id: string
+  label: string
+  emoji: string | null
+  sort_order: number
+  workout_exercises: RawWorkoutExerciseRow[] | null
+}
+
+interface RawWorkoutExerciseRow {
+  exercise_id: string
+  name_snapshot: string
+  sets: number
+  reps: string
+  weight: string
+  rest_seconds: number
+  target_duration_seconds: number | null
+  sort_order: number
+}
+
+function buildSnapshot(row: RawProgramRow): CurrentProgramSnapshot {
+  const days: CurrentProgramSnapshotDay[] = (row.workout_days ?? [])
+    .slice()
+    .sort((a, b) => a.sort_order - b.sort_order)
+    .map((d) => {
+      const exercises: CurrentProgramSnapshotExercise[] = (d.workout_exercises ?? [])
+        .slice()
+        .sort((a, b) => a.sort_order - b.sort_order)
+        .map((ex) => ({
+          exercise_id: ex.exercise_id,
+          name_snapshot: ex.name_snapshot,
+          sets: ex.sets,
+          reps: ex.reps,
+          weight: ex.weight,
+          rest_seconds: ex.rest_seconds,
+          target_duration_seconds: ex.target_duration_seconds,
+          sort_order: ex.sort_order,
+        }))
+      return {
+        id: d.id,
+        label: d.label,
+        emoji: d.emoji ?? "🏋️",
+        sort_order: d.sort_order,
+        workout_exercises: exercises,
+      }
+    })
+  return { id: row.id, name: row.name, days }
+}
+
+const PROGRAM_SELECT =
+  "id, name, workout_days(id, label, emoji, sort_order, workout_exercises(exercise_id, name_snapshot, sets, reps, weight, rest_seconds, target_duration_seconds, sort_order))"
+
+const TOOL_DESCRIPTION = `Edit an existing program in place — rename it, add/remove/reorder days, swap exercises, or revise prescriptions — without breaking session history (logged set_logs are preserved via wipe-and-reinsert at the workout_exercises layer).
+
+Patch shape:
+  - Top level: PATCH semantics. Omit a field → leave it unchanged. Pass \`name\` → rename. Pass \`days\` → declarative PUT inside that field (see below).
+  - Inside \`days\`: declarative. Each entry with an \`id\` matching an existing day = UPDATE; without \`id\` = INSERT; existing days NOT in the array = DELETE.
+
+Each item in a day's \`exercises\` array can be EITHER:
+  - A bare UUID string — applies legacy defaults (3 sets, 10 reps, 0 kg, 90s rest).
+  - A full prescription object — required fields {exercise_id, sets, reps, weight_kg, rest_seconds}; \`target_duration_seconds\` for duration exercises (T75).
+
+Atomicity: per-day, no cross-day rollback. If a mid-flight INSERT fails, prior days are already persisted; the response includes \`applied_days\`, \`failed_at\`, and \`remaining_days\` plus retry guidance.
+
+Always call with \`dry_run: true\` first (the default) — review \`preview.rendered\` and the \`removed_days\`/\`added_days\`/\`warnings\` arrays. Re-call with \`dry_run: false\` to apply.
+
+Destructive guard: removing ≥1 day requires \`confirm: true\` along with \`dry_run: false\`. The handler also blocks deletion of any day with logged sessions (returns a structured error).
+
+Mid-cycle awareness: when an active cycle exists for the program, the response surfaces a French warning ("Cycle actif depuis ..."). Edits still proceed when confirmed.
+
+For activating/deactivating a program (\`is_active\`), use the dedicated \`set_active_program\` tool (coming soon) — \`update_program\` rejects \`is_active\` in the patch.`
+
+export const updateProgram: ToolDefinition = {
+  name: "update_program",
+  description: TOOL_DESCRIPTION,
+  inputSchema: {
+    type: "object",
+    properties: {
+      program_id: {
+        type: "string",
+        description: "UUID of the program to update. Obtain from list_programs or get_program_details.",
+      },
+      name: {
+        type: "string",
+        description: "Optional. New program name. Omit to leave the name unchanged.",
+      },
+      days: {
+        type: "array",
+        description:
+          "Optional. Full desired list of days (declarative PUT inside this field). Days with `id` matching an existing day = UPDATE; days without `id` = INSERT; existing days NOT in this array = DELETE (requires `confirm: true` and FK pre-check). Omit the field entirely to leave days unchanged.",
+        minItems: 1,
+        maxItems: 14,
+        items: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              description: "UUID of an existing day to UPDATE. Omit to INSERT a new day.",
+            },
+            label: { type: "string", description: "Day label shown in the app." },
+            emoji: { type: "string", description: "Optional emoji for the day." },
+            exercises: {
+              type: "array",
+              minItems: 1,
+              maxItems: 40,
+              items: {
+                oneOf: [
+                  {
+                    type: "string",
+                    description: "Bare UUID — defaults applied (3 sets, 10 reps, 0 kg, 90s rest).",
+                  },
+                  {
+                    type: "object",
+                    description: "Full prescription. Required fields documented in `create_program`.",
+                    properties: {
+                      exercise_id: { type: "string" },
+                      sets: { type: "integer", minimum: 1, maximum: 10 },
+                      reps: { type: "string", pattern: "^\\d+(-\\d+)?$" },
+                      weight_kg: { type: "number", minimum: 0, maximum: 500 },
+                      rest_seconds: { type: "integer", minimum: 0, maximum: 600 },
+                      target_duration_seconds: {
+                        type: "integer",
+                        minimum: 5,
+                        maximum: 600,
+                      },
+                    },
+                    required: ["exercise_id", "sets", "reps", "weight_kg", "rest_seconds"],
+                  },
+                ],
+              },
+            },
+          },
+          required: ["label", "exercises"],
+        },
+      },
+      dry_run: {
+        type: "boolean",
+        description: "Default true. Set false to apply.",
+      },
+      confirm: {
+        type: "boolean",
+        description: "Default false. REQUIRED when the patch removes ≥1 day.",
+      },
+    },
+    required: ["program_id"],
+  },
+
+  async handler(args, supabase) {
+    if (!supabase) {
+      return err("Authentication required — please provide a valid Bearer token.")
+    }
+
+    const { data: userData, error: userErr } = await supabase.auth.getUser()
+    if (userErr || !userData?.user) {
+      return err("Could not identify the authenticated user.")
+    }
+    const userId = userData.user.id
+
+    const parseResult = parsePatchShape(args)
+    if (!parseResult.ok) {
+      return err(parseResult.error)
+    }
+    const parsedPatch = parseResult.value
+
+    const { data: programRow, error: programErr } = await supabase
+      .from("programs")
+      .select(PROGRAM_SELECT)
+      .eq("id", parsedPatch.program_id)
+      .maybeSingle()
+    if (programErr) {
+      return err(`Error fetching program: ${programErr.message}`)
+    }
+    if (!programRow) {
+      return err("Program not found or you don't have access.")
+    }
+    const currentProgram = buildSnapshot(programRow as unknown as RawProgramRow)
+
+    const currentDayIds = new Set(currentProgram.days.map((d) => d.id))
+    const idsResult = validateDayIdentities(parsedPatch.days ?? [], currentDayIds)
+    if (!idsResult.ok) {
+      return err(idsResult.error)
+    }
+
+    // Catalog fetch covers BOTH the patch's referenced ids AND the unchanged days'
+    // persisted exercise_ids — the dry_run renderer needs the equipment field for
+    // every line it'll emit (formatPrescriptionLine's weight convention).
+    const rawDays =
+      Array.isArray(args.days)
+        ? (args.days as Array<Record<string, unknown>>)
+        : []
+    const patchIds = rawDays.flatMap((d) =>
+      Array.isArray(d.exercises) ? collectCandidateExerciseIds(d.exercises) : [],
+    )
+    const currentIds = currentProgram.days.flatMap((d) =>
+      d.workout_exercises.map((ex) => ex.exercise_id),
+    )
+    const unionIds = [...new Set([...patchIds, ...currentIds])]
+    const { data: catalogRows, error: catalogErr } = await fetchExercisesByIds(
+      supabase,
+      unionIds,
+    )
+    if (catalogErr) {
+      return err(`Invalid input: ${catalogErr}`)
+    }
+    const catalogById = new Map(catalogRows.map((e) => [e.id, e] as const))
+
+    if (parsedPatch.days) {
+      const validateOne = (
+        day: ParsedPatchDay,
+        i: number,
+      ): { ok: true; updated: ParsedPatchDay } | { ok: false; error: string } => {
+        const rawExercises = Array.isArray(rawDays[i]?.exercises)
+          ? (rawDays[i].exercises as unknown[])
+          : []
+        const result = validateDayExercises(rawExercises, day.label, catalogById)
+        if (!result.ok) return result
+        return { ok: true, updated: { ...day, parsed_exercises: result.parsed } }
+      }
+
+      const validated = parsedPatch.days.map((day, i) => validateOne(day, i))
+      const failure = validated.find((r) => !r.ok)
+      if (failure && !failure.ok) {
+        return err(`Invalid input: ${failure.error}`)
+      }
+      parsedPatch.days = validated.map(
+        (r) => (r as { ok: true; updated: ParsedPatchDay }).updated,
+      )
+    }
+
+    const diff = computeProgramDiff(currentProgram, parsedPatch)
+
+    // FK pre-check: count sessions per to-be-deleted day in a single batched
+    // query, then annotate the diff entries (mutating in place is fine — the
+    // diff is a fresh object owned by this handler).
+    if (diff.days_to_delete.length > 0) {
+      const deleteIds = diff.days_to_delete.map((d) => d.id)
+      const { data: sessionRows, error: sessErr } = await supabase
+        .from("sessions")
+        .select("workout_day_id")
+        .in("workout_day_id", deleteIds)
+      if (sessErr) {
+        return err(`Error checking sessions for deleted days: ${sessErr.message}`)
+      }
+      const counts = (sessionRows ?? []).reduce<Map<string, number>>((acc, row) => {
+        const id = (row as { workout_day_id: string }).workout_day_id
+        acc.set(id, (acc.get(id) ?? 0) + 1)
+        return acc
+      }, new Map())
+      diff.days_to_delete.forEach((d) => {
+        d.session_count = counts.get(d.id) ?? 0
+        d.blocking = d.session_count > 0
+      })
+    }
+
+    const { data: cycleData } = await supabase
+      .from("cycles")
+      .select("started_at")
+      .eq("program_id", parsedPatch.program_id)
+      .is("finished_at", null)
+      .maybeSingle()
+    const activeCycleWarning =
+      cycleData && typeof (cycleData as { started_at?: unknown }).started_at === "string"
+        ? formatActiveCycleWarning({ started_at: (cycleData as { started_at: string }).started_at })
+        : null
+
+    const blockingErrors = diff.days_to_delete
+      .filter((d) => d.blocking)
+      .map((d) => ({
+        day_label: d.label,
+        error: `Cannot remove day '${d.label}' — it has ${d.session_count} logged sessions. Rename or repurpose it instead, or remove the corresponding entries from the patch and resubmit.`,
+      }))
+
+    if (parsedPatch.dry_run) {
+      const rendered = formatProgramAfterUpdate(diff, currentProgram, catalogById)
+      const removed_days = diff.days_to_delete.map((d) => ({
+        id: d.id,
+        label: d.label,
+        session_count: d.session_count,
+        blocking: d.blocking,
+      }))
+      const added_days = diff.days_to_insert.map((d) => ({ label: d.label }))
+      const warnings = activeCycleWarning ? [activeCycleWarning] : []
+
+      const payload = {
+        dry_run: true,
+        program_id: parsedPatch.program_id,
+        rendered,
+        removed_days,
+        added_days,
+        warnings,
+        errors: blockingErrors,
+        message:
+          blockingErrors.length > 0
+            ? "Patch blocked — see `errors[]`. Revise the payload and re-run."
+            : "Dry run preview only — no writes performed. Re-call with `dry_run: false` to apply.",
+      }
+
+      return jsonReply(payload, blockingErrors.length > 0)
+    }
+
+    const confirmResult = requireConfirmForDestructive(diff, parsedPatch.confirm)
+    if (!confirmResult.ok) {
+      return err(confirmResult.error)
+    }
+
+    if (blockingErrors.length > 0) {
+      const message = blockingErrors.map((e) => e.error).join("\n")
+      return err(message)
+    }
+
+    const applyResult = await applyProgramDiff(supabase, diff, catalogById, userId)
+    const responsePayload = {
+      dry_run: false,
+      program_id: parsedPatch.program_id,
+      applied_days: applyResult.applied_days,
+      failed_at: applyResult.failed_at,
+      remaining_days: applyResult.remaining_days,
+      warnings: activeCycleWarning ? [activeCycleWarning] : [],
+      message: applyResult.message,
+    }
+    return jsonReply(responsePayload, applyResult.failed_at !== null)
+  },
+}

--- a/supabase/functions/mcp/tools/updateProgram_test.ts
+++ b/supabase/functions/mcp/tools/updateProgram_test.ts
@@ -1,0 +1,831 @@
+/**
+ * Integration tests for the `update_program` MCP tool handler (T81, Epic C #280).
+ *
+ * Black-box: drives the registered handler with an in-memory mock supabase that
+ * - simulates RLS by filtering programs by user_id on SELECT,
+ * - records every write op (op + table + payload + filters) in a callLog so
+ *   the dry_run-zero-writes test can assert on it,
+ * - supports scripted error injection at a specific table/op pair to drive
+ *   the partial-success scenario.
+ *
+ * The mock is intentionally minimal — only the chains the handler actually
+ * builds are implemented. Unsupported chains throw loudly.
+ */
+
+import {
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+  assertNotMatch,
+} from "https://deno.land/std@0.224.0/assert/mod.ts"
+import { updateProgram } from "./updateProgram.ts"
+
+// ---------------------------------------------------------------------------
+// Verbatim retry guidance — must round-trip unchanged from T80 through T81.
+// ---------------------------------------------------------------------------
+
+const RETRY_GUIDANCE =
+  "To retry, submit a new patch containing only the remaining_days (with their `id`s) plus any corrections; applied_days are already up to date and should be omitted from `days[]` (or included with their existing `id` to be left unchanged)."
+
+// ---------------------------------------------------------------------------
+// Fixture ids (deterministic UUIDs)
+// ---------------------------------------------------------------------------
+
+const ID_USER = "11111111-1111-4111-8111-111111111111"
+const ID_OTHER_USER = "22222222-2222-4222-8222-222222222222"
+const ID_PROGRAM = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+const ID_OTHER_PROGRAM = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+const ID_DAY_PUSH = "cccccccc-1111-4111-8111-cccccccccccc"
+const ID_DAY_PULL = "cccccccc-2222-4222-8222-cccccccccccc"
+const ID_DAY_LEGS = "cccccccc-3333-4333-8333-cccccccccccc"
+const ID_BENCH = "dddddddd-1111-4111-8111-dddddddddddd"
+const ID_PUSHUP = "dddddddd-2222-4222-8222-dddddddddddd"
+
+const BENCH = {
+  id: ID_BENCH,
+  name: "Bench Press",
+  muscle_group: "chest",
+  emoji: null,
+  equipment: "barbell",
+  measurement_type: "reps",
+  default_duration_seconds: null,
+}
+
+const PUSHUP = {
+  id: ID_PUSHUP,
+  name: "Push-up",
+  muscle_group: "chest",
+  emoji: null,
+  equipment: "bodyweight",
+  measurement_type: "reps",
+  default_duration_seconds: null,
+}
+
+// ---------------------------------------------------------------------------
+// Mock state shapes
+// ---------------------------------------------------------------------------
+
+interface ProgramRow {
+  id: string
+  user_id: string
+  name: string
+}
+
+interface DayRow {
+  id: string
+  program_id: string
+  user_id: string
+  label: string
+  emoji: string
+  sort_order: number
+}
+
+interface ExerciseRow {
+  id: string
+  workout_day_id: string
+  exercise_id: string
+  name_snapshot: string
+  sets: number
+  reps: string
+  weight: string
+  rest_seconds: number
+  target_duration_seconds: number | null
+  sort_order: number
+  // extra columns persisted by buildWorkoutExerciseInsertRowsForDay; ignored by tests
+  [extra: string]: unknown
+}
+
+interface SessionRow {
+  id: string
+  workout_day_id: string
+  user_id: string
+}
+
+interface CycleRow {
+  id: string
+  program_id: string
+  started_at: string
+  finished_at: string | null
+}
+
+interface MockState {
+  programs: ProgramRow[]
+  days: DayRow[]
+  exercises: ExerciseRow[]
+  sessions: SessionRow[]
+  cycles: CycleRow[]
+  catalog: typeof BENCH[]
+}
+
+interface CallEntry {
+  op: "select" | "update" | "delete" | "insert"
+  table: string
+  payload?: unknown
+  filters?: Filter[]
+  returning?: string
+  terminal?: "single" | "maybeSingle"
+}
+
+interface Filter {
+  type: "eq" | "in" | "is"
+  col: string
+  val: unknown
+}
+
+interface FaultRule {
+  table: string
+  op: "select" | "update" | "delete" | "insert"
+  /** 0-indexed nth occurrence of (table, op) at which to inject the fault. */
+  occurrence: number
+  message: string
+}
+
+// ---------------------------------------------------------------------------
+// MockSupabase
+// ---------------------------------------------------------------------------
+
+class MockSupabase {
+  callLog: CallEntry[] = []
+  faults: FaultRule[] = []
+  occurrenceCount = new Map<string, number>()
+  dayIdCounter = 0
+
+  constructor(
+    public state: MockState,
+    public currentUserId: string = ID_USER,
+  ) {}
+
+  failOn(rule: FaultRule): this {
+    this.faults.push(rule)
+    return this
+  }
+
+  consumeFault(table: string, op: CallEntry["op"]): string | null {
+    const key = `${table}:${op}`
+    const idx = this.occurrenceCount.get(key) ?? 0
+    this.occurrenceCount.set(key, idx + 1)
+    const match = this.faults.find(
+      (f) => f.table === table && f.op === op && f.occurrence === idx,
+    )
+    return match ? match.message : null
+  }
+
+  nextDayId(): string {
+    this.dayIdCounter += 1
+    return `mock-day-new-${this.dayIdCounter}`
+  }
+
+  auth = {
+    getUser: () =>
+      Promise.resolve({
+        data: { user: { id: this.currentUserId } },
+        error: null,
+      }),
+  }
+
+  from(table: string): MockBuilder {
+    return new MockBuilder(this, table)
+  }
+}
+
+class MockBuilder {
+  private entry: CallEntry
+  private filters: Filter[] = []
+
+  constructor(
+    private mock: MockSupabase,
+    private table: string,
+  ) {
+    this.entry = { op: "select", table }
+  }
+
+  // --- starters ---
+
+  select(cols: string): this {
+    this.entry.op = this.entry.op === "select" ? "select" : this.entry.op
+    this.entry.returning = cols
+    return this
+  }
+
+  update(payload: unknown): this {
+    this.entry.op = "update"
+    this.entry.payload = payload
+    return this
+  }
+
+  delete(): this {
+    this.entry.op = "delete"
+    return this
+  }
+
+  insert(payload: unknown): this {
+    this.entry.op = "insert"
+    this.entry.payload = payload
+    return this
+  }
+
+  // --- filters ---
+
+  eq(col: string, val: unknown): this {
+    this.filters.push({ type: "eq", col, val })
+    return this
+  }
+
+  in(col: string, val: unknown[]): this {
+    this.filters.push({ type: "in", col, val })
+    return this
+  }
+
+  is(col: string, val: unknown): this {
+    this.filters.push({ type: "is", col, val })
+    return this
+  }
+
+  // --- terminals ---
+
+  single(): Promise<{ data: unknown; error: { message: string } | null }> {
+    this.entry.terminal = "single"
+    return this.execute()
+  }
+
+  maybeSingle(): Promise<{ data: unknown; error: { message: string } | null }> {
+    this.entry.terminal = "maybeSingle"
+    return this.execute()
+  }
+
+  // Thenable: enables `await builder` for chains without single/maybeSingle
+  // (e.g. bulk INSERT, UPDATE/DELETE filtered by .eq, SELECT lists).
+  then<T1, T2>(
+    onFulfilled: (v: { data: unknown; error: { message: string } | null }) => T1 | PromiseLike<T1>,
+    onRejected?: (reason: unknown) => T2 | PromiseLike<T2>,
+  ): Promise<T1 | T2> {
+    return this.execute().then(onFulfilled, onRejected)
+  }
+
+  private async execute(): Promise<{ data: unknown; error: { message: string } | null }> {
+    this.entry.filters = this.filters
+    this.mock.callLog.push(this.entry)
+
+    const fault = this.mock.consumeFault(this.table, this.entry.op)
+    if (fault) {
+      return { data: null, error: { message: fault } }
+    }
+
+    if (this.entry.op === "select") return this.executeSelect()
+    if (this.entry.op === "update") return this.executeUpdate()
+    if (this.entry.op === "delete") return this.executeDelete()
+    return this.executeInsert()
+  }
+
+  private executeSelect(): { data: unknown; error: null } {
+    const t = this.table
+    const f = this.filters
+
+    if (t === "programs") {
+      const candidates = this.mock.state.programs
+        .filter((p) => p.user_id === this.mock.currentUserId)
+        .filter((p) => matchAll(p, f))
+      const result = candidates.map((p) => embedProgram(p, this.mock.state))
+      return finalizeSelect(result, this.entry.terminal)
+    }
+
+    if (t === "exercises") {
+      const rows = this.mock.state.catalog.filter((e) => matchAll(e, f))
+      return finalizeSelect(rows, this.entry.terminal)
+    }
+
+    if (t === "sessions") {
+      const rows = this.mock.state.sessions.filter((s) => matchAll(s, f))
+      return finalizeSelect(
+        rows.map((r) => ({ workout_day_id: r.workout_day_id })),
+        this.entry.terminal,
+      )
+    }
+
+    if (t === "cycles") {
+      const rows = this.mock.state.cycles.filter((c) => matchAll(c, f))
+      return finalizeSelect(
+        rows.map((r) => ({ started_at: r.started_at })),
+        this.entry.terminal,
+      )
+    }
+
+    throw new Error(`MockSupabase.select: unsupported table "${t}"`)
+  }
+
+  private executeUpdate(): { data: null; error: null } {
+    const t = this.table
+    const f = this.filters
+    const payload = this.entry.payload as Record<string, unknown>
+    const targets = (this.mock.state[stateKeyForTable(t)] as Record<string, unknown>[]).filter(
+      (r) => matchAll(r, f),
+    )
+    targets.forEach((r) => Object.assign(r, payload))
+    return { data: null, error: null }
+  }
+
+  private executeDelete(): { data: null; error: null } {
+    const t = this.table
+    const f = this.filters
+    const key = stateKeyForTable(t)
+    const arr = this.mock.state[key] as Record<string, unknown>[]
+    const remaining = arr.filter((r) => !matchAll(r, f))
+    ;(this.mock.state[key] as Record<string, unknown>[]).length = 0
+    ;(this.mock.state[key] as Record<string, unknown>[]).push(...remaining)
+    return { data: null, error: null }
+  }
+
+  private executeInsert(): { data: unknown; error: null } {
+    const t = this.table
+    const payload = this.entry.payload
+
+    if (t === "workout_days") {
+      const row = payload as Omit<DayRow, "id">
+      const id = this.mock.nextDayId()
+      const full: DayRow = { id, ...row }
+      this.mock.state.days.push(full)
+      if (this.entry.terminal === "single") {
+        return { data: { id }, error: null }
+      }
+      return { data: null, error: null }
+    }
+
+    if (t === "workout_exercises") {
+      const rows = (payload as Record<string, unknown>[]).map((r, i) => ({
+        ...r,
+        id: `mock-ex-${this.mock.state.exercises.length + i + 1}`,
+      })) as ExerciseRow[]
+      this.mock.state.exercises.push(...rows)
+      return { data: null, error: null }
+    }
+
+    throw new Error(`MockSupabase.insert: unsupported table "${t}"`)
+  }
+}
+
+function matchAll(row: Record<string, unknown>, filters: Filter[]): boolean {
+  return filters.every((f) => {
+    if (f.type === "eq") return row[f.col] === f.val
+    if (f.type === "in") {
+      const list = f.val as unknown[]
+      return list.includes(row[f.col])
+    }
+    if (f.type === "is") return row[f.col] === f.val
+    return true
+  })
+}
+
+function stateKeyForTable(table: string): keyof MockState {
+  switch (table) {
+    case "programs":
+      return "programs"
+    case "workout_days":
+      return "days"
+    case "workout_exercises":
+      return "exercises"
+    case "sessions":
+      return "sessions"
+    case "cycles":
+      return "cycles"
+    case "exercises":
+      return "catalog"
+  }
+  throw new Error(`Unknown table: ${table}`)
+}
+
+function embedProgram(p: ProgramRow, state: MockState): unknown {
+  const days = state.days
+    .filter((d) => d.program_id === p.id)
+    .slice()
+    .sort((a, b) => a.sort_order - b.sort_order)
+    .map((d) => ({
+      id: d.id,
+      label: d.label,
+      emoji: d.emoji,
+      sort_order: d.sort_order,
+      workout_exercises: state.exercises
+        .filter((ex) => ex.workout_day_id === d.id)
+        .slice()
+        .sort((a, b) => a.sort_order - b.sort_order)
+        .map((ex) => ({
+          exercise_id: ex.exercise_id,
+          name_snapshot: ex.name_snapshot,
+          sets: ex.sets,
+          reps: ex.reps,
+          weight: ex.weight,
+          rest_seconds: ex.rest_seconds,
+          target_duration_seconds: ex.target_duration_seconds,
+          sort_order: ex.sort_order,
+        })),
+    }))
+  return { id: p.id, name: p.name, workout_days: days }
+}
+
+function finalizeSelect(
+  rows: unknown[],
+  terminal?: "single" | "maybeSingle",
+): { data: unknown; error: null } {
+  if (terminal === "maybeSingle") {
+    return { data: rows.length > 0 ? rows[0] : null, error: null }
+  }
+  if (terminal === "single") {
+    return { data: rows[0] ?? null, error: null }
+  }
+  return { data: rows, error: null }
+}
+
+// ---------------------------------------------------------------------------
+// State factories
+// ---------------------------------------------------------------------------
+
+function makeBaseState(): MockState {
+  return {
+    programs: [
+      { id: ID_PROGRAM, user_id: ID_USER, name: "PPL" },
+      { id: ID_OTHER_PROGRAM, user_id: ID_OTHER_USER, name: "Other Routine" },
+    ],
+    days: [
+      {
+        id: ID_DAY_PUSH,
+        program_id: ID_PROGRAM,
+        user_id: ID_USER,
+        label: "Push",
+        emoji: "💪",
+        sort_order: 0,
+      },
+      {
+        id: ID_DAY_PULL,
+        program_id: ID_PROGRAM,
+        user_id: ID_USER,
+        label: "Pull",
+        emoji: "🪝",
+        sort_order: 1,
+      },
+    ],
+    exercises: [
+      {
+        id: "seed-ex-1",
+        workout_day_id: ID_DAY_PUSH,
+        exercise_id: ID_BENCH,
+        name_snapshot: "Bench Press",
+        sets: 4,
+        reps: "8",
+        weight: "80",
+        rest_seconds: 120,
+        target_duration_seconds: null,
+        sort_order: 0,
+      },
+      {
+        id: "seed-ex-2",
+        workout_day_id: ID_DAY_PULL,
+        exercise_id: ID_PUSHUP,
+        name_snapshot: "Push-up",
+        sets: 3,
+        reps: "10",
+        weight: "0",
+        rest_seconds: 90,
+        target_duration_seconds: null,
+        sort_order: 0,
+      },
+    ],
+    sessions: [],
+    cycles: [],
+    catalog: [BENCH, PUSHUP],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseReply(reply: { content: Array<{ text: string }> }): Record<string, unknown> {
+  return JSON.parse(reply.content[0].text) as Record<string, unknown>
+}
+
+function writeOps(callLog: CallEntry[]): CallEntry[] {
+  return callLog.filter(
+    (c) =>
+      (c.op === "insert" || c.op === "update" || c.op === "delete") &&
+      (c.table === "programs" ||
+        c.table === "workout_days" ||
+        c.table === "workout_exercises"),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+Deno.test("update_program renames the program (apply success, no day touched)", async () => {
+  const mock = new MockSupabase(makeBaseState())
+
+  const reply = await updateProgram.handler(
+    { program_id: ID_PROGRAM, name: "PPL v2", dry_run: false },
+    mock as never,
+  )
+
+  assertEquals(reply.isError ?? false, false)
+  const body = parseReply(reply)
+  assertEquals(body.dry_run, false)
+  assertEquals(body.applied_days, [])
+  assertEquals(body.failed_at, null)
+  assertEquals(body.remaining_days, [])
+  // State updated.
+  assertEquals(
+    mock.state.programs.find((p) => p.id === ID_PROGRAM)?.name,
+    "PPL v2",
+  )
+  // Single program UPDATE — no day or exercise writes.
+  const writes = writeOps(mock.callLog)
+  assertEquals(writes.length, 1)
+  assertEquals(writes[0].table, "programs")
+  assertEquals(writes[0].op, "update")
+})
+
+Deno.test("update_program adds a new day, captures its id, and reports it in applied_days", async () => {
+  const mock = new MockSupabase(makeBaseState())
+
+  const reply = await updateProgram.handler(
+    {
+      program_id: ID_PROGRAM,
+      days: [
+        // Keep current days unchanged (carry their ids + same exercises shape).
+        {
+          id: ID_DAY_PUSH,
+          label: "Push",
+          emoji: "💪",
+          exercises: [ID_BENCH],
+        },
+        {
+          id: ID_DAY_PULL,
+          label: "Pull",
+          emoji: "🪝",
+          exercises: [ID_PUSHUP],
+        },
+        // New day — no `id`.
+        {
+          label: "Legs",
+          emoji: "🦵",
+          exercises: [ID_BENCH],
+        },
+      ],
+      dry_run: false,
+    },
+    mock as never,
+  )
+
+  assertEquals(reply.isError ?? false, false)
+  const body = parseReply(reply)
+  const applied = body.applied_days as Array<{ label: string; ops: string[]; id: string }>
+  const inserted = applied.find((a) => a.label === "Legs")
+  assertExists(inserted)
+  assertEquals(inserted!.ops, ["inserted"])
+  assertEquals(inserted!.id, "mock-day-new-1")
+  // 3 days persist.
+  const newDays = mock.state.days.filter((d) => d.program_id === ID_PROGRAM)
+  assertEquals(newDays.length, 3)
+})
+
+Deno.test("update_program blocks deletion of a day with logged sessions (FK pre-check) and writes nothing", async () => {
+  const state = makeBaseState()
+  // Pull day has 2 logged sessions → FK pre-check should block deletion.
+  state.sessions.push(
+    { id: "s1", workout_day_id: ID_DAY_PULL, user_id: ID_USER },
+    { id: "s2", workout_day_id: ID_DAY_PULL, user_id: ID_USER },
+  )
+  const mock = new MockSupabase(state)
+
+  const reply = await updateProgram.handler(
+    {
+      program_id: ID_PROGRAM,
+      // Omit Pull → DELETE intended. Pass confirm so we reach the FK check.
+      days: [
+        {
+          id: ID_DAY_PUSH,
+          label: "Push",
+          emoji: "💪",
+          exercises: [ID_BENCH],
+        },
+      ],
+      dry_run: false,
+      confirm: true,
+    },
+    mock as never,
+  )
+
+  assertEquals(reply.isError, true)
+  const text = reply.content[0].text
+  assertStringIncludes(text, "Pull")
+  assertStringIncludes(text, "2 logged sessions")
+  // No mutating writes happened on programs/workout_days/workout_exercises.
+  assertEquals(writeOps(mock.callLog).length, 0)
+})
+
+Deno.test("update_program rejects destructive apply without confirm and writes nothing", async () => {
+  const mock = new MockSupabase(makeBaseState())
+
+  const reply = await updateProgram.handler(
+    {
+      program_id: ID_PROGRAM,
+      // Omit Pull → DELETE intended, but no confirm.
+      days: [
+        {
+          id: ID_DAY_PUSH,
+          label: "Push",
+          emoji: "💪",
+          exercises: [ID_BENCH],
+        },
+      ],
+      dry_run: false,
+    },
+    mock as never,
+  )
+
+  assertEquals(reply.isError, true)
+  const text = reply.content[0].text
+  assertStringIncludes(text, "confirm: true")
+  assertEquals(writeOps(mock.callLog).length, 0)
+})
+
+Deno.test("update_program defaults to dry_run when the flag is omitted — no writes, full preview returned", async () => {
+  const mock = new MockSupabase(makeBaseState())
+
+  const reply = await updateProgram.handler(
+    {
+      program_id: ID_PROGRAM,
+      name: "PPL v2",
+      days: [
+        {
+          id: ID_DAY_PUSH,
+          label: "Push v2",
+          emoji: "💪",
+          exercises: [
+            {
+              exercise_id: ID_BENCH,
+              sets: 5,
+              reps: "5",
+              weight_kg: 100,
+              rest_seconds: 180,
+            },
+          ],
+        },
+        // Implicit DELETE of Pull (omitted) — surfaces in removed_days.
+        // Implicit INSERT of Legs.
+        {
+          label: "Legs",
+          emoji: "🦵",
+          exercises: [ID_BENCH],
+        },
+      ],
+      // dry_run intentionally omitted → defaults to true.
+    },
+    mock as never,
+  )
+
+  assertEquals(reply.isError ?? false, false)
+  const body = parseReply(reply)
+  assertEquals(body.dry_run, true)
+  // Preview includes the renamed program + new day prescription.
+  assertStringIncludes(body.rendered as string, "PPL v2")
+  assertStringIncludes(body.rendered as string, "Push v2")
+  assertStringIncludes(body.rendered as string, "Bench Press — 5 × 5 × 100 kg total — 180s rest")
+  // Removed/added bookkeeping.
+  const removed = body.removed_days as Array<{ id: string; label: string }>
+  assertEquals(removed.length, 1)
+  assertEquals(removed[0].label, "Pull")
+  const added = body.added_days as Array<{ label: string }>
+  assertEquals(added, [{ label: "Legs" }])
+  // Zero writes recorded.
+  assertEquals(writeOps(mock.callLog).length, 0)
+})
+
+Deno.test("update_program surfaces the active-cycle warning in BOTH dry_run and apply responses", async () => {
+  const stateApply = makeBaseState()
+  stateApply.cycles.push({
+    id: "cyc-1",
+    program_id: ID_PROGRAM,
+    started_at: "2026-04-15T10:00:00.000Z",
+    finished_at: null,
+  })
+  const mockApply = new MockSupabase(stateApply)
+
+  const applyReply = await updateProgram.handler(
+    { program_id: ID_PROGRAM, name: "PPL v2", dry_run: false },
+    mockApply as never,
+  )
+  const applyBody = parseReply(applyReply)
+  const applyWarnings = applyBody.warnings as string[]
+  assertEquals(applyWarnings.length, 1)
+  assertStringIncludes(applyWarnings[0], "Cycle actif depuis 2026-04-15")
+
+  // Re-run as dry_run — same cycle state, same warning expected.
+  const stateDry = makeBaseState()
+  stateDry.cycles.push({
+    id: "cyc-1",
+    program_id: ID_PROGRAM,
+    started_at: "2026-04-15T10:00:00.000Z",
+    finished_at: null,
+  })
+  const mockDry = new MockSupabase(stateDry)
+
+  const dryReply = await updateProgram.handler(
+    { program_id: ID_PROGRAM, name: "PPL v2" },
+    mockDry as never,
+  )
+  const dryBody = parseReply(dryReply)
+  const dryWarnings = dryBody.warnings as string[]
+  assertEquals(dryWarnings.length, 1)
+  assertStringIncludes(dryWarnings[0], "Cycle actif depuis 2026-04-15")
+})
+
+Deno.test("update_program returns a partial-success report when a mid-flight day INSERT fails", async () => {
+  const mock = new MockSupabase(makeBaseState())
+  // Two new days planned. Fail the SECOND `workout_days.insert` call.
+  // The plan order is: [...deletes, ...updates, ...inserts]. Our patch keeps both
+  // current days as updates (so 2 update flows fire first), then attempts 2 inserts.
+  // The 0th workout_days.insert is the first new day; the 1st is the second.
+  mock.failOn({
+    table: "workout_days",
+    op: "insert",
+    occurrence: 1,
+    message: "boom on second insert",
+  })
+
+  const reply = await updateProgram.handler(
+    {
+      program_id: ID_PROGRAM,
+      days: [
+        // Keep both current days as updates so the apply plan reaches the inserts.
+        {
+          id: ID_DAY_PUSH,
+          label: "Push",
+          emoji: "💪",
+          exercises: [ID_BENCH],
+        },
+        {
+          id: ID_DAY_PULL,
+          label: "Pull",
+          emoji: "🪝",
+          exercises: [ID_PUSHUP],
+        },
+        // New: day "Legs" inserts cleanly.
+        { label: "Legs", emoji: "🦵", exercises: [ID_BENCH] },
+        // New: day "Mobility" — second insert, scripted to fail.
+        { label: "Mobility", emoji: "🧘", exercises: [ID_BENCH] },
+      ],
+      dry_run: false,
+    },
+    mock as never,
+  )
+
+  assertEquals(reply.isError, true)
+  const body = parseReply(reply)
+  const applied = body.applied_days as Array<{ label: string }>
+  // The two updates AND the first insert succeed → 3 applied.
+  assertEquals(applied.length, 3)
+  const labelsApplied = applied.map((a) => a.label)
+  assertEquals(labelsApplied.includes("Legs"), true)
+  const failedAt = body.failed_at as { day_label: string; error: string } | null
+  assertExists(failedAt)
+  assertEquals(failedAt!.day_label, "Mobility")
+  assertStringIncludes(failedAt!.error, "boom on second insert")
+  const remaining = body.remaining_days as Array<{ label: string; intent: string }>
+  // After the failure on Mobility, nothing remains.
+  assertEquals(remaining, [])
+  // Verbatim retry guidance round-trips through.
+  assertStringIncludes(body.message as string, RETRY_GUIDANCE)
+})
+
+Deno.test("update_program rejects access to another user's program with the RLS-style 'not found' message and writes nothing", async () => {
+  const mock = new MockSupabase(makeBaseState(), ID_USER)
+
+  const reply = await updateProgram.handler(
+    { program_id: ID_OTHER_PROGRAM, name: "hijack attempt", dry_run: false },
+    mock as never,
+  )
+
+  assertEquals(reply.isError, true)
+  assertEquals(
+    reply.content[0].text,
+    "Program not found or you don't have access.",
+  )
+  assertEquals(writeOps(mock.callLog).length, 0)
+  // Other user's program name unchanged.
+  assertEquals(
+    mock.state.programs.find((p) => p.id === ID_OTHER_PROGRAM)?.name,
+    "Other Routine",
+  )
+})
+
+Deno.test("update_program rejects is_active in the patch with a pointer to set_active_program", async () => {
+  const mock = new MockSupabase(makeBaseState())
+
+  const reply = await updateProgram.handler(
+    { program_id: ID_PROGRAM, is_active: true },
+    mock as never,
+  )
+
+  assertEquals(reply.isError, true)
+  assertStringIncludes(reply.content[0].text, "set_active_program")
+  assertNotMatch(reply.content[0].text, /unknown field/i)
+})

--- a/supabase/functions/mcp/tools/updateProgram_test.ts
+++ b/supabase/functions/mcp/tools/updateProgram_test.ts
@@ -37,7 +37,6 @@ const ID_PROGRAM = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
 const ID_OTHER_PROGRAM = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
 const ID_DAY_PUSH = "cccccccc-1111-4111-8111-cccccccccccc"
 const ID_DAY_PULL = "cccccccc-2222-4222-8222-cccccccccccc"
-const ID_DAY_LEGS = "cccccccc-3333-4333-8333-cccccccccccc"
 const ID_BENCH = "dddddddd-1111-4111-8111-dddddddddddd"
 const ID_PUSHUP = "dddddddd-2222-4222-8222-dddddddddddd"
 


### PR DESCRIPTION
## What

Ships the **`update_program`** MCP write tool — first in-place editor for GymLogic programs that **preserves training history** (logged sessions, set_logs, cycles all survive across edits).

7 tickets across 4 waves:
- **T76** — `get_program_details` exposes `exercise_id` (catalog-side id, not the slot row id), unlocking patches that reference exercises the agent already saw.
- **T77** — extracts `validateDayExercises` + `fetchExercisesByIds` + shared `updateProgramTypes.ts` from `createProgram.ts`. Pure refactor, both create + update import.
- **T78** — pure module `lib/updateProgramDiff.ts` (`computeProgramDiff`): structural diff between current state and parsed patch, including the smart-reorder escape hatch when the patch transits through a 0-days state.
- **T79** — pure module `lib/updateProgramValidation.ts`: `parsePatchShape`, `validateDayIdentities`, `requireConfirmForDestructive`. `is_active` rejected with a pointer to `set_active_program` (coming soon).
- **T80** — `applyProgramDiff` orchestrator + `applyDayUpdate` persistence helper. Per-day atomic, partial-success report on mid-flight failure with verbatim retry guidance.
- **T81** — handler `tools/updateProgram.ts` wires the four pure modules + registry registration + `SERVER_INFO.version` bump 0.3.0 → 0.4.0 + 2 format helpers (`formatProgramAfterUpdate`, `formatActiveCycleWarning`). 9 black-box scenarios via in-memory mock supabase covering rename, add day, FK block, no-confirm reject, dry_run-default, mid-cycle warning, partial-success, RLS cross-user, `is_active` reject.
- **T82** — `skills/gymlogic-mcp/SKILL.md` documents the new tool: roster bumped to 9 tools, declarative-`days` semantics spelled out (id present → UPDATE, absent → INSERT, omitted → DELETE), 3 worked French examples (rename only, add a day, swap exercise + revise), destructive-guard / mid-cycle / partial-success paragraphs.

Tool count: **8 → 9** (`tools/list` returns `update_program` in the 7th slot).

## Why

Until #280, editing a program required **recreating it via `create_program`** — which orphaned every logged session pointing at the old `workout_days` rows. In practice this meant: agents that promised "modifie ton programme" silently destroyed history.

`update_program` resolves it through **per-day wipe-and-reinsert** of `workout_exercises` rows (safe because `set_logs.exercise_id` references `exercises(id)` on the catalog, not the slot id), preserving program identity and sessions.

The patch shape is **PATCH at top-level** (`name?`, `days?`) and **declarative inside `days`** — a day with `id` is an UPDATE, no `id` is an INSERT, an existing day omitted is a DELETE. This keeps rename-only patches trivial (omit `days`), while making destructive changes explicit (the dry_run preview surfaces `removed_days[]` + `errors[]`, and apply requires both `dry_run: false` AND `confirm: true`).

## How

### Architecture (T76-T80 are pure modules, T81 is the handler that wires them)

```
parsePatchShape (T79)                    → top-level shape, defaults, is_active rejection
        ↓
fetch current program (RLS-scoped)       → CurrentProgramSnapshot
        ↓
validateDayIdentities (T79)              → no dup ids, every id ∈ current
        ↓
fetchExercisesByIds (T77)                → catalog (union of patch + unchanged ids)
        ↓
validateDayExercises (T77)               → per-day parse + cross-field
        ↓
computeProgramDiff (T78)                 → structural diff + apply_order
        ↓
FK pre-check on sessions                 → annotates days_to_delete with session_count
        ↓
active-cycle check                       → optional warning string
        ↓
┌─ dry_run=true  → render + structured preview (errors[] when blocking)
└─ dry_run=false → requireConfirmForDestructive (T79) + applyProgramDiff (T80)
```

### Key design decisions (full rationale in `docs/Tech_Plan_—_MCP_—_update_program_#280.md`)

- **Wipe-and-reinsert per day** — every UPDATE-day always replaces its `workout_exercises` rows (idempotent), every INSERT-day inserts fresh. Safe by FK design.
- **Smart re-order escape hatch** — when `current.days.length - days_to_delete.length === 0` AND `days_to_insert.length > 0`, apply order flips to inserts-first → deletes-last so the program never transits through an empty intermediate state.
- **Per-day atomic, no cross-day rollback** — partial-success report (`applied_days`, `failed_at`, `remaining_days`) with verbatim retry guidance lets the agent resubmit a clean patch covering only `remaining_days`.
- **No web mirror** for new helpers (`lib/updateProgram*.ts`, `applyDayUpdate`) — `update_program` is strictly MCP-only, the existing `programPersistence.ts` mirror stays untouched.
- **Catalog union fetch** in the handler — patch ids + unchanged-day exercise_ids fetched in a single batched call, so the dry_run renderer always has the equipment for `formatPrescriptionLine`'s convention suffix.

### Tests

- **140 vitest** tests across the 6 new test files (`updateProgramDiff.test.ts`, `updateProgramValidation.test.ts`, `updateProgramApply.test.ts`, `applyDayUpdate.test.ts`, `catalogLookup.test.ts`, format helper extensions).
- **9 Deno integration tests** (`updateProgram_test.ts`) with in-memory mock supabase that simulates RLS by user_id, supports embedded `programs.workout_days.workout_exercises` selects, and supports scripted fault injection for the partial-success path.
- Full vitest suite: 1329/1329 pass; lint: 0 errors; build: green; deno tests on the touched files: green.

### E2E HITL validation (Claude Desktop, prod against `favusepjqwpcroiolvaz`)

3/3 French prompts resolved zero-shot to `update_program` (never `create_program`):

1. **Rename** — *"renomme mon programme 'Mai 2026 — Push/Legs/Pull/Upper (Coach Iris)' en 'Mai 2026 — Test Update'"* → propose-confirm-act + dry_run + apply, response `applied_days: [], message: "Updated 0 day(s)."`.
2. **Add day** — *"ajoute une journée 'Cardio' avec 3 exos cardio en mode duration"* → agent fetched `get_program_details` first to read all 4 day ids, ran 3 `search_exercises` calls, echoed all 4 current days + 1 new day. Server preserved history, program now at 5 days.
3. **Swap + revise** — *"sur Push, passe le bench à 4×8 @ 80kg ; sur Pull, ajoute des tractions assistées 3×8 bodyweight"* → modified Push and Pull, echoed Legs / Upper / Cardio unchanged, no `create_program` attempt.

### Iris validation (cross-agent E2E)

SKILL.md `gymlogic-mcp` v0.4.0 + `AGENTS.md` row 8 deployed on the Iris VPS (commit `ffa19f3` on `sudo-ceo`). 3/3 French prompts resolved zero-shot to `update_program` (never `create_program`):

| Prompt | `days[]` echo | Specific check | Outcome |
|---|---|---|---|
| 1. Pure rename | ø (rule 2: omit `days` when only renaming) | em-dash U+2014 preserved through round-trip | ✅ `applied_days: 0` |
| 2. Add `Cardio` day | 6 (5 UPDATE + 1 INSERT without id) | Duration mode object form: `reps:"0"`, `weight_kg:0`, `target_duration_seconds: 30/60/45` | ✅ program at 5 days, history intact |
| 3. Revise Push bench + add Pull rowing | 6 days, all UPDATE | `per_hand` convention respected: agent called `get_exercise_details` on the rowing UUID **before** the patch, sent `weight_kg: 22` (not 44) | ✅ both days mutated, others echoed unchanged |

**Cross-agent confirmations**: `update_program` always preferred over `create_program`; `days[]` echo of unchanged days correct; per-hand convention pre-flight inspection happened (gold-standard agent behavior); UTF-8 round-trip 100% (em-dashes, FR accents, emojis 💪🔥⚡🫀🏋️ all intact in payloads + responses).

### Deploy state

Edge function `mcp` v0.4.0 deployed to `favusepjqwpcroiolvaz` (script size 126.4 kB).

## Follow-ups (out of scope, tracked separately)

- **Auto-apply pattern in SKILL.md** — across all 3 Iris prompts (and similar pattern observed on Claude Desktop), the agent ran `dry_run: true` immediately followed by `dry_run: false` in the same turn without surfacing the preview to the human first. Tolerable on rename / 0-removed-days cases but problematic when prescriptions actually move. Either harden the SKILL ("never auto-call with `dry_run: false` in the same turn as `dry_run: true`") or document the carve-out for non-destructive patches.
- **Agent-side UUID hallucination guard** — Iris attempted `get_exercise_details({ exercise_id: "kroc-row-id" })` with a literal placeholder string fabricated after a failed `search_exercises("Kroc row")`. Recovery was clean but it's a real hallucination case. Two non-exclusive paths: (a) tighten the SKILL canonical rule with an explicit anti-pattern example; (b) server-side, return a more agent-actionable error message (e.g. `"kroc-row-id" is not a valid UUID v4; do not invent ids — use search_exercises and pick a returned id`) instead of a generic catalog-miss.
- **Object-form auto-conversion bloat** — Iris expanded all unchanged days from bare-UUID strings to fully-specified prescription objects on echo (~2 KB payload for 6 days). Server-side identical (catalog defaults), purely cosmetic, but token cost adds up. Consider a SKILL hint: *"bare UUIDs OK on echo of unchanged days, saves tokens"*.
- **`search_exercises` FR fuzzy matching** — both Claude and Iris failed to surface `Marche ou jogging sur place` / `Sauter - standard` from FR queries. Tracked in #286.
- **`create_program` description has the same `preview.days[].rendered` mismatch** — symmetric to the fix in `c593095` (Copilot review on this PR). Tiny standalone PR, or batch into Epic D.
- **`set_active_program` MCP tool** — referenced as "(coming soon)" in the SKILL pointer and the `is_active` rejection message; ships in a separate Epic.

Closes #280

Made with [Cursor](https://cursor.com)
