### PR TITLE
fix(workout): persist PR atoms so mid-session refresh keeps badges in bilan

### DIFF
--- a/src/lib/cancelSession.test.ts
+++ b/src/lib/cancelSession.test.ts
@@ -8,6 +8,8 @@ const AUTH_ATOM = Symbol("authAtom")
 const SESSION_ATOM = Symbol("sessionAtom")
 const REST_ATOM = Symbol("restAtom")
 const IS_QUICK_WORKOUT_ATOM = Symbol("isQuickWorkoutAtom")
+const PR_FLAGS_ATOM = Symbol("prFlagsAtom")
+const SESSION_BEST_PERFORMANCE_ATOM = Symbol("sessionBestPerformanceAtom")
 
 const DEFAULT_SESSION_STATE = {
   currentDayId: null,
@@ -83,6 +85,8 @@ vi.mock("@/store/atoms", () => ({
   sessionAtom: SESSION_ATOM,
   restAtom: REST_ATOM,
   isQuickWorkoutAtom: IS_QUICK_WORKOUT_ATOM,
+  prFlagsAtom: PR_FLAGS_ATOM,
+  sessionBestPerformanceAtom: SESSION_BEST_PERFORMANCE_ATOM,
   defaultSessionState: DEFAULT_SESSION_STATE,
 }))
 
@@ -193,6 +197,27 @@ describe("cancelSession", () => {
       resetSessionAtoms()
 
       expect(mockClearPatchStorage).toHaveBeenCalledTimes(1)
+    })
+
+    /**
+     * Regression #291 — `prFlagsAtom` and `sessionBestPerformanceAtom` were
+     * promoted to `atomWithStorage` so PRs survive a mid-session refresh.
+     * That persistence means `resetSessionAtoms` must explicitly wipe them
+     * too, otherwise PR badges from a previous session would leak into the
+     * next bilan after Cancel or "New Session".
+     */
+    it("clears prFlagsAtom and sessionBestPerformanceAtom (regression #291)", () => {
+      resetSessionAtoms()
+
+      const prFlagsSet = mockStore.set.mock.calls.find(
+        ([atom]) => atom === PR_FLAGS_ATOM,
+      )
+      const sessionBestSet = mockStore.set.mock.calls.find(
+        ([atom]) => atom === SESSION_BEST_PERFORMANCE_ATOM,
+      )
+
+      expect(prFlagsSet?.[1]).toEqual({})
+      expect(sessionBestSet?.[1]).toEqual({})
     })
   })
 

--- a/src/lib/cancelSession.ts
+++ b/src/lib/cancelSession.ts
@@ -6,6 +6,8 @@ import {
   sessionAtom,
   restAtom,
   isQuickWorkoutAtom,
+  prFlagsAtom,
+  sessionBestPerformanceAtom,
   defaultSessionState,
 } from "@/store/atoms"
 import {
@@ -43,14 +45,20 @@ function timeoutAfter(ms: number, label: string): Promise<never> {
  * `WorkoutPage.handleNewSession` (post-finish "New Session"). Single source
  * of truth for "no active session" state.
  *
+ * `prFlagsAtom` and `sessionBestPerformanceAtom` are persisted (regression
+ * #291) so they must be cleared here too, otherwise PR badges from the
+ * previous session would leak into the next one's bilan.
+ *
  * Does NOT touch local React state inside `WorkoutPage` (finishedStats,
- * finishedQuickInfo, prFlags, …). Those only matter post-finish; during an
- * active session they are already in their initial state.
+ * finishedQuickInfo, …). Those only matter post-finish; during an active
+ * session they are already in their initial state.
  */
 export function resetSessionAtoms(): void {
   store.set(sessionAtom, defaultSessionState)
   store.set(restAtom, null)
   store.set(isQuickWorkoutAtom, false)
+  store.set(prFlagsAtom, {})
+  store.set(sessionBestPerformanceAtom, {})
   clearSessionExercisePatchStorage()
 }
 

--- a/src/store/atoms.test.ts
+++ b/src/store/atoms.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, beforeEach } from "vitest"
 import { createStore } from "jotai"
-import { sessionAtom, completedExerciseIdsAtom } from "./atoms"
+import {
+  sessionAtom,
+  completedExerciseIdsAtom,
+  prFlagsAtom,
+  sessionBestPerformanceAtom,
+} from "./atoms"
 
 describe("completedExerciseIdsAtom", () => {
   it("returns empty set when no sets data exists", () => {
@@ -112,5 +117,82 @@ describe("completedExerciseIdsAtom", () => {
     expect(completed.has("exercise-1")).toBe(true)
     expect(completed.has("exercise-2")).toBe(true)
     expect(completed.has("exercise-3")).toBe(false)
+  })
+})
+
+/**
+ * Regression #291 — PRs hit during a session must survive a hard reload so
+ * the post-session bilan still shows them. Both atoms back the PR badge
+ * pipeline (prFlagsAtom drives `prExercises`; sessionBestPerformanceAtom
+ * keeps the in-session running best for live PR detection).
+ *
+ * Tests cover the round-trip: writes propagate to localStorage, and a fresh
+ * store mounting the atom (mirroring `useAtom` after a page reload) reads
+ * the value back. If either atom regresses to a plain `atom`, these fail.
+ *
+ * Note on store semantics: `atomWithStorage` reads localStorage at module
+ * load (`getOnInit`) or on atom mount (`onMount`). Calling `store.get()` on
+ * a fresh store without subscribing does NOT re-read storage — it returns
+ * the baseAtom's module-load default. We must `store.sub()` to mount the
+ * atom, which is exactly what `useAtom` does in components.
+ */
+describe("session PR atoms persist across reloads (regression #291)", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("writes prFlagsAtom values to localStorage", () => {
+    const store = createStore()
+    store.set(prFlagsAtom, { "ex-1": true, "ex-2": true })
+
+    expect(localStorage.getItem("prFlags")).toBe(
+      JSON.stringify({ "ex-1": true, "ex-2": true }),
+    )
+  })
+
+  it("hydrates prFlagsAtom from localStorage on mount (simulates page reload)", () => {
+    localStorage.setItem(
+      "prFlags",
+      JSON.stringify({ "ex-1": true, "ex-2": true }),
+    )
+
+    const store = createStore()
+    const unsub = store.sub(prFlagsAtom, () => {})
+
+    expect(store.get(prFlagsAtom)).toEqual({ "ex-1": true, "ex-2": true })
+    unsub()
+  })
+
+  it("writes sessionBestPerformanceAtom values to localStorage", () => {
+    const store = createStore()
+    store.set(sessionBestPerformanceAtom, { "ex-1": 100, "ex-2": 95 })
+
+    expect(localStorage.getItem("sessionBestPerformance")).toBe(
+      JSON.stringify({ "ex-1": 100, "ex-2": 95 }),
+    )
+  })
+
+  it("hydrates sessionBestPerformanceAtom from localStorage on mount", () => {
+    localStorage.setItem(
+      "sessionBestPerformance",
+      JSON.stringify({ "ex-1": 100, "ex-2": 95 }),
+    )
+
+    const store = createStore()
+    const unsub = store.sub(sessionBestPerformanceAtom, () => {})
+
+    expect(store.get(sessionBestPerformanceAtom)).toEqual({
+      "ex-1": 100,
+      "ex-2": 95,
+    })
+    unsub()
+  })
+
+  it("clears the persisted prFlags when the atom is reset to empty", () => {
+    const store = createStore()
+    store.set(prFlagsAtom, { "ex-1": true })
+    store.set(prFlagsAtom, {})
+
+    expect(localStorage.getItem("prFlags")).toBe(JSON.stringify({}))
   })
 })

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -79,10 +79,32 @@ export const queueSyncMetaAtom = atomWithStorage<{
   pendingCount: number
 }>("queueSyncMeta", { pendingCount: 0 })
 
-export const prFlagsAtom = atom<Record<string, boolean>>({})
+/**
+ * Persisted so a mid-session refresh doesn't wipe PR detection state. Without
+ * persistence, `WorkoutPage` would compute `prExercises` from an empty map
+ * after a reload and the bilan would show no PRs even though `set_logs.was_pr`
+ * is correct in the DB (regression #291). `getOnInit` mirrors `sessionAtom` so
+ * the value is correct on first paint of `SessionSummary`.
+ */
+export const prFlagsAtom = atomWithStorage<Record<string, boolean>>(
+  "prFlags",
+  {},
+  undefined,
+  { getOnInit: true },
+)
 
-/** Best PR-relevant score per `exercise_id` this session (1RM, reps, or seconds — matches `PrModality`). */
-export const sessionBestPerformanceAtom = atom<Record<string, number>>({})
+/**
+ * Best PR-relevant score per `exercise_id` this session (1RM, reps, or seconds
+ * — matches `PrModality`). Persisted alongside `prFlagsAtom` so post-refresh
+ * sets are still compared against the in-session running best, not just the
+ * historical best from the DB.
+ */
+export const sessionBestPerformanceAtom = atomWithStorage<Record<string, number>>(
+  "sessionBestPerformance",
+  {},
+  undefined,
+  { getOnInit: true },
+)
 
 export const installPromptStateAtom = atomWithStorage<{ dismissed: boolean }>(
   "installPrompt",


### PR DESCRIPTION
## What

- Promote `prFlagsAtom` and `sessionBestPerformanceAtom` to `atomWithStorage` (with `getOnInit: true`, mirroring `sessionAtom`) so PR detection state survives a hard reload.
- Wipe both persisted atoms in `resetSessionAtoms` so a cancelled or finished session can't leak PR badges into the next bilan. (`clearUserState` already cleared them on sign-out — verified by existing test.)
- Add regression tests at the atom level (write → localStorage, mount → hydrate, reset → wipe) and at the cancel/reset path.

## Why

Reproducible bug from the field (issue #291): user hits a PR mid-session, refreshes the app, finishes the session — `SessionSummary` renders with **zero PR badges** even though `set_logs.was_pr` is correct in the DB.

Root cause: `prFlagsAtom` was a plain in-memory `atom()`. A reload wiped it. `WorkoutPage.handleFinish` then computed `prExercises = exercises.filter(ex => prFlags[ex.exercise_id])` against an empty map, and the bilan inherited that emptiness via `finishedStats.prExercises`.

## How

The fix itself is small (one persistence flag flip × 2 atoms + one reset call). The interesting work was making the regression test actually catch the regression.

The original draft test used `createStore() → set → createStore() → get` and claimed "fresh store mirrors a hard reload." That's not how `atomWithStorage` works: storage is read at **module load** (via `getOnInit`) or on **atom mount** (via `onMount`). A naked `store.get()` on a fresh store returns the baseAtom's module-load default — never re-reading localStorage — so the test was green-by-accident even with the persistence in place, and would have stayed green if someone reverted the fix.

Rewrote the regression suite to test the round-trip directly:
- **Write side**: `store.set(atom, X)` → `localStorage.getItem(key) === JSON.stringify(X)`
- **Read side**: pre-seed localStorage → `store.sub(atom, ...)` to mount (same path `useAtom` takes in components) → `store.get(atom)` returns the seeded value
- **Clear side**: setting back to `{}` propagates to localStorage so the next session starts clean

Added a parallel test in `cancelSession.test.ts` locking in that `resetSessionAtoms` clears both atoms — without it, the new persistence would silently leak PR badges across sessions.

Closes #291

Made with [Cursor](https://cursor.com)