### PR TITLE
fix(oauth): stop flashing "authorization not found" after consent approve

### DIFF
--- a/src/lib/supabase-oauth.ts
+++ b/src/lib/supabase-oauth.ts
@@ -1,7 +1,16 @@
 /**
- * @supabase/auth-js does not type the OAuth 2.1 server methods yet.
- * This wrapper isolates the single unsafe cast — remove when the
- * package ships official types.
+ * @supabase/auth-js v2.103.3 ships the OAuth 2.1 server methods at runtime
+ * (`supabase.auth.oauth.*` — see GoTrueClient.js line 155) but does not yet
+ * declare them in its `.d.ts`. This wrapper isolates the unsafe cast and
+ * also pins down two non-obvious bits of SDK behavior:
+ *
+ *  - The server returns `redirect_url` (NOT `redirect_to` — the Supabase docs
+ *    page at /auth/oauth-server/oauth-flows is wrong; the Go source uses
+ *    `RedirectURL string \`json:"redirect_url"\``).
+ *  - `approveAuthorization` / `denyAuthorization` will silently call
+ *    `window.location.assign(response.data.redirect_url)` themselves unless
+ *    `skipBrowserRedirect: true` is passed. We always opt out so the consent
+ *    page owns navigation + post-redirect UX (issue #292).
  */
 import { supabase } from "./supabase"
 
@@ -11,21 +20,35 @@ interface OAuthResult<T> {
 }
 
 export interface OAuthRedirect {
-  redirect_to: string
+  redirect_url: string
 }
 
 export interface AuthorizationDetails {
   authorization_id: string
+  // The server occasionally exposes the OAuth client metadata under either
+  // `client` or `application`; accept both rather than crash if either name
+  // changes upstream.
+  client?: { name?: string; icon_uri?: string }
   application?: { name?: string; icon_uri?: string }
   scope?: string
+}
+
+export interface OAuthConsentOptions {
+  skipBrowserRedirect?: boolean
 }
 
 interface OAuthApi {
   getAuthorizationDetails: (
     id: string,
   ) => Promise<OAuthResult<AuthorizationDetails | OAuthRedirect>>
-  approveAuthorization: (id: string) => Promise<OAuthResult<OAuthRedirect>>
-  denyAuthorization: (id: string) => Promise<OAuthResult<OAuthRedirect>>
+  approveAuthorization: (
+    id: string,
+    options?: OAuthConsentOptions,
+  ) => Promise<OAuthResult<OAuthRedirect>>
+  denyAuthorization: (
+    id: string,
+    options?: OAuthConsentOptions,
+  ) => Promise<OAuthResult<OAuthRedirect>>
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -47,5 +47,8 @@
   "oauthConsentDeny": "Deny",
   "oauthConsentError": "Authorization request not found or expired",
   "oauthConsentMissingId": "Missing authorization request",
-  "oauthConsentLoading": "Loading authorization details…"
+  "oauthConsentLoading": "Loading authorization details…",
+  "oauthConsentSuccessTitle": "Authorization granted",
+  "oauthConsentDeniedTitle": "Authorization denied",
+  "oauthConsentSuccessHint": "Return to the app to continue. You can close this tab."
 }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -47,5 +47,8 @@
   "oauthConsentDeny": "Refuser",
   "oauthConsentError": "Demande d'autorisation introuvable ou expirée",
   "oauthConsentMissingId": "Demande d'autorisation manquante",
-  "oauthConsentLoading": "Chargement des détails d'autorisation…"
+  "oauthConsentLoading": "Chargement des détails d'autorisation…",
+  "oauthConsentSuccessTitle": "Autorisation accordée",
+  "oauthConsentDeniedTitle": "Autorisation refusée",
+  "oauthConsentSuccessHint": "Retournez à l'application pour continuer. Vous pouvez fermer cet onglet."
 }

--- a/src/pages/OAuthConsentPage.test.tsx
+++ b/src/pages/OAuthConsentPage.test.tsx
@@ -1,0 +1,162 @@
+import { vi, describe, it, expect, beforeEach } from "vitest"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { renderWithProviders } from "@/test/utils"
+import { OAuthConsentPage } from "./OAuthConsentPage"
+
+const TEST_AUTH_ID = "auth-xyz-123"
+const TEST_REDIRECT = "https://claude.ai/api/mcp/auth_callback?code=abc"
+const TEST_USER = { id: "uid-1", email: "test@example.com" }
+
+const mockGetUser = vi.fn()
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: () => mockGetUser(),
+      getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+    },
+  },
+  clearUserState: vi.fn(),
+}))
+
+const mockGetAuthorizationDetails = vi.fn()
+const mockApproveAuthorization = vi.fn()
+const mockDenyAuthorization = vi.fn()
+vi.mock("@/lib/supabase-oauth", () => ({
+  supabaseOAuth: {
+    getAuthorizationDetails: (...args: unknown[]) =>
+      mockGetAuthorizationDetails(...args),
+    approveAuthorization: (...args: unknown[]) =>
+      mockApproveAuthorization(...args),
+    denyAuthorization: (...args: unknown[]) => mockDenyAuthorization(...args),
+  },
+}))
+
+const assignSpy = vi.fn()
+
+function renderPage() {
+  return renderWithProviders(<OAuthConsentPage />, {
+    initialEntries: [`/oauth/consent?authorization_id=${TEST_AUTH_ID}`],
+  })
+}
+
+describe("OAuthConsentPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    assignSpy.mockClear()
+    // jsdom's `window.location` is read-only; replace `assign` via defineProperty.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, assign: assignSpy },
+    })
+    mockGetUser.mockResolvedValue({ data: { user: TEST_USER } })
+    mockGetAuthorizationDetails.mockResolvedValue({
+      data: {
+        authorization_id: TEST_AUTH_ID,
+        client: { name: "Claude" },
+        scope: "openid email profile",
+      },
+      error: null,
+    })
+  })
+
+  it("renders the consent UI with the client name once details load", async () => {
+    renderPage()
+    expect(
+      await screen.findByText(/wants to access your training data/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Claude/)).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /authorize/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("calls approveAuthorization with skipBrowserRedirect, navigates via location.assign, and shows the success state (regression for #292)", async () => {
+    mockApproveAuthorization.mockResolvedValueOnce({
+      data: { redirect_url: TEST_REDIRECT },
+      error: null,
+    })
+    const user = userEvent.setup()
+    renderPage()
+
+    const approveBtn = await screen.findByRole("button", { name: /authorize/i })
+    await user.click(approveBtn)
+
+    await waitFor(() => {
+      expect(mockApproveAuthorization).toHaveBeenCalledWith(TEST_AUTH_ID, {
+        skipBrowserRedirect: true,
+      })
+    })
+    expect(assignSpy).toHaveBeenCalledWith(TEST_REDIRECT)
+
+    expect(
+      await screen.findByText(/authorization granted/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/you can close this tab/i),
+    ).toBeInTheDocument()
+    // Critically, the misleading error must NOT be visible.
+    expect(
+      screen.queryByText(/not found or expired/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it("surfaces the raw SDK error message when approveAuthorization fails", async () => {
+    mockApproveAuthorization.mockResolvedValueOnce({
+      data: null,
+      error: { message: "authorization not found" },
+    })
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.click(
+      await screen.findByRole("button", { name: /authorize/i }),
+    )
+
+    expect(
+      await screen.findByText("authorization not found"),
+    ).toBeInTheDocument()
+    expect(assignSpy).not.toHaveBeenCalled()
+  })
+
+  it("calls denyAuthorization with skipBrowserRedirect and shows the denied state", async () => {
+    mockDenyAuthorization.mockResolvedValueOnce({
+      data: { redirect_url: `${TEST_REDIRECT}&error=access_denied` },
+      error: null,
+    })
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.click(await screen.findByRole("button", { name: /deny/i }))
+
+    await waitFor(() => {
+      expect(mockDenyAuthorization).toHaveBeenCalledWith(TEST_AUTH_ID, {
+        skipBrowserRedirect: true,
+      })
+    })
+    expect(assignSpy).toHaveBeenCalledWith(
+      `${TEST_REDIRECT}&error=access_denied`,
+    )
+    expect(
+      await screen.findByText(/authorization denied/i),
+    ).toBeInTheDocument()
+  })
+
+  it("auto-navigates when getAuthorizationDetails returns redirect_url (already-consented flow)", async () => {
+    mockGetAuthorizationDetails.mockResolvedValueOnce({
+      data: { redirect_url: TEST_REDIRECT },
+      error: null,
+    })
+    renderPage()
+
+    await waitFor(() => {
+      expect(assignSpy).toHaveBeenCalledWith(TEST_REDIRECT)
+    })
+    expect(
+      await screen.findByText(/authorization granted/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/pages/OAuthConsentPage.test.tsx
+++ b/src/pages/OAuthConsentPage.test.tsx
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from "vitest"
+import { vi, describe, it, expect, beforeEach, afterAll } from "vitest"
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { renderWithProviders } from "@/test/utils"
@@ -7,6 +7,13 @@ import { OAuthConsentPage } from "./OAuthConsentPage"
 const TEST_AUTH_ID = "auth-xyz-123"
 const TEST_REDIRECT = "https://claude.ai/api/mcp/auth_callback?code=abc"
 const TEST_USER = { id: "uid-1", email: "test@example.com" }
+
+// Capture the real `window.location` ONCE, before any test mutates it, so
+// `afterAll` can put the original `Location` instance back. Otherwise the
+// re-defined plain-object `value` would leak into other suites running in
+// the same worker (and `beforeEach`'s spread would re-capture the already-
+// mutated copy on subsequent runs).
+const ORIGINAL_LOCATION = window.location
 
 const mockGetUser = vi.fn()
 vi.mock("@/lib/supabase", () => ({
@@ -48,9 +55,12 @@ describe("OAuthConsentPage", () => {
     vi.clearAllMocks()
     assignSpy.mockClear()
     // jsdom's `window.location` is read-only; replace `assign` via defineProperty.
+    // Spread the *original* location (not the current one — which may have
+    // already been mutated by the previous test) so `href`, `origin`, etc.
+    // stay consistent across the whole suite.
     Object.defineProperty(window, "location", {
       configurable: true,
-      value: { ...window.location, assign: assignSpy },
+      value: { ...ORIGINAL_LOCATION, assign: assignSpy },
     })
     mockGetUser.mockResolvedValue({ data: { user: TEST_USER } })
     mockGetAuthorizationDetails.mockResolvedValue({
@@ -60,6 +70,13 @@ describe("OAuthConsentPage", () => {
         scope: "openid email profile",
       },
       error: null,
+    })
+  })
+
+  afterAll(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: ORIGINAL_LOCATION,
     })
   })
 

--- a/src/pages/OAuthConsentPage.tsx
+++ b/src/pages/OAuthConsentPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import { Dumbbell, Loader2, ShieldCheck, XCircle } from "lucide-react"
+import { CheckCircle2, Dumbbell, Loader2, ShieldCheck, XCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -22,6 +22,15 @@ const SCOPE_LABELS: Record<string, { en: string; fr: string }> = {
   profile: { en: "View your profile info", fr: "Voir vos informations de profil" },
 }
 
+// Some MCP clients (notably Claude Desktop via claude.ai) finish the OAuth
+// dance with a `claude://` deep-link instead of an HTTPS callback. In that
+// case `window.location.assign` triggers the OS protocol handler but does NOT
+// navigate the tab — so we must render a terminal "you can close this tab"
+// state instead of leaving the consent UI mounted with a stale spinner.
+function assignAndStay(url: string) {
+  window.location.assign(url)
+}
+
 export function OAuthConsentPage() {
   const { t, i18n } = useTranslation("common")
   const navigate = useNavigate()
@@ -32,6 +41,7 @@ export function OAuthConsentPage() {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [submitting, setSubmitting] = useState(false)
+  const [done, setDone] = useState<"approved" | "denied" | null>(null)
 
   useEffect(() => {
     async function load() {
@@ -57,8 +67,10 @@ export function OAuthConsentPage() {
         return
       }
 
-      if ("redirect_to" in data) {
-        window.location.href = data.redirect_to
+      if ("redirect_url" in data) {
+        assignAndStay(data.redirect_url)
+        setDone("approved")
+        setLoading(false)
         return
       }
 
@@ -73,7 +85,13 @@ export function OAuthConsentPage() {
     if (!authorizationId) return
     setSubmitting(true)
 
-    const { data, error: err } = await supabaseOAuth.approveAuthorization(authorizationId)
+    // `skipBrowserRedirect: true` prevents the SDK from silently calling
+    // `window.location.assign` itself; we own the navigation so we can also
+    // render the success terminal state for deep-link callbacks (issue #292).
+    const { data, error: err } = await supabaseOAuth.approveAuthorization(
+      authorizationId,
+      { skipBrowserRedirect: true },
+    )
 
     if (err) {
       setError(err.message)
@@ -81,19 +99,23 @@ export function OAuthConsentPage() {
       return
     }
 
-    if (data?.redirect_to) {
-      window.location.href = data.redirect_to
+    if (data?.redirect_url) {
+      assignAndStay(data.redirect_url)
+      setDone("approved")
     } else {
       setError(t("oauthConsentError"))
-      setSubmitting(false)
     }
+    setSubmitting(false)
   }, [authorizationId, t])
 
   const handleDeny = useCallback(async () => {
     if (!authorizationId) return
     setSubmitting(true)
 
-    const { data, error: err } = await supabaseOAuth.denyAuthorization(authorizationId)
+    const { data, error: err } = await supabaseOAuth.denyAuthorization(
+      authorizationId,
+      { skipBrowserRedirect: true },
+    )
 
     if (err) {
       setError(err.message)
@@ -101,16 +123,18 @@ export function OAuthConsentPage() {
       return
     }
 
-    if (data?.redirect_to) {
-      window.location.href = data.redirect_to
+    if (data?.redirect_url) {
+      assignAndStay(data.redirect_url)
+      setDone("denied")
     } else {
       setError(t("oauthConsentError"))
-      setSubmitting(false)
     }
+    setSubmitting(false)
   }, [authorizationId, t])
 
   const lang = i18n.language.startsWith("fr") ? "fr" : "en"
-  const clientName = details?.application?.name ?? "Unknown app"
+  const clientName =
+    details?.client?.name ?? details?.application?.name ?? "Unknown app"
   const scopes = details?.scope?.split(" ").filter(Boolean) ?? []
 
   return (
@@ -138,6 +162,18 @@ export function OAuthConsentPage() {
             <CardContent className="flex flex-col items-center gap-4 py-12">
               <XCircle className="h-10 w-10 text-red-400" />
               <p className="text-center text-sm text-zinc-400">{error}</p>
+            </CardContent>
+          ) : done ? (
+            <CardContent className="flex flex-col items-center gap-4 py-12">
+              <CheckCircle2 className="h-10 w-10 text-[#00c9a7]" />
+              <p className="text-center text-base font-medium text-white">
+                {done === "approved"
+                  ? t("oauthConsentSuccessTitle")
+                  : t("oauthConsentDeniedTitle")}
+              </p>
+              <p className="text-center text-sm text-zinc-400">
+                {t("oauthConsentSuccessHint")}
+              </p>
             </CardContent>
           ) : (
             <>

--- a/src/pages/OAuthConsentPage.tsx
+++ b/src/pages/OAuthConsentPage.tsx
@@ -83,6 +83,10 @@ export function OAuthConsentPage() {
 
   const handleApprove = useCallback(async () => {
     if (!authorizationId) return
+    // Clear any error from a previous attempt — the render branch is
+    // `loading → error → done → consent`, so a stale `error` would mask
+    // the success state when a retry succeeds.
+    setError(null)
     setSubmitting(true)
 
     // `skipBrowserRedirect: true` prevents the SDK from silently calling
@@ -110,6 +114,7 @@ export function OAuthConsentPage() {
 
   const handleDeny = useCallback(async () => {
     if (!authorizationId) return
+    setError(null)
     setSubmitting(true)
 
     const { data, error: err } = await supabaseOAuth.denyAuthorization(


### PR DESCRIPTION
## What

- `OAuthConsentPage` now reads `data.redirect_url` (the real field name returned by `@supabase/auth-js@2.103.3` and the underlying Go server) instead of the non-existent `data.redirect_to`.
- Pass `{ skipBrowserRedirect: true }` to `approveAuthorization` / `denyAuthorization` so the page owns the navigation rather than racing the SDK's hidden `window.location.assign` side-effect.
- Add a neutral terminal state — *"Authorization granted — return to the app, you can close this tab"* — that covers both HTTPS-callback and `claude://` deep-link redirect URIs.
- Accept `client.name` AND `application.name` for the displayed client name (Supabase's docs are inconsistent between the two).
- New Vitest suite (`OAuthConsentPage.test.tsx`, 5 cases) covering the regression: `skipBrowserRedirect: true` is forwarded, `location.assign` is called with `redirect_url`, success state renders, the misleading error stays absent on success, and SDK error messages still surface verbatim on real failures.

## Why

Connecting the GymLogic MCP server from Claude Desktop / claude.ai showed a brief but jarring *"authorization not found"* error on `gymlogic.me/oauth/consent` right after clicking Approve, even though the OAuth handshake itself succeeded (Claude eventually opened its success page in a new tab via the `claude://` protocol handler).

Two compounding bugs caused this:

1. **Wrong field name (deterministic).** The wrapper at `src/lib/supabase-oauth.ts` declared `redirect_to`, but `@supabase/auth-js@2.103.3` returns `redirect_url`. Verified in `node_modules/@supabase/auth-js/dist/module/GoTrueClient.js:4576-4583` and the upstream `supabase/auth` Go source (`ConsentResponse{ RedirectURL string \`json:\"redirect_url\"\` }`). Our `else` branch therefore *always* fired `setError(...)` after a successful approve. Worth flagging upstream: [Supabase's own OAuth docs](https://supabase.com/docs/guides/auth/oauth-server/oauth-flows) document `redirect_to` — they're wrong, which is how the bug got introduced in the first place.
2. **Hidden SDK side-effect.** `approveAuthorization` silently calls `window.location.assign(response.data.redirect_url)` itself unless `skipBrowserRedirect: true` is passed. For Claude Desktop the `redirect_url` is a `claude://` deep-link, so the OS handler fires (Chrome's *"Open Claude?"* prompt) but the tab does **not** navigate — leaving our consent page mounted with the bogus error visible.

PAT-based connectors (Le Chat etc.) bypass this page entirely and are unaffected. Other OAuth-based MCP clients (Cursor, Le Chat OAuth path) benefit from the fix mechanically since they hit the same page.

## How

- **`src/lib/supabase-oauth.ts`** — kept the wrapper (auth-js v2.103.3 ships the runtime `oauth.*` methods but still no `.d.ts` types), renamed the typed field to `redirect_url`, added `OAuthConsentOptions { skipBrowserRedirect }`, extended `AuthorizationDetails` to accept both `client` and `application`. Updated the comment to document the two non-obvious SDK behaviors the wrapper now neutralizes.
- **`src/pages/OAuthConsentPage.tsx`** — both handlers now pass `{ skipBrowserRedirect: true }`, read `redirect_url`, and explicitly call `window.location.assign(...)` themselves. Added a `done: \"approved\" | \"denied\" | null` terminal state with a `CheckCircle2` success card so the user has a positive signal whether or not the redirect URL navigates the tab.
- **`src/locales/{en,fr}/common.json`** — three new keys for the success/denied/hint copy.
- **`src/pages/OAuthConsentPage.test.tsx` *(new)*** — 5 tests, including an explicit regression test for #292 that asserts the `\"not found or expired\"` message is NOT visible after a successful approve.

Closes #292


Made with [Cursor](https://cursor.com)