### PR TITLE
perf(mcp): batch exercise resolution via resolve_exercises tool (#310)

### DIFF
--- a/docs/Epic_Brief_—_MCP_—_Batch_Exercise_Resolution_#310.md
+++ b/docs/Epic_Brief_—_MCP_—_Batch_Exercise_Resolution_#310.md
@@ -48,7 +48,7 @@ Replace the multi-call `search_exercises` + `get_exercise_details` dance with a 
 
 | Story # | Measure |
 |---|---|
-| 1, 7 | Median tool calls per autonomous `create_program` flow ≤ **3** (was ~20-40); ceiling = `1 resolve_exercises + 2 create_program calls (dry_run + apply)` |
+| 1, 7 | Median tool calls within the **resolve → create_program (dry_run) → create_program (apply)** sub-flow ≤ **3** (was ~20-40); ceiling = `1 resolve_exercises + 2 create_program calls`. *Excludes pre-flight context-gathering reads* (`list_programs`, `get_upcoming_workouts`, `get_training_stats`) the agent may run before deciding to build a program. |
 | 2 | Zero `get_exercise_details` calls during a `create_program` flow when the agent uses the new tool |
 | 7 | Wall-clock time from "build me a program" to dry-run preview echoed to user ≤ **10s** P50, ≤ **20s** P95 |
 | 8 | Token consumption per autonomous program creation reduced by ≥ **70%** vs. baseline (issue #310 screenshot, measured on Claude Sonnet free tier) |
@@ -67,7 +67,7 @@ Replace the multi-call `search_exercises` + `get_exercise_details` dance with a 
 7. MCP protocol version bump (`v0.5.0` — additive, non-breaking) and `CHANGELOG.md` entry.
 
 **Out of scope:**
-- Removing or replacing `search_exercises` (deferred — measure agent adoption first; revisit if `search_exercises` calls drop near zero or stay stubbornly high).
+- Removing or replacing `search_exercises` (deferred — measure agent adoption first over a **≥ 2-week observation window** of post-launch agent traffic; revisit then with concrete data: kill if `search_exercises` calls drop to near-zero in autonomous flows, or escalate the steering mechanism — deprecation warning in tool description, `tools/list` exclusion behind a feature flag — if usage stays stubbornly high).
 - Per-query filters in `resolve_exercises` input (`{ name, muscle_group?, equipment? }`). Defer until name-only proves insufficient in real agent traces. Adding optional fields later is non-breaking.
 - Optional `include_details: true` flag to bundle the full instructions blob in `resolve_exercises` response. Pattern 3 (single-exercise lookup) stays at 2 calls (`resolve_exercises` + `get_exercise_details`), which is acceptable.
 - Allowing `create_program` to accept exercise names directly (Option 2 in issue #310 comments — rejected as brittle with similar names).

--- a/docs/Epic_Brief_—_MCP_—_Batch_Exercise_Resolution_#310.md
+++ b/docs/Epic_Brief_—_MCP_—_Batch_Exercise_Resolution_#310.md
@@ -1,0 +1,86 @@
+# Epic Brief — MCP — Batch Exercise Resolution #310
+
+## Summary
+
+Replace the multi-call `search_exercises` + `get_exercise_details` dance with a single batch tool, `resolve_exercises`, that takes a list of exercise names and returns UUIDs plus the catalog metadata needed to build or edit a program. Cuts ~10x the MCP round-trips for "build me a program" and "update my program" autonomous flows, slashes user token quota burn, and brings the propose-confirm-act handshake within reach of free-tier conversations.
+
+---
+
+## Context & Problem
+
+**Who is affected:**
+- End users asking AI agents (Claude Desktop, Cursor, Le Chat, generic MCP clients) to build or edit multi-day training programs.
+- AI agents themselves, whose autonomous flow currently fires 20-40 MCP calls before a single program lands.
+
+**Current state:**
+- `file:supabase/functions/mcp/tools/searchExercises.ts` only emits the exercise UUID **on a single match** — multi-match results require the agent to narrow down with a second (or third) call. Footer text literally instructs the agent to "search again with the user's choice."
+- `file:supabase/functions/mcp/tools/createProgram.ts`'s tool description tells the agent to call `get_exercise_details` first to confirm `weight_convention`, adding N more calls (one per weighted exercise).
+- Verified against a real conversation screenshot from issue #310: ~38 search calls + ~12 details calls for a 12-exercise, 3-day beginner full-body program. Roughly 50 round-trips for one program creation.
+- `weight_convention` is fully derived from `equipment` via `file:supabase/functions/mcp/lib/format.ts` (`formatWeightConvention`) — no DB schema work needed to surface it elsewhere.
+- Edge Functions are stateless — no persistent cache between calls.
+
+**Pain points:**
+| Pain | Impact |
+|---|---|
+| User waits 30s+ between "build me a program" and the dry-run preview | Drop-off, poor first impression vs the in-app AI generator |
+| Free-tier token quota exhausted before program is created | User cannot iterate on the program in the same session |
+| Agent narrowing loop (e.g. "Now let me search for specific exercises..." → 26 steps in one block) | Conversation feels broken; users lose trust in the AI workflow |
+| Existing tool descriptions push the agent toward inefficient paths | Even after shipping a faster tool, habit-bias may keep the old flow |
+
+---
+
+## User Stories
+
+1. As an **AI agent**, I want to resolve a list of exercise names to UUIDs in a single call, so that I can build a multi-day program without 30+ tool round-trips.
+2. As an **AI agent**, I want each resolved exercise to include `weight_convention`, `measurement_type`, and `default_duration_seconds`, so that I can call `create_program` immediately without an extra `get_exercise_details` per exercise.
+3. As an **AI agent**, I want ambiguous matches (close-scoring candidates) flagged with up to 2 alternates, so that I can surface them to the user instead of silently picking the wrong variant.
+4. As an **AI agent**, I want unresolved queries (zero matches) returned as `{ matches: [], reason: "no_match" }` within the same response, so that one missing exercise does not fail the whole batch.
+5. As an **AI agent**, I want clear, opinionated tool descriptions distinguishing `resolve_exercises` (name → ID) from `search_exercises` (browse by filters), so that I pick the right tool without second-guessing.
+6. As an **AI agent updating a program** (`update_program` swap flow), I want the same batch resolution available, so that swapping multiple exercises does not regress to per-exercise searches.
+7. As an **end user**, I want "build me a program" to complete in under 10 seconds instead of 30-60s, so that I'm not staring at a thinking spinner.
+8. As an **end user**, I want fewer of my free-tier tokens consumed per program request, so that I can iterate (refine, swap, regenerate) within the same conversation.
+9. As an **end user**, when an exercise name is genuinely ambiguous (e.g. "leg press" → multiple variants), I want my AI agent to surface the options and let me pick, so that I get the program I actually wanted.
+10. As an **end user**, when a name does not exist in the catalog (e.g. "trap bar deadlift"), I want my AI agent to either retry with a broader term or flag it explicitly, so that I'm not blindsided post-creation by a missing exercise.
+11. As an **MCP server maintainer**, I want the new tool to coexist with `search_exercises` rather than replace it, so that browse-by-filter intent ("show me chest exercises with dumbbells", "what's a good biceps exercise") continues to work for the agent.
+12. As an **MCP server maintainer**, I want `skills/gymlogic-mcp/SKILL.md` and the tool descriptions updated together, so that all agent entry points (description-only clients and skill-aware clients alike) consistently steer toward the right catalog tool.
+
+### Success measures
+
+| Story # | Measure |
+|---|---|
+| 1, 7 | Median tool calls per autonomous `create_program` flow ≤ **3** (was ~20-40); ceiling = `1 resolve_exercises + 2 create_program calls (dry_run + apply)` |
+| 2 | Zero `get_exercise_details` calls during a `create_program` flow when the agent uses the new tool |
+| 7 | Wall-clock time from "build me a program" to dry-run preview echoed to user ≤ **10s** P50, ≤ **20s** P95 |
+| 8 | Token consumption per autonomous program creation reduced by ≥ **70%** vs. baseline (issue #310 screenshot, measured on Claude Sonnet free tier) |
+
+---
+
+## Scope
+
+**In scope:**
+1. New MCP tool `resolve_exercises` with input `{ queries: string[] }`. Per-query response carries top-1 match, optional alternates on ambiguity, and bundled catalog metadata (`weight_convention`, `measurement_type`, `default_duration_seconds`).
+2. Score-gap ambiguity detection (top-1 vs top-2 similarity delta, threshold ~0.1) at the Postgres / Edge Function layer. Substring-rank-0 ties are treated as ambiguous.
+3. Per-query null on no-match (uniform response shape regardless of outcome — every input query gets a result row).
+4. Updated tool descriptions for **both** `resolve_exercises` AND `search_exercises` to disambiguate intent (name-resolve vs filter-browse).
+5. Updated `skills/gymlogic-mcp/SKILL.md`: new tool reference, "Catalog tools — which one when" decision table near the top, revised worked examples for Pattern 3 (lookup), Pattern 4 (program design), and the `update_program` swap example.
+6. Updated `create_program` tool description to drop the "call `get_exercise_details` first" guidance (now redundant — `resolve_exercises` returns the convention).
+7. MCP protocol version bump (`v0.5.0` — additive, non-breaking) and `CHANGELOG.md` entry.
+
+**Out of scope:**
+- Removing or replacing `search_exercises` (deferred — measure agent adoption first; revisit if `search_exercises` calls drop near zero or stay stubbornly high).
+- Per-query filters in `resolve_exercises` input (`{ name, muscle_group?, equipment? }`). Defer until name-only proves insufficient in real agent traces. Adding optional fields later is non-breaking.
+- Optional `include_details: true` flag to bundle the full instructions blob in `resolve_exercises` response. Pattern 3 (single-exercise lookup) stays at 2 calls (`resolve_exercises` + `get_exercise_details`), which is acceptable.
+- Allowing `create_program` to accept exercise names directly (Option 2 in issue #310 comments — rejected as brittle with similar names).
+- Cross-call cache layer in the MCP server (Option 3 — rejected, Edge Functions are stateless).
+- Backward-compat alias for `search_exercises_batch` (the name floated in the issue comments) — we commit to `resolve_exercises` as the canonical name.
+- Production instrumentation / dashboard for `tool_calls_per_create_program` metric. Tracked separately as a follow-up; useful for proving the win in production but not blocking shipping.
+
+---
+
+## Success Criteria
+
+- **Numeric**: median tool calls per autonomous `create_program` flow ≤ 3, with ceiling of `1 resolve_exercises + 2 create_program calls (dry_run + apply)`.
+- **Numeric**: token consumption per autonomous program creation reduced by ≥ 70% on Claude Sonnet free tier vs. the baseline screenshot in issue #310.
+- **Numeric**: wall-clock time from prompt to dry-run preview ≤ 10s P50.
+- **Qualitative**: a real autonomous prompt ("build me a complete beginner weekly workout with 3 sessions") reproduces the issue scenario in ≤ 3 tool calls, without the agent narrating "Let me search for specific exercises..." multiple times.
+- **Qualitative**: agents (Claude, Cursor, generic MCP clients) reach for `resolve_exercises` over `search_exercises` when the user's prompt names specific exercises — verified via at least 5 representative manual end-to-end prompts post-launch covering: build program, update-swap exercise, browse-by-muscle, single exercise lookup, ambiguous-name handling.

--- a/docs/T98_—_resolve_exercises_Tool_End-to-End.md
+++ b/docs/T98_—_resolve_exercises_Tool_End-to-End.md
@@ -1,0 +1,131 @@
+# T98 — `resolve_exercises` Tool End-to-End
+
+## Goal
+
+Ship the new MCP tool `resolve_exercises` that batch-resolves a list of exercise names to UUIDs in a single call, with bundled catalog metadata (`weight_convention`, `measurement_type`, `default_duration_seconds`) so downstream `create_program` / `update_program` flows don't need follow-up `get_exercise_details` calls.
+
+Addresses Epic Brief stories **1, 2, 3, 4, 7, 8, 9, 10, 11**: the core capability + ambiguity surfacing + no-match handling + perf win + token reduction + catalog-tool coexistence.
+
+## Mode
+
+**AFK** — every decision is locked in the Tech Plan (RPC signature, score-gap value, status field shape, env-var fallback, test coverage scope, version bump). No mid-flight design choices.
+
+## Slice
+
+`migration (RPC + GRANT)` → `lib/scoreGap.ts (pure helper)` → `tools/resolveExercises.ts (handler)` → `tools/registry.ts (registration)` → `index.ts (server version bump)` → `vitest unit tests (handler + helper)` → `SKILL.md tool-reference row (one-line additive edit)`.
+
+End-to-end demoable: after merge, an MCP client calling `tools/list` sees the new tool; `tools/call` returns properly-shaped batch results.
+
+## Dependencies
+
+None. Self-contained capability slice. Existing `search_exercises` keeps working unchanged.
+
+## Scope
+
+### 1. Postgres migration
+
+Create `supabase/migrations/YYYYMMDDhhmmss_resolve_exercises_batch.sql` with:
+
+- `CREATE OR REPLACE FUNCTION resolve_exercises_batch(queries text[])` per the Tech Plan SQL snippet
+- Returns `TABLE (query_idx int, query_text text, exercise_id uuid, name text, name_en text, muscle_group text, equipment text, measurement_type text, default_duration_seconds int, score real)`
+- `LANGUAGE plpgsql STABLE SECURITY INVOKER`
+- Per-query PL/pgSQL FOR loop: normalize via `extensions.unaccent(lower(...))`, `CONTINUE` on empty, `RETURN QUERY` ranked top-3 reusing the existing search ranking expression
+- `GRANT EXECUTE ON FUNCTION public.resolve_exercises_batch(text[]) TO authenticated`
+- Inline `-- See also: 20260326120000_search_exercises.sql (keep ranking clauses aligned or consciously diverge)` comment near the WHERE/ORDER BY block
+
+**Also add a matching `-- See also:` comment to** `file:supabase/migrations/20260326120000_search_exercises.sql` pointing back to this new migration. (Cross-reference enforcement, per Tech Plan Critical Constraint #7.)
+
+### 2. New file — `supabase/functions/mcp/lib/scoreGap.ts`
+
+| Item | Detail |
+|---|---|
+| Exports | `isAmbiguous(matches: ScoredMatch[]): boolean`, `getAmbiguityGap(): number`, `DEFAULT_AMBIGUITY_GAP = 0.10` |
+| `isAmbiguous` | Returns `true` when `matches.length >= 2 && matches[0].score - matches[1].score < getAmbiguityGap()`. NaN-safe. |
+| `getAmbiguityGap` | Reads `Deno.env.get("MCP_AMBIGUITY_GAP")`, parses with `parseFloat`, validates as finite `(0, 1]`, falls back to `DEFAULT_AMBIGUITY_GAP` on (unset, NaN, out-of-range). Cached after first read. |
+| Comment block | Include a `// TUNING:` comment near `DEFAULT_AMBIGUITY_GAP` describing what to look for in production traces (false-ambiguous rate, false-confident pick rate) and how to adjust the env var. |
+
+### 3. New file — `supabase/functions/mcp/lib/scoreGap.test.ts`
+
+Vitest unit coverage:
+
+- Default threshold: gap=0.10 boundary cases (0.099, 0.10, 0.101)
+- Edge cases: single match, zero matches, three-way tie, NaN scores
+- Env-var override path: valid value, invalid string, out-of-range (0 / negative / >1), missing env var
+- Caching behaviour (subsequent reads after env mutation return the cached value, per the documented contract)
+
+### 4. New file — `supabase/functions/mcp/tools/resolveExercises.ts`
+
+Implements `ToolDefinition` per `file:supabase/functions/mcp/tools/registry.ts`:
+
+| Item | Detail |
+|---|---|
+| `name` | `"resolve_exercises"` |
+| `description` | Self-contained, factual: what it does, input shape, response shape with `status` field semantics, max 50 queries. Do **NOT** include "use this instead of search_exercises" steering — that lands in T99. |
+| `inputSchema` | `{ type: "object", properties: { queries: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 50 } }, required: ["queries"] }` |
+| Validation | Non-empty array, length ≤ 50, every element string. Errors return `isError: true` with explicit messages per the Tech Plan failure-mode table. |
+| Auth | Standard early-return on `!supabase` with `"Authentication required..."` text. |
+| RPC call | Single `supabase.rpc("resolve_exercises_batch", { queries })` call. |
+| Grouping | Build `Map<number, RawRow[]>` keyed by `row.query_idx`, NOT by row position. |
+| Per-query status | `"empty_query"` (input was blank) / `"no_match"` (input had text, no rows) / `"ambiguous"` (rows present + `isAmbiguous(matches)` true → top 1-3 attached) / `"matched"` (rows present + not ambiguous → top-1 only). |
+| Bundled metadata | Each `ResolvedExercise` includes `weight_convention: formatWeightConvention(row.equipment)` from `file:supabase/functions/mcp/lib/format.ts`. Never duplicate the equipment-to-convention map in this file. |
+| Response | `{ content: [{ type: "text", text: JSON.stringify(response, null, 2) }] }` matching `BatchResolveResponse` shape from Tech Plan data model. |
+
+### 5. New file — `supabase/functions/mcp/tools/resolveExercises.test.ts`
+
+Mirror the fake-supabase pattern from `file:supabase/functions/mcp/lib/catalogLookup.test.ts`. Required test coverage:
+
+- Happy path single match → `status: "matched"`, top-1 exercise with `weight_convention`
+- Ambiguous-with-alternates → `status: "ambiguous"`, 2-3 entries
+- No-match (RPC returns zero rows for a real query) → `status: "no_match"`, empty matches
+- Empty/whitespace query in batch → `status: "empty_query"`
+- All-empty batch
+- Mixed batch (matched + ambiguous + no_match + empty_query in one call)
+- Batch-size cap exceeded (51 queries) → `isError: true`
+- Empty `queries` array → `isError: true`
+- Non-string element in `queries` → `isError: true`
+- RPC error propagation → `isError: true` with verbatim message
+- No-auth → `"Authentication required..."`
+- `weight_convention` bundling correct for `dumbbell` (`per_hand`), `barbell` (`total`), `bodyweight` (`bodyweight`)
+- **Non-input-order RPC results**: queries `["a", "b", "c"]`, fake RPC returns rows tagged with `query_idx` `[2, 0, 1]` — verify Edge Function groups by tagged column, not row position
+
+### 6. Modified file — `supabase/functions/mcp/tools/registry.ts`
+
+Append `resolveExercises` import + register in the `tools` array. No other changes.
+
+### 7. Modified file — `supabase/functions/mcp/index.ts`
+
+Bump `SERVER_INFO.version` from `"0.4.0"` to `"0.5.0"`.
+
+### 8. Modified file — `skills/gymlogic-mcp/SKILL.md` (minimal additive only)
+
+- Add a row to the **tool reference table** (currently lines ~68-78) for `resolve_exercises`. Description should mirror the tool's MCP `description` (factual, no cross-tool steering).
+- Update the **count line** ("Nine tools total — seven reads, two writes" near line 66) to "Ten tools total — seven reads, two writes, one resolver" (or equivalent — author's choice).
+
+**Do NOT touch** the decision table, Pattern 3, Pattern 4, `update_program` worked examples, Edge Cases table, or any cross-tool steering copy. All of that is T99.
+
+## Out of Scope
+
+- Tool description updates that steer agents AWAY from `search_exercises` or `get_exercise_details` (T99).
+- SKILL.md decision table, Pattern updates, worked example rewrites (T99).
+- Updates to `createProgram.ts`'s `TOOL_DESCRIPTION` constant (T99).
+- Removing `search_exercises` from the MCP toolkit (deferred per Epic Brief, ≥ 2-week observation window).
+- Production instrumentation / metrics for tool-call counts (separate follow-up ticket).
+- `LEGACY_MIGRATION_ERROR_MESSAGE` in `createProgramValidation.ts` — leave untouched (v0.2.x→v0.3.x migration text, not v0.5.x guidance).
+
+## Acceptance Criteria
+
+- [ ] New migration file applies cleanly via `supabase migration up` against the local Supabase stack
+- [ ] `resolve_exercises_batch(ARRAY['bench press', 'squat', ''])` called via `psql` returns ranked rows for the first two queries and zero rows for the third
+- [ ] `tools/list` MCP request returns 10 tools including `resolve_exercises` with the documented input schema
+- [ ] `tools/call resolve_exercises { queries: ["bench press", "leg press", "trap bar deadlift", ""] }` returns a JSON payload with 4 entries, each with the documented `status` field; the "leg press" entry has `status: "ambiguous"` and ≥ 2 alternates; the "trap bar deadlift" entry has `status: "no_match"`; the empty-string entry has `status: "empty_query"`
+- [ ] Each `ResolvedExercise` row includes `weight_convention` derived via `formatWeightConvention(equipment)` (verified for at least one `dumbbell` and one `barbell` exercise in the catalog)
+- [ ] `MCP_AMBIGUITY_GAP=0.05` environment override changes the ambiguity threshold without code change (verified via test or manual run)
+- [ ] All new vitest tests pass (`scoreGap.test.ts` and `resolveExercises.test.ts`); existing tests still pass
+- [ ] `tsc --noEmit` is clean
+- [ ] An end-to-end manual smoke test against a real MCP client (Claude Desktop or `mcp inspector`) successfully resolves a 12-name batch in a single call and returns properly-shaped results
+
+## References
+
+- [Epic Brief — MCP — Batch Exercise Resolution #310](./Epic_Brief_—_MCP_—_Batch_Exercise_Resolution_#310.md)
+- [Tech Plan — MCP — Batch Exercise Resolution #310](./Tech_Plan_—_MCP_—_Batch_Exercise_Resolution_#310.md) — Sections: Key Decisions, Critical Constraints (#1, #2, #3, #4, #6, #7, #8), Data Model, Component Responsibilities (`resolveExercises.ts`, `scoreGap.ts`, `resolve_exercises_batch`), Failure Mode Analysis
+- GitHub issue [#310](https://github.com/PierreTsia/workout-app/issues/310)

--- a/docs/T99_—_Agent_Steering_for_resolve_exercises.md
+++ b/docs/T99_—_Agent_Steering_for_resolve_exercises.md
@@ -1,0 +1,140 @@
+# T99 — Agent Steering for `resolve_exercises`
+
+## Goal
+
+Redirect agent attention from the multi-call `search_exercises` + `get_exercise_details` dance to the new `resolve_exercises` tool across every steering surface (per-call tool descriptions AND session-start SKILL.md content) in a single, coherent change. Without this work, the new tool from T98 exists but agents won't reach for it consistently — the perf win never materializes.
+
+Addresses Epic Brief stories **5, 6, 12**: clear tool-purpose distinction so agents pick the right tool; `update_program` swap flow gets the same batching win as `create_program`; SKILL.md and tool-description coherence ensures all agent entry points (description-only clients AND skill-aware clients) align.
+
+## Mode
+
+**AFK** — copy is mechanical from the Tech Plan's existing description sketches; SKILL.md updates are deterministic edits to existing patterns. No copy approval beyond the Tech Plan's locked decisions.
+
+## Slice
+
+Single coherent agent-steering layer:
+`tools/searchExercises.ts (description revision)` → `tools/createProgram.ts (TOOL_DESCRIPTION revision)` → `SKILL.md (decision table + Pattern 3 + Pattern 4 + update_program worked examples + Edge Cases row)`.
+
+End-to-end demoable: after merge, an agent prompted with "build me a 4-day program" reaches for `resolve_exercises` instead of N × `search_exercises` + N × `get_exercise_details`.
+
+## Dependencies
+
+**T98** — cannot steer agents toward a tool that doesn't yet exist in the registry. T99 must land **after** T98 is on `main`.
+
+## Scope
+
+### 1. Modified file — `supabase/functions/mcp/tools/searchExercises.ts`
+
+Update the `description` field to add explicit cross-tool steering. Approximate copy (refine for tone consistency with sibling tools):
+
+> Browse the exercise catalog by muscle group, equipment, or difficulty filters. Use this when you don't yet have specific exercise names in mind — e.g. "find chest exercises with dumbbells", "what's a good biceps exercise". **If you already know the names of the exercises you want (e.g. building a program from a list), use `resolve_exercises` instead — it batch-resolves names to UUIDs in a single call and returns the catalog metadata you'll need for `create_program`/`update_program`.**
+
+No behavioural change to the tool itself. Description-only edit.
+
+### 2. Modified file — `supabase/functions/mcp/tools/createProgram.ts`
+
+Update the `TOOL_DESCRIPTION` constant. Specifically:
+
+- **Drop** the line: *"Call `get_exercise_details` first to confirm the convention (`weight_convention` field)."* (currently in the "Weight conventions" paragraph around lines 110-116).
+- **Replace** with: *"Use `resolve_exercises` first to get UUIDs + the `weight_convention` field for each exercise in one call — no need to follow up with `get_exercise_details` per exercise."*
+- Verify no other paragraphs in `TOOL_DESCRIPTION` reference `get_exercise_details` for convention guidance. Leave references to `get_exercise_details` for other purposes (instructions, video, etc.) untouched.
+
+**Do NOT touch** `LEGACY_MIGRATION_ERROR_MESSAGE` in `file:supabase/functions/mcp/lib/createProgramValidation.ts` — that's a v0.2.x → v0.3.x migration message, not v0.5.x guidance.
+
+### 3. Modified file — `skills/gymlogic-mcp/SKILL.md`
+
+Multi-section coherent rewrite. Each subsection below is a discrete edit:
+
+#### 3a. Add a "Catalog tools — which one when" decision table
+
+Insert near the top of the "Tool reference" section (around line 65, just above the existing 9-tool table). Format:
+
+| User intent / agent state | Tool | Why |
+|---|---|---|
+| Agent already has specific exercise NAMES in mind ("bench press", "squat", "leg press") and needs UUIDs to build/edit a program | `resolve_exercises` | One call resolves all names to UUIDs + bundles `weight_convention` / `measurement_type` / `default_duration_seconds`. Use this for `create_program` / `update_program` flows. |
+| Agent needs to BROWSE the catalog by muscle group, equipment, or difficulty ("find chest exercises with dumbbells", "biceps exercise") | `search_exercises` | Returns a filtered list with full metadata. Pick from results, then optionally `resolve_exercises` if you need UUIDs in bulk. |
+| User asks how to perform a SPECIFIC named exercise ("how do I do a Romanian deadlift") | `resolve_exercises` (1-element batch) → `get_exercise_details(uuid)` | `resolve_exercises` gives you the UUID; `get_exercise_details` returns the full instructions / video / image blob. |
+| Agent has a UUID and needs full instructions / media | `get_exercise_details` | Direct lookup by UUID. |
+
+#### 3b. Update Pattern 3 — Exercise lookup → details
+
+Replace the current code block (around lines 200-208) so the resolution step uses `resolve_exercises`:
+
+```jsonc
+// 1. Resolve the name to a UUID + metadata
+resolve_exercises({ queries: ["romanian deadlift"] })
+// → { results: [{ status: "matched", matches: [{ id: "<uuid>", weight_convention: "total", ... }] }] }
+
+// 2. Pull full instructions / video for that UUID
+get_exercise_details({ exercise_id: "<uuid>" })
+```
+
+Add a one-line note: *"For ambiguous names (`status: "ambiguous"`), present the alternates from `matches` to the user before calling `get_exercise_details`."*
+
+#### 3c. Update Pattern 4 — Design + persist a new program
+
+Rewrite step 2 of the Pattern 4 flow (around lines 213-217). The current text is:
+
+> 2. Search exercises to resolve UUIDs (one `search_exercises` call per movement, narrow to single matches).
+> 3. **For weighted exercises, pull `weight_convention` once** with `get_exercise_details` so the prescription weight you pass means the right thing per side vs total.
+
+Replace with:
+
+> 2. Resolve all exercise names to UUIDs in **one call** with `resolve_exercises({ queries: [...] })`. The response includes `weight_convention` for each exercise — no follow-up `get_exercise_details` calls needed before `create_program`. For any entry with `status: "ambiguous"`, present alternates to the user; for `status: "no_match"`, retry with a broader name or ask the user.
+
+Step 3 (formerly the `get_exercise_details` step) is removed. Renumber subsequent steps.
+
+#### 3d. Update both `update_program` worked examples (Patterns 2 and 3 in the "Common write patterns — `update_program`" section, around lines 366-449)
+
+Wherever the example calls `search_exercises` per movement, collapse those into a single `resolve_exercises` call. Concrete edits:
+
+- **Worked example 2 (add a Cardio day)** lines 376-379: replace the three `search_exercises` calls with `resolve_exercises({ queries: ["running", "jump rope", "plank"] })`.
+- **Worked example 3 (swap an exercise)** line 416: replace `search_exercises({ query: "conventional deadlift" })` with `resolve_exercises({ queries: ["conventional deadlift"] })`.
+
+Adjust the surrounding narration to match.
+
+#### 3e. Update the Edge Cases table
+
+Soften the row currently at line 478:
+
+> | `search_exercises` returns multiple matches | **Do not pick blindly.** List them and ask the user. Only call `get_exercise_details` once a single match is selected. |
+
+To:
+
+> | `search_exercises` returns multiple matches | When BROWSING, list them and ask the user. **For program-building flows, prefer `resolve_exercises` — it returns alternates with `status: "ambiguous"` so you can disambiguate without a second call.** |
+
+#### 3f. Inline version annotation
+
+Following the existing convention (lines 110, 339), add a sentence near the new tool reference table row mentioning *"(since v0.5.0)"* — both in the tool-reference table description column and in the Pattern 4 narration where `resolve_exercises` first appears.
+
+#### 3g. Remove the `### Server endpoint` count line consistency
+
+Verify that the count line near line 66 ("Ten tools total — seven reads, two writes, one resolver" or whatever T98 set) matches the actual table after this PR. Adjust if needed.
+
+## Out of Scope
+
+- Removing `search_exercises` from the MCP toolkit (deferred per Epic Brief, ≥ 2-week observation window with concrete decision criteria).
+- Removing `get_exercise_details` from the MCP toolkit (still needed for instructions / video / image use cases).
+- Production instrumentation / metrics for tool-call counts (separate follow-up ticket).
+- `LEGACY_MIGRATION_ERROR_MESSAGE` in `createProgramValidation.ts` — leave untouched (v0.2.x → v0.3.x migration text).
+- `CHANGELOG.md` — does not exist in this repo; version annotations live inline in SKILL.md per the existing convention.
+- New worked examples beyond the four listed above.
+
+## Acceptance Criteria
+
+- [ ] `tools/searchExercises.ts` description explicitly steers callers with names toward `resolve_exercises`
+- [ ] `tools/createProgram.ts` `TOOL_DESCRIPTION` no longer instructs the agent to call `get_exercise_details` first for `weight_convention`; it points to `resolve_exercises` instead
+- [ ] SKILL.md contains a "Catalog tools — which one when" decision table covering at minimum: build-program / browse-by-filter / single-exercise-instructions / UUID-direct-lookup intents
+- [ ] SKILL.md Pattern 3 (single exercise lookup) uses `resolve_exercises` before `get_exercise_details`
+- [ ] SKILL.md Pattern 4 (program design) uses a single `resolve_exercises` call to resolve all exercises and dropped the standalone `get_exercise_details` step for `weight_convention`
+- [ ] Both `update_program` worked examples (add-day and swap-exercise) collapse per-movement `search_exercises` calls into a single `resolve_exercises` batch
+- [ ] SKILL.md Edge Cases table acknowledges `resolve_exercises`'s `ambiguous` status as the program-building path for handling multi-match
+- [ ] Tool count line in SKILL.md ("Ten tools total...") is consistent with the actual reference table
+- [ ] Manual end-to-end smoke test against Claude Desktop: prompt *"build me a complete beginner weekly workout program with 3 sessions"* — Claude reaches for `resolve_exercises` (verified by counting tool calls in the conversation), program lands in ≤ 3 `create_program`-related calls (1 resolve + 1 dry_run + 1 apply)
+
+## References
+
+- [Epic Brief — MCP — Batch Exercise Resolution #310](./Epic_Brief_—_MCP_—_Batch_Exercise_Resolution_#310.md) — Stories 5, 6, 12; Critical Constraint #5 (SKILL.md / description coherence)
+- [Tech Plan — MCP — Batch Exercise Resolution #310](./Tech_Plan_—_MCP_—_Batch_Exercise_Resolution_#310.md) — Modified Files table; Critical Constraint #5
+- [T98 — `resolve_exercises` Tool End-to-End](./T98_—_resolve_exercises_Tool_End-to-End.md) (prerequisite)
+- GitHub issue [#310](https://github.com/PierreTsia/workout-app/issues/310)

--- a/docs/Tech_Plan_—_MCP_—_Batch_Exercise_Resolution_#310.md
+++ b/docs/Tech_Plan_—_MCP_—_Batch_Exercise_Resolution_#310.md
@@ -9,13 +9,14 @@
 | Tool name | `resolve_exercises` | Conveys intent (name → UUID resolution); avoids confusion with existing `search_exercises` |
 | Input shape | `{ queries: string[] }` only — no per-query filters in v1 | Real agent traces (issue #310 screenshot) show context-embedding in the name string itself; adding optional fields later is non-breaking |
 | Postgres execution | New `resolve_exercises_batch(queries text[])` RPC; single round-trip; PL/pgSQL FOR loop returning ranked rows tagged by `query_idx` | 1 round-trip vs N; reuses `pg_trgm`/`unaccent` infra; PL/pgSQL more readable than `unnest LATERAL` for this shape; perf difference negligible at scale |
-| Score-gap threshold | `0.10` between top-1 and top-2 similarity scores; substring-rank-0 ties naturally fall under this rule (identical scores → gap=0 → ambiguous) | Catches dominant ambiguity case (substring collisions like "leg press"); starter value, tunable later from production traces |
+| Score-gap threshold | `0.10` between top-1 and top-2 similarity scores (substring-rank-0 ties naturally fall under this rule — identical scores → gap=0 → ambiguous). Read at runtime from env var `MCP_AMBIGUITY_GAP` with fallback to `0.10`. | Catches dominant ambiguity case (substring collisions like "leg press"); env-var hook lets us tune from production traces without redeploying the function |
 | Top-K | 3 (top-1 always; top-2/3 only attached when `ambiguous: true`) | Enough alternates for agent to surface to user without payload bloat |
 | Bundled metadata | Each result includes `weight_convention`, `measurement_type`, `default_duration_seconds` | Eliminates N × `get_exercise_details` calls before `create_program`. `weight_convention` derived in Edge Function via existing `formatWeightConvention()` — single source of truth |
 | Tool coexistence | Keep `search_exercises` in MCP toolkit | Browse-by-filter is a legitimate intent; non-breaking; agents steered via tool descriptions + SKILL.md |
 | Server version | `0.4.0` → `0.5.0` | Additive (new tool, no breaking change to existing tools) |
 | Max batch size | 50 queries | Comfortable buffer above realistic program-build (~12 names per call); DoS guardrail |
-| Empty/whitespace queries | Per-query `{matches: [], reason: "empty_query"}` | Uniform response shape — every input query gets a result row |
+| Per-query result shape | Single `status` field with values `"matched"` \| `"ambiguous"` \| `"no_match"` \| `"empty_query"` (no separate `ambiguous` boolean) | One source of truth for the agent to switch on; avoids the agent reading two fields to derive one decision |
+| Empty/whitespace queries | Per-query `{ status: "empty_query", matches: [] }` | Uniform response shape — every input query gets a result row |
 | Score-gap helper location | Separate `file:supabase/functions/mcp/lib/scoreGap.ts` + dedicated tests | Tiny pure function but isolation lets us unit-test edge cases (0.099 / 0.10 / 0.101) without supabase mocks |
 
 ### Critical Constraints
@@ -26,7 +27,8 @@
 4. **`weight_convention` source of truth**: derived via `formatWeightConvention(equipment)` in `file:supabase/functions/mcp/lib/format.ts`. NEVER duplicate this mapping in SQL — equipment-to-convention rules can shift (e.g. when issue #281 lands weighted bodyweight) and the TS layer must remain canonical.
 5. **SKILL.md / description coherence**: all four updates (`resolve_exercises` desc, `search_exercises` desc revision, `create_program` desc edit, SKILL.md) must ship in the same PR. Mismatched guidance is worse than no change — the agent will pick a random path.
 6. **MCP version bump**: `SERVER_INFO.version` in `file:supabase/functions/mcp/index.ts` plus a `CHANGELOG.md` entry. The protocol version (`PROTOCOL_VERSION = "2025-03-26"`) does NOT change — that's the MCP spec version.
-7. **Ranking-clause duplication accepted**: the new RPC's `WHERE`/`ORDER BY` mirrors the existing `search_exercises` RPC's clauses. Not extracted to a shared SQL helper because the two tools may legitimately diverge over time (resolve cares about top-match quality; search cares about list completeness). Documented here so any future tuning of one is consciously evaluated against the other.
+7. **Ranking-clause duplication accepted, with mandatory cross-reference comments**: the new RPC's `WHERE`/`ORDER BY` mirrors the existing `search_exercises` RPC's clauses. Not extracted to a shared SQL helper because the two tools may legitimately diverge over time (resolve cares about top-match quality; search cares about list completeness). **Both migration files MUST carry an inline `-- See also: <other migration filename>` comment near the ranking clause** so anyone tuning one side consciously evaluates the impact on the other (without this, the next person to touch `search_exercises` ranking will silently miss `resolve_exercises_batch`).
+8. **Not designed for bulk catalog operations**: the 50-query batch cap is a per-call MCP-tool guardrail aimed at agent flows. For catalog migrations, seeding scripts, or admin tooling that needs to resolve hundreds or thousands of names, use direct DB access (raw `search_exercises` RPC in a loop, or a dedicated admin endpoint) — do NOT chain `resolve_exercises` calls. Documented so the limitation isn't mistaken for a system-wide constraint.
 
 ---
 
@@ -43,8 +45,7 @@ classDiagram
     }
     class ResolvedQuery {
         +string query
-        +boolean ambiguous
-        +string|null reason
+        +string status
         +ResolvedExercise[] matches
     }
     class ResolvedExercise {
@@ -181,9 +182,9 @@ graph TD
 | File | Purpose |
 |---|---|
 | `supabase/functions/mcp/tools/resolveExercises.ts` | New tool handler: validate input, call RPC, apply score-gap rule per query, bundle `weight_convention`, format JSON response |
-| `supabase/functions/mcp/tools/resolveExercises.test.ts` | Vitest unit tests with fake supabase client (mirror `file:supabase/functions/mcp/lib/catalogLookup.test.ts` pattern) |
-| `supabase/functions/mcp/lib/scoreGap.ts` | Pure helper: `isAmbiguous(matches: {score: number}[]): boolean`. Extracted for unit testing without supabase mocks. Exports `AMBIGUITY_GAP = 0.10`. |
-| `supabase/functions/mcp/lib/scoreGap.test.ts` | Vitest unit tests for threshold rule (gap=0.10, edge cases at 0.099 / 0.10 / 0.101, single-match, zero-match, three-way tie, NaN defensive) |
+| `supabase/functions/mcp/tools/resolveExercises.test.ts` | Vitest unit tests with fake supabase client (mirror `file:supabase/functions/mcp/lib/catalogLookup.test.ts` pattern). MUST cover at minimum: happy path single match, ambiguous-with-alternates, no-match, empty-query in batch, all-empty batch, batch-size cap exceeded, RPC error propagation, no-auth, status field for each branch (`matched` / `ambiguous` / `no_match` / `empty_query`), `weight_convention` bundling, AND **a dedicated test where the fake RPC returns rows in non-input order** (e.g. queries `["a", "b", "c"]` get rows tagged with `query_idx` `[2, 0, 1]`) — verifies the Edge Function groups by tagged column, not row position |
+| `supabase/functions/mcp/lib/scoreGap.ts` | Pure helper: `isAmbiguous(matches: {score: number}[]): boolean` + `getAmbiguityGap()` (env-driven, defaults to `0.10`). Extracted for unit testing without supabase mocks. Exports `DEFAULT_AMBIGUITY_GAP = 0.10`. |
+| `supabase/functions/mcp/lib/scoreGap.test.ts` | Vitest unit tests for threshold rule (default gap=0.10, edge cases at 0.099 / 0.10 / 0.101, single-match, zero-match, three-way tie, NaN defensive) PLUS env-var override path (valid value, invalid value, out-of-range value, missing var). |
 | `supabase/migrations/YYYYMMDDhhmmss_resolve_exercises_batch.sql` | New Postgres RPC + GRANT |
 
 ### Modified Files
@@ -204,17 +205,23 @@ graph TD
 - Calls `supabase.rpc("resolve_exercises_batch", { queries })` once
 - Groups returned rows by `query_idx`
 - For each input query index 0..N-1:
-  - Determine reason: empty/whitespace input → `"empty_query"`; otherwise no rows → `"no_match"`; matches present → `null`
-  - Apply `isAmbiguous(matches)` → if true, attach top-1, top-2, top-3 with `ambiguous: true`; else attach only top-1
-  - Map each row to `ResolvedExercise` with `weight_convention: formatWeightConvention(row.equipment)`
+  - Determine `status`:
+    - empty/whitespace input → `"empty_query"` (zero matches)
+    - real input, RPC returned 0 rows → `"no_match"` (zero matches)
+    - real input, RPC returned ≥ 1 row, `isAmbiguous(matches)` true → `"ambiguous"` (top-1, top-2, top-3 attached)
+    - real input, RPC returned ≥ 1 row, `isAmbiguous(matches)` false → `"matched"` (top-1 attached only)
+  - Map each match row to `ResolvedExercise` with `weight_convention: formatWeightConvention(row.equipment)`
+- **Result grouping is `query_idx`-tagged, not row-position-tagged** — the RPC returns rows with an explicit `query_idx int` column; Edge Function groups by that column. Robust to any Postgres reordering / parallelization. Covered by an explicit unit test (see test file responsibilities below).
 - Returns `{content: [{type: "text", text: JSON.stringify(response, null, 2)}]}`
 - Auth: standard pattern from existing tools (early return on `!supabase` with `"Authentication required..."` text)
 
 **`scoreGap.ts`** (pure helper)
-- `isAmbiguous(matches: ScoredMatch[]): boolean` — returns true when `matches.length >= 2 && matches[0].score - matches[1].score < AMBIGUITY_GAP`
-- No dependencies, no supabase, no I/O — pure function for clean unit tests
-- Threshold constant `AMBIGUITY_GAP = 0.10` exported for tests
+- `isAmbiguous(matches: ScoredMatch[]): boolean` — returns true when `matches.length >= 2 && matches[0].score - matches[1].score < getAmbiguityGap()`
+- `getAmbiguityGap(): number` — reads env var `MCP_AMBIGUITY_GAP` via `Deno.env.get(...)`, parses with `parseFloat`, validates as finite number in `(0, 1]`, falls back to `DEFAULT_AMBIGUITY_GAP = 0.10` on any of (unset, NaN, out-of-range). Cached after first read (env doesn't change mid-process).
+- No supabase, no I/O beyond the env var read — pure-enough for clean unit tests (env var monkey-patched in test setup)
+- `DEFAULT_AMBIGUITY_GAP = 0.10` exported for tests
 - NaN-safe (NaN comparisons are false → never returns true on bad data → defaults to top-1-only behavior, no crash)
+- Includes a `// TUNING:` comment block describing what to look for in production traces (false-ambiguous rate, false-confident pick rate) and how to adjust the env var.
 
 **`resolve_exercises_batch`** (new Postgres RPC)
 - `LANGUAGE plpgsql STABLE SECURITY INVOKER`
@@ -229,15 +236,16 @@ graph TD
 | `queries` missing or not an array | Tool returns `isError: true` with text: `"queries must be a non-empty array of strings"` |
 | `queries.length > 50` | Tool returns `isError: true` with text: `"queries exceeds max batch size of 50 (got N)"` |
 | `queries.length === 0` | Tool returns `isError: true` (same message as missing) |
-| Single empty/whitespace query in batch | That entry: `{query: "", matches: [], reason: "empty_query"}`; siblings unaffected |
-| Single query matches zero exercises | That entry: `{query, matches: [], reason: "no_match"}`; siblings unaffected |
-| All queries match zero exercises | Response: 100% `no_match` rows. Batch is still success (200, no `isError`) — agent reads and decides next move |
+| Single empty/whitespace query in batch | That entry: `{query: "", status: "empty_query", matches: []}`; siblings unaffected |
+| Single query matches zero exercises | That entry: `{query, status: "no_match", matches: []}`; siblings unaffected |
+| All queries match zero exercises | Response: 100% `status: "no_match"` rows. Batch is still success (200, no `isError`) — agent reads and decides next move |
 | RPC error (Postgres down, function permission missing) | Tool returns `isError: true` with the error message verbatim. Agent surfaces to user. |
 | No auth (`!supabase`) | Standard `"Authentication required — please provide a valid Bearer token."` |
 | Two queries with identical text | Each gets its own result row independently — no dedup across queries (agent's payload, agent's choice) |
 | Catalog has zero exercises (fresh DB seed missing) | All queries → `no_match`; agent surfaces "no exercises found in catalog" gracefully |
 | Agent sends 50 single-character queries (e.g. `["a", "b", ...]`) | Each returns ambiguous matches (substring collisions); response payload up to 50 × 3 rows = 150 rows. Bounded. |
-| Score field is `NaN` (defensive — shouldn't happen from PG `real`) | `isAmbiguous` returns false (NaN comparisons are false) → tool emits top-1 only. No crash. |
+| Score field is `NaN` (defensive — shouldn't happen from PG `real`) | `isAmbiguous` returns false (NaN comparisons are false) → tool emits top-1 only with `status: "matched"`. No crash. |
 | Catalog row with unknown `equipment` value | `formatWeightConvention` falls back to `"total"` and logs a warning (existing behavior). Tool response still well-formed. |
-| Two adjacent matches with identical raw scores but different substring ranks | Score gap = 0 → ambiguous → both surfaced as alternates. Acceptable: ranking is recorded by row order; the agent gets to disambiguate. |
+| Two adjacent matches with identical raw scores but different substring ranks | Score gap = 0 → `status: "ambiguous"` → both surfaced as alternates. Acceptable: ranking is recorded by row order; the agent gets to disambiguate. |
+| RPC returns rows in non-input order (Postgres parallelization or planner choice) | Edge Function groups by explicit `query_idx` column on each row, not row position. Robust by design. Covered by a dedicated unit test in `resolveExercises.test.ts`. |
 | Agent passes a non-string element (e.g. `[123, "bench"]`) | Caught in input validation: `isError: true` with `"queries[N] must be a string"` |

--- a/docs/Tech_Plan_—_MCP_—_Batch_Exercise_Resolution_#310.md
+++ b/docs/Tech_Plan_—_MCP_—_Batch_Exercise_Resolution_#310.md
@@ -1,0 +1,243 @@
+# Tech Plan — MCP — Batch Exercise Resolution #310
+
+## Architectural Approach
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Tool name | `resolve_exercises` | Conveys intent (name → UUID resolution); avoids confusion with existing `search_exercises` |
+| Input shape | `{ queries: string[] }` only — no per-query filters in v1 | Real agent traces (issue #310 screenshot) show context-embedding in the name string itself; adding optional fields later is non-breaking |
+| Postgres execution | New `resolve_exercises_batch(queries text[])` RPC; single round-trip; PL/pgSQL FOR loop returning ranked rows tagged by `query_idx` | 1 round-trip vs N; reuses `pg_trgm`/`unaccent` infra; PL/pgSQL more readable than `unnest LATERAL` for this shape; perf difference negligible at scale |
+| Score-gap threshold | `0.10` between top-1 and top-2 similarity scores; substring-rank-0 ties naturally fall under this rule (identical scores → gap=0 → ambiguous) | Catches dominant ambiguity case (substring collisions like "leg press"); starter value, tunable later from production traces |
+| Top-K | 3 (top-1 always; top-2/3 only attached when `ambiguous: true`) | Enough alternates for agent to surface to user without payload bloat |
+| Bundled metadata | Each result includes `weight_convention`, `measurement_type`, `default_duration_seconds` | Eliminates N × `get_exercise_details` calls before `create_program`. `weight_convention` derived in Edge Function via existing `formatWeightConvention()` — single source of truth |
+| Tool coexistence | Keep `search_exercises` in MCP toolkit | Browse-by-filter is a legitimate intent; non-breaking; agents steered via tool descriptions + SKILL.md |
+| Server version | `0.4.0` → `0.5.0` | Additive (new tool, no breaking change to existing tools) |
+| Max batch size | 50 queries | Comfortable buffer above realistic program-build (~12 names per call); DoS guardrail |
+| Empty/whitespace queries | Per-query `{matches: [], reason: "empty_query"}` | Uniform response shape — every input query gets a result row |
+| Score-gap helper location | Separate `file:supabase/functions/mcp/lib/scoreGap.ts` + dedicated tests | Tiny pure function but isolation lets us unit-test edge cases (0.099 / 0.10 / 0.101) without supabase mocks |
+
+### Critical Constraints
+
+1. **RLS / SECURITY INVOKER**: the new RPC must mirror the existing `file:supabase/migrations/20260326120000_search_exercises.sql` auth pattern (`SECURITY INVOKER` + `GRANT EXECUTE ... TO authenticated`). Without it, real users get 403s. The existing `exercises` table RLS scopes the query to the calling user automatically — no extra logic needed in the function.
+2. **Diacritic / unicode normalization**: must use `extensions.unaccent(lower(...))` on BOTH query input and the indexed columns, matching the existing search RPC. Inconsistency here would produce different match sets for "épaules" vs "epaules" between the two tools.
+3. **Tool registry contract**: the new handler must implement `ToolDefinition` from `file:supabase/functions/mcp/tools/registry.ts` and be added to the `tools` array. The dispatch in `file:supabase/functions/mcp/index.ts` (`tools/call` case) is generic — no changes needed there beyond the registry append.
+4. **`weight_convention` source of truth**: derived via `formatWeightConvention(equipment)` in `file:supabase/functions/mcp/lib/format.ts`. NEVER duplicate this mapping in SQL — equipment-to-convention rules can shift (e.g. when issue #281 lands weighted bodyweight) and the TS layer must remain canonical.
+5. **SKILL.md / description coherence**: all four updates (`resolve_exercises` desc, `search_exercises` desc revision, `create_program` desc edit, SKILL.md) must ship in the same PR. Mismatched guidance is worse than no change — the agent will pick a random path.
+6. **MCP version bump**: `SERVER_INFO.version` in `file:supabase/functions/mcp/index.ts` plus a `CHANGELOG.md` entry. The protocol version (`PROTOCOL_VERSION = "2025-03-26"`) does NOT change — that's the MCP spec version.
+7. **Ranking-clause duplication accepted**: the new RPC's `WHERE`/`ORDER BY` mirrors the existing `search_exercises` RPC's clauses. Not extracted to a shared SQL helper because the two tools may legitimately diverge over time (resolve cares about top-match quality; search cares about list completeness). Documented here so any future tuning of one is consciously evaluated against the other.
+
+---
+
+## Data Model
+
+No new tables, no new columns. Pure RPC + tool layer addition.
+
+### Response shape (JSON returned in the tool's text content)
+
+```mermaid
+classDiagram
+    class BatchResolveResponse {
+        +ResolvedQuery[] results
+    }
+    class ResolvedQuery {
+        +string query
+        +boolean ambiguous
+        +string|null reason
+        +ResolvedExercise[] matches
+    }
+    class ResolvedExercise {
+        +uuid id
+        +string name
+        +string|null name_en
+        +string muscle_group
+        +string equipment
+        +string measurement_type
+        +int|null default_duration_seconds
+        +string weight_convention
+        +number score
+    }
+    BatchResolveResponse --> ResolvedQuery
+    ResolvedQuery --> ResolvedExercise
+```
+
+### New Postgres RPC
+
+```sql
+-- supabase/migrations/YYYYMMDDhhmmss_resolve_exercises_batch.sql
+
+CREATE OR REPLACE FUNCTION resolve_exercises_batch(
+  queries text[]
+)
+RETURNS TABLE (
+  query_idx int,
+  query_text text,
+  exercise_id uuid,
+  name text,
+  name_en text,
+  muscle_group text,
+  equipment text,
+  measurement_type text,
+  default_duration_seconds int,
+  score real
+)
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+AS $$
+DECLARE
+  q_raw text;
+  q_norm text;
+  qi int;
+BEGIN
+  IF queries IS NULL OR array_length(queries, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  FOR qi IN 1..array_length(queries, 1) LOOP
+    q_raw := queries[qi];
+    q_norm := trim(lower(extensions.unaccent(coalesce(q_raw, ''))));
+
+    -- Empty/whitespace queries return zero rows for this query_idx;
+    -- the Edge Function maps absence + reason "empty_query".
+    IF length(q_norm) = 0 THEN
+      CONTINUE;
+    END IF;
+
+    RETURN QUERY
+      SELECT
+        qi - 1 AS query_idx,
+        q_raw AS query_text,
+        e.id AS exercise_id,
+        e.name,
+        e.name_en,
+        e.muscle_group,
+        e.equipment,
+        e.measurement_type::text,
+        e.default_duration_seconds,
+        GREATEST(
+          similarity(extensions.unaccent(lower(e.name)), q_norm),
+          similarity(extensions.unaccent(lower(coalesce(e.name_en, ''))), q_norm)
+        )::real AS score
+      FROM exercises e
+      WHERE
+        extensions.unaccent(lower(e.name)) ILIKE '%' || q_norm || '%'
+        OR extensions.unaccent(lower(coalesce(e.name_en, ''))) ILIKE '%' || q_norm || '%'
+        OR similarity(extensions.unaccent(lower(e.name)), q_norm) > 0.15
+        OR similarity(extensions.unaccent(lower(coalesce(e.name_en, ''))), q_norm) > 0.15
+      ORDER BY
+        CASE
+          WHEN extensions.unaccent(lower(e.name)) ILIKE '%' || q_norm || '%' THEN 0
+          WHEN extensions.unaccent(lower(coalesce(e.name_en, ''))) ILIKE '%' || q_norm || '%' THEN 1
+          ELSE 2
+        END,
+        GREATEST(
+          similarity(extensions.unaccent(lower(e.name)), q_norm),
+          similarity(extensions.unaccent(lower(coalesce(e.name_en, ''))), q_norm)
+        ) DESC,
+        e.name,
+        e.id
+      LIMIT 3;
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.resolve_exercises_batch(text[]) TO authenticated;
+```
+
+### Table Notes
+
+- **No `rank` column in the RPC output** — substring vs similarity ordering is encoded in the row order (deterministic via `LIMIT 3` after `ORDER BY`); the Edge Function reads rows in result order. Adding an explicit rank column is 4 bytes per row of payload bloat for no agent-visible benefit.
+- **`measurement_type::text` cast** — the column is constrained text in `exercises`; cast to plain text in the result so the consumer doesn't need to know about the underlying type.
+- **`score::real`** — keeps the field 32-bit for transport; `pg_trgm` similarity is float in [0, 1], no precision loss in 24-bit mantissa.
+- **Empty-query handling lives in PL/pgSQL** — the `CONTINUE` branch produces zero rows for that `query_idx`. The Edge Function detects "no rows for this index" and decides whether it's `no_match` (input had real text) or `empty_query` (input was blank).
+- **No score normalization across queries** — `pg_trgm` similarity is per-query; comparing scores across different queries is meaningless. The `ambiguous` flag operates strictly within a single query's results, never across.
+
+---
+
+## Component Architecture
+
+### Layer Overview
+
+```mermaid
+graph TD
+    Agent["AI Agent<br/>(Claude / Cursor / generic MCP)"]
+    EdgeFn["MCP Edge Function<br/>(supabase/functions/mcp/index.ts)"]
+    Tool["resolveExercises.ts<br/>(new tool handler)"]
+    ScoreGap["scoreGap.ts<br/>(pure ambiguity helper)"]
+    Format["format.ts<br/>(formatWeightConvention)"]
+    RPC["resolve_exercises_batch<br/>(new Postgres RPC)"]
+    Exercises[(exercises table<br/>RLS-scoped)]
+
+    Agent -->|"tools/call resolve_exercises"| EdgeFn
+    EdgeFn -->|"dispatch via toolRegistry"| Tool
+    Tool --> ScoreGap
+    Tool --> Format
+    Tool -->|"supabase.rpc('resolve_exercises_batch')"| RPC
+    RPC --> Exercises
+```
+
+### New Files & Responsibilities
+
+| File | Purpose |
+|---|---|
+| `supabase/functions/mcp/tools/resolveExercises.ts` | New tool handler: validate input, call RPC, apply score-gap rule per query, bundle `weight_convention`, format JSON response |
+| `supabase/functions/mcp/tools/resolveExercises.test.ts` | Vitest unit tests with fake supabase client (mirror `file:supabase/functions/mcp/lib/catalogLookup.test.ts` pattern) |
+| `supabase/functions/mcp/lib/scoreGap.ts` | Pure helper: `isAmbiguous(matches: {score: number}[]): boolean`. Extracted for unit testing without supabase mocks. Exports `AMBIGUITY_GAP = 0.10`. |
+| `supabase/functions/mcp/lib/scoreGap.test.ts` | Vitest unit tests for threshold rule (gap=0.10, edge cases at 0.099 / 0.10 / 0.101, single-match, zero-match, three-way tie, NaN defensive) |
+| `supabase/migrations/YYYYMMDDhhmmss_resolve_exercises_batch.sql` | New Postgres RPC + GRANT |
+
+### Modified Files
+
+| File | Change |
+|---|---|
+| `supabase/functions/mcp/tools/registry.ts` | Register new tool in the `tools` array |
+| `supabase/functions/mcp/tools/searchExercises.ts` | Update `description`: explicit "use `resolve_exercises` instead if you already know the names" steering |
+| `supabase/functions/mcp/tools/createProgram.ts` | Update `TOOL_DESCRIPTION`: drop "Call `get_exercise_details` first to confirm the convention" line; replace with reference to `resolve_exercises` returning the convention |
+| `supabase/functions/mcp/index.ts` | Bump `SERVER_INFO.version` from `"0.4.0"` to `"0.5.0"` |
+| `skills/gymlogic-mcp/SKILL.md` | Add "Catalog tools — which one when" decision table near top; update Pattern 3, Pattern 4, both `update_program` worked examples to use `resolve_exercises`; update tool-reference table to include new tool (10 tools total); revise the `LEGACY_MIGRATION_ERROR_MESSAGE` reference if it still mentions `get_exercise_details` for convention guidance |
+| `CHANGELOG.md` | v0.5.0 entry — new tool + perf description |
+
+### Component Responsibilities
+
+**`resolveExercises.ts`** (new tool handler)
+- Validates `args.queries`: must be non-empty array, length ≤ 50, every element is string (else returns `isError: true` with explicit message)
+- Calls `supabase.rpc("resolve_exercises_batch", { queries })` once
+- Groups returned rows by `query_idx`
+- For each input query index 0..N-1:
+  - Determine reason: empty/whitespace input → `"empty_query"`; otherwise no rows → `"no_match"`; matches present → `null`
+  - Apply `isAmbiguous(matches)` → if true, attach top-1, top-2, top-3 with `ambiguous: true`; else attach only top-1
+  - Map each row to `ResolvedExercise` with `weight_convention: formatWeightConvention(row.equipment)`
+- Returns `{content: [{type: "text", text: JSON.stringify(response, null, 2)}]}`
+- Auth: standard pattern from existing tools (early return on `!supabase` with `"Authentication required..."` text)
+
+**`scoreGap.ts`** (pure helper)
+- `isAmbiguous(matches: ScoredMatch[]): boolean` — returns true when `matches.length >= 2 && matches[0].score - matches[1].score < AMBIGUITY_GAP`
+- No dependencies, no supabase, no I/O — pure function for clean unit tests
+- Threshold constant `AMBIGUITY_GAP = 0.10` exported for tests
+- NaN-safe (NaN comparisons are false → never returns true on bad data → defaults to top-1-only behavior, no crash)
+
+**`resolve_exercises_batch`** (new Postgres RPC)
+- `LANGUAGE plpgsql STABLE SECURITY INVOKER`
+- Iterates query array via PL/pgSQL FOR loop; per query: normalize, skip empties, RETURN QUERY ranked top-3
+- Reuses the same ranking expression as the existing `search_exercises` RPC (substring rank then similarity desc)
+- Inherits RLS from the `exercises` table (scoped to authenticated user)
+
+### Failure Mode Analysis
+
+| Failure | Behavior |
+|---|---|
+| `queries` missing or not an array | Tool returns `isError: true` with text: `"queries must be a non-empty array of strings"` |
+| `queries.length > 50` | Tool returns `isError: true` with text: `"queries exceeds max batch size of 50 (got N)"` |
+| `queries.length === 0` | Tool returns `isError: true` (same message as missing) |
+| Single empty/whitespace query in batch | That entry: `{query: "", matches: [], reason: "empty_query"}`; siblings unaffected |
+| Single query matches zero exercises | That entry: `{query, matches: [], reason: "no_match"}`; siblings unaffected |
+| All queries match zero exercises | Response: 100% `no_match` rows. Batch is still success (200, no `isError`) — agent reads and decides next move |
+| RPC error (Postgres down, function permission missing) | Tool returns `isError: true` with the error message verbatim. Agent surfaces to user. |
+| No auth (`!supabase`) | Standard `"Authentication required — please provide a valid Bearer token."` |
+| Two queries with identical text | Each gets its own result row independently — no dedup across queries (agent's payload, agent's choice) |
+| Catalog has zero exercises (fresh DB seed missing) | All queries → `no_match`; agent surfaces "no exercises found in catalog" gracefully |
+| Agent sends 50 single-character queries (e.g. `["a", "b", ...]`) | Each returns ambiguous matches (substring collisions); response payload up to 50 × 3 rows = 150 rows. Bounded. |
+| Score field is `NaN` (defensive — shouldn't happen from PG `real`) | `isAmbiguous` returns false (NaN comparisons are false) → tool emits top-1 only. No crash. |
+| Catalog row with unknown `equipment` value | `formatWeightConvention` falls back to `"total"` and logs a warning (existing behavior). Tool response still well-formed. |
+| Two adjacent matches with identical raw scores but different substring ranks | Score gap = 0 → ambiguous → both surfaced as alternates. Acceptable: ranking is recorded by row order; the agent gets to disambiguate. |
+| Agent passes a non-string element (e.g. `[123, "bench"]`) | Caught in input validation: `isError: true` with `"queries[N] must be a string"` |

--- a/skills/gymlogic-mcp/SKILL.md
+++ b/skills/gymlogic-mcp/SKILL.md
@@ -65,6 +65,19 @@ All nine tools 401 if no auth context. The tool response will be `Authentication
 
 Ten tools total — eight reads, two writes.
 
+### Catalog tools — which one when
+
+The catalog has three tools that look superficially similar. Pick by **what you already know** about the exercise(s) you're after:
+
+| You already know… | Tool | Why |
+|---|---|---|
+| Specific exercise NAMES (e.g. `["bench press", "squat", "leg press"]`) and need UUIDs to build/edit a program | `resolve_exercises` (since v0.5.0) | One call resolves all names to UUIDs and bundles `weight_convention` / `measurement_type` / `default_duration_seconds` — everything `create_program` / `update_program` need. No follow-up `get_exercise_details` required. |
+| A muscle group / equipment / difficulty filter ("find chest exercises with dumbbells", "what's a good biceps exercise") and want to BROWSE | `search_exercises` | Returns a filtered list. Once the user picks, optionally batch the chosen names through `resolve_exercises` if you need UUIDs in bulk. |
+| A specific name AND the user wants instructions / video / common mistakes ("how do I do a Romanian deadlift") | `resolve_exercises` (1-element batch) → `get_exercise_details(uuid)` | `resolve_exercises` gives you the UUID; `get_exercise_details` returns the full instructions / video / image blob. |
+| A UUID already (from any prior tool call) and need full instructions / media | `get_exercise_details` | Direct lookup by UUID. Do NOT call this just to get `weight_convention` — `resolve_exercises` already includes it. |
+
+### Full intent → tool table
+
 | User intent | Tool | Notes |
 |---|---|---|
 | "Show me my recent workouts / sessions / training history" | `get_workout_history` | Defaults to last 10 sessions. Filter by `from_date` / `to_date` (ISO 8601) or `exercise_name` (fuzzy). Each session header surfaces `*(program: <name>, id: <uuid>)*` for sessions that belong to a cycle — pass that `id` straight to `get_program_details` to chain into the program structure. Sessions without a cycle (legacy data) omit the annotation. |
@@ -200,22 +213,23 @@ Read the per-muscle-group volume. Group `Pectoraux + Épaules + Triceps` as push
 User: *"How do I do a Romanian deadlift?"*
 
 ```jsonc
-// 1. Find it
-search_exercises({ query: "romanian deadlift" })
-// → returns { id: "<uuid>", ... } if single match, list otherwise
+// 1. Resolve the name to a UUID + metadata (1-element batch is fine)
+resolve_exercises({ queries: ["romanian deadlift"] })
+// → { results: [{ status: "matched", matches: [{ id: "<uuid>", weight_convention: "total", ... }] }] }
 
-// 2. Pull full details (only on single match — otherwise ask user to pick)
+// 2. Pull full instructions / video / image for that UUID
 get_exercise_details({ exercise_id: "<uuid>" })
 ```
+
+For ambiguous names (`status: "ambiguous"`), present the alternates from `matches` to the user before calling `get_exercise_details`. For `status: "no_match"`, fall back to `search_exercises` with broader filters or ask the user to rephrase.
 
 ### Pattern 4 — Design + persist a new program
 
 User: *"Propose-moi un 4 jours full-body et active-le."*
 
 1. Read context: `get_training_stats`, optionally `get_upcoming_workouts` to see the current program.
-2. Search exercises to resolve UUIDs (one `search_exercises` call per movement, narrow to single matches).
-3. **For weighted exercises, pull `weight_convention` once** with `get_exercise_details` so the prescription weight you pass means the right thing per side vs total.
-4. Dry-run preview using either bare UUIDs (server defaults) or full prescription objects (frozen progression — see "Common write patterns" below):
+2. Resolve every exercise name to a UUID in **one call** with `resolve_exercises({ queries: [...] })` (since v0.5.0). The response includes `weight_convention`, `measurement_type`, and `default_duration_seconds` per exercise — no follow-up `get_exercise_details` calls needed before `create_program`. For any entry with `status: "ambiguous"`, present alternates to the user; for `status: "no_match"`, retry with a broader name or ask the user.
+3. Dry-run preview using either bare UUIDs (server defaults) or full prescription objects (frozen progression — see "Common write patterns" below):
 
 ```jsonc
 create_program({
@@ -238,8 +252,8 @@ create_program({
 })
 ```
 
-5. Read the preview's `days[].rendered` lines back to the user (e.g. *"Squat — 4 × 8 × 100 kg total — 180s rest"*) and get explicit consent.
-6. Apply: same call with `dry_run: false`. Confirm: *"Program created and set active."*
+4. Read the preview's `days[].rendered` lines back to the user (e.g. *"Squat — 4 × 8 × 100 kg total — 180s rest"*) and get explicit consent.
+5. Apply: same call with `dry_run: false`. Confirm: *"Program created and set active."*
 
 **Server defaults (bare UUID form)**: 3 sets × 10 reps × 90s rest, weight 0 (or duration mode for time-based exercises). The user can fine-tune in-app afterwards.
 
@@ -373,10 +387,13 @@ update_program({
 list_programs({})
 get_program_details({ program_id: "<pid>" })   // ← read every day id + every exercise_id
 
-// Step 2 — search the new exercises (one search per movement)
-search_exercises({ query: "running" })         // → <uuid-run>
-search_exercises({ query: "jump rope" })       // → <uuid-jump>
-search_exercises({ query: "plank" })           // → <uuid-plank>
+// Step 2 — resolve all the new exercise names in ONE call
+resolve_exercises({ queries: ["running", "jump rope", "plank"] })
+// → { results: [
+//     { query: "running",   status: "matched", matches: [{ id: "<uuid-run>",   measurement_type: "duration", default_duration_seconds: 30, ... }] },
+//     { query: "jump rope", status: "matched", matches: [{ id: "<uuid-jump>",  measurement_type: "duration", default_duration_seconds: 60, ... }] },
+//     { query: "plank",     status: "matched", matches: [{ id: "<uuid-plank>", measurement_type: "duration", default_duration_seconds: 45, ... }] },
+//   ] }
 
 // Step 3 — preview the patch
 update_program({
@@ -414,7 +431,7 @@ The agent must **include every current day** in `days[]` — the array is declar
 ```jsonc
 list_programs({})
 get_program_details({ program_id: "<pid>" })   // read every day id + current prescriptions
-search_exercises({ query: "conventional deadlift" })  // → <uuid-conv-dl>
+resolve_exercises({ queries: ["conventional deadlift"] })  // → <uuid-conv-dl> + weight_convention
 
 update_program({
   program_id: "<pid>",
@@ -476,8 +493,11 @@ If the program has an unfinished cycle, both dry_run and apply responses include
 | `No workout sessions found for this period.` | Tell the user; don't fabricate data. Suggest they log a session in the app first. |
 | `No active program found.` (from `get_upcoming_workouts`) | Tell the user, offer to design one with `create_program`. |
 | `No active training cycle for "X".` | A program exists but no cycle is started. Tell the user to start a cycle in-app. |
-| `search_exercises` returns multiple matches | **Do not pick blindly.** List them and ask the user. Only call `get_exercise_details` once a single match is selected. |
-| `Invalid UUID at days["<label>"].exercises[<i>]` | You passed a non-UUID string (e.g. an exercise name). Resolve via `search_exercises` first. |
+| `search_exercises` returns multiple matches | When BROWSING, list them and ask the user. **For program-building flows, prefer `resolve_exercises` — it returns alternates with `status: "ambiguous"` so you can disambiguate without a second call.** |
+| `resolve_exercises` returns `status: "ambiguous"` | Top-2 scores are within the threshold (≈0.10). Look at `matches[]` for alternates, pick from context if obvious (equipment / muscle group hint), otherwise present the list to the user. |
+| `resolve_exercises` returns `status: "no_match"` | Nothing similar enough in the catalog. Try `search_exercises` with broader filters (muscle group + equipment), or ask the user to rephrase / pick from a browse list. |
+| `resolve_exercises` returns `status: "empty_query"` | One of the input strings was blank/whitespace. Filter empty strings out of `queries` before calling. |
+| `Invalid UUID at days["<label>"].exercises[<i>]` | You passed a non-UUID string (e.g. an exercise name). Resolve via `resolve_exercises` (preferred) or `search_exercises` first. |
 | `Unknown or inaccessible exercise_id(s):` | The UUID is valid format but the exercise doesn't exist or isn't visible to this user. Re-search. |
 | `create_program v0.3.0 introduced a breaking change...` | You used the v0.2.x `exercise_ids` field. Switch to `exercises` (bare UUIDs or full objects — see "Common write patterns"). |
 | `reps exercise "X" cannot have target_duration_seconds` | You set `target_duration_seconds` on a reps-mode exercise. Drop it (use reps + weight_kg instead). Duration exercises (planks, holds) get T75 support. |
@@ -490,7 +510,7 @@ If the program has an unfinished cycle, both dry_run and apply responses include
 ## Parameter format conventions
 
 - **Dates**: ISO 8601, date-only (`2026-04-27`) for `from_date` / `to_date`. Server appends `T00:00:00Z` / `T23:59:59Z` automatically.
-- **Exercise IDs**: UUID v4 (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`). Always obtained from `search_exercises`. Never invent or transcribe from memory.
+- **Exercise IDs**: UUID v4 (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`). Always obtained from `resolve_exercises` (preferred for batch program-building) or `search_exercises`. Never invent or transcribe from memory.
 - **Muscle groups (FR canonical)**: `Abdos`, `Biceps`, `Deltoïdes post.`, `Dos`, `Épaules`, `Fessiers`, `Ischios`, `Ischios / Bas du dos`, `Lombaires`, `Mollets`, `Pectoraux`, `Quadriceps`, `Trapèzes`, `Triceps`.
 - **Equipment values**: `barbell`, `dumbbell`, `cable`, `machine`, `ez_bar`, `bodyweight`.
 - **Body region aliases** (for `search_exercises` only): `upper_body`, `lower_body`, `push`, `pull`, `arms`, `legs`, `core`.

--- a/skills/gymlogic-mcp/SKILL.md
+++ b/skills/gymlogic-mcp/SKILL.md
@@ -63,15 +63,16 @@ All nine tools 401 if no auth context. The tool response will be `Authentication
 
 ## Tool reference (intent → tool)
 
-Nine tools total — seven reads, two writes.
+Ten tools total — eight reads, two writes.
 
 | User intent | Tool | Notes |
 |---|---|---|
 | "Show me my recent workouts / sessions / training history" | `get_workout_history` | Defaults to last 10 sessions. Filter by `from_date` / `to_date` (ISO 8601) or `exercise_name` (fuzzy). Each session header surfaces `*(program: <name>, id: <uuid>)*` for sessions that belong to a cycle — pass that `id` straight to `get_program_details` to chain into the program structure. Sessions without a cycle (legacy data) omit the annotation. |
 | "How am I doing / volume / PRs / muscle group balance / push-pull split" | `get_training_stats` | Defaults to last 30 days. Filter by `muscle_group` (FR name, e.g. `Pectoraux`, `Dos`). |
 | "What's my next workout / what's programmed for tomorrow" | `get_upcoming_workouts` | Default 3 days, max 7. Returns `No active program found` if user has none. The header surfaces `*(id: <uuid>)*` of the active program — pass that `id` straight to `get_program_details` if the user wants the full template instead of the next few scheduled days. |
-| "Find / search exercises for X muscle / with Y equipment" | `search_exercises` | FR + EN names. Use **before** `get_exercise_details` to resolve a UUID. Aliases: `chest`/`pecs` → `Pectoraux`, body regions like `push`/`pull`/`legs`/`core`/`upper_body`/`lower_body` work too. |
-| "Tell me more about exercise X / how to do X" | `get_exercise_details` | Requires a UUID (`exercise_id`). **Always run `search_exercises` first** to resolve it; if multiple matches come back, ask the user to pick. |
+| "Find / search exercises for X muscle / with Y equipment" | `search_exercises` | FR + EN names. Use for exploration / browsing by filter. For "I already know the name(s) I want to put in a program" prefer `resolve_exercises` (one round-trip, returns everything `create_program` needs). Aliases: `chest`/`pecs` → `Pectoraux`, body regions like `push`/`pull`/`legs`/`core`/`upper_body`/`lower_body` work too. |
+| "I have a list of exercise names — give me their catalog ids" / "build a program from this list" | `resolve_exercises` | Batch (up to 30 names per call). Returns id, equipment, `weight_convention`, `measurement_type`, `default_duration_seconds` per query — enough to call `create_program` directly without `get_exercise_details`. Each query gets a status: `matched` / `ambiguous` / `no_match` / `empty_query`. On `ambiguous`, pick from context or ask the user; on `no_match`, fall back to `search_exercises` with broader filters. |
+| "Tell me more about exercise X / how to do X" | `get_exercise_details` | Requires a UUID (`exercise_id`). For exploring an exercise the user is curious about (instructions, video, common mistakes). **Not** needed before `create_program` — `resolve_exercises` already returns what `create_program` needs. |
 | "List / browse the user's training programs" | `list_programs` | Returns id, name, is_active, day_count, created_at, has_active_cycle for every non-archived program. Pass `include_archived: true` to see archived ones. Works regardless of cycle state — use to enumerate programs before drilling into one. |
 | "Show me the structure of program X / review my draft / what's in this program" | `get_program_details` | Requires a UUID (`program_id`). Returns the full structure (days + exercises with sets/reps/weights/rest). Works on **any** program — active, draft, or archived. **Always run `list_programs` first** to resolve the UUID, or use the `program_id` surfaced by `get_upcoming_workouts` / `get_workout_history`. |
 | "Design / save / replace my program" | `create_program` | Multi-day. **`dry_run` defaults to `true`** — preview first, then re-call with `dry_run: false` to persist. Deactivates other active programs. |

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -14,7 +14,7 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!
 const MCP_URL = `${SUPABASE_URL}/functions/v1/mcp`
 const AUTH_ISSUER = `${SUPABASE_URL}/auth/v1`
 
-const SERVER_INFO = { name: "gymlogic", version: "0.4.0" }
+const SERVER_INFO = { name: "gymlogic", version: "0.5.0" }
 const PROTOCOL_VERSION = "2025-03-26"
 
 function ok(id: string | number | null, result: unknown) {

--- a/supabase/functions/mcp/lib/assembleResolution.test.ts
+++ b/supabase/functions/mcp/lib/assembleResolution.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest"
+import {
+  assembleResolutionResults,
+  type ResolveBatchRow,
+} from "./assembleResolution"
+
+function makeRow(overrides: Partial<ResolveBatchRow> = {}): ResolveBatchRow {
+  return {
+    query_idx: 0,
+    query_text: "bench press",
+    exercise_id: "11111111-1111-4111-8111-111111111111",
+    name: "Développé couché",
+    name_en: "Bench press",
+    muscle_group: "Pectoraux",
+    equipment: "barbell",
+    measurement_type: "reps",
+    default_duration_seconds: null,
+    score: 0.85,
+    ...overrides,
+  }
+}
+
+describe("assembleResolutionResults", () => {
+  it("returns an empty array when no queries were provided", () => {
+    expect(assembleResolutionResults([], [])).toEqual([])
+  })
+
+  it("when top-1 clearly beats top-2 (gap >> threshold), keeps only the winner in matches", () => {
+    // Two candidates returned by RPC for the same query, top-1 score 1.0,
+    // top-2 score 0.5 → gap 0.5, well above default threshold 0.10.
+    // Status is "matched" and the agent should not see the runner-up:
+    // it'd just be noise that nudges the model to second-guess.
+    const queries = ["bench press"]
+    const rows = [
+      makeRow({ exercise_id: "11111111-1111-4111-8111-111111111111", score: 1.0 }),
+      makeRow({ exercise_id: "22222222-2222-4222-8222-222222222222", score: 0.5 }),
+    ]
+
+    const results = assembleResolutionResults(queries, rows)
+
+    expect(results[0].status).toBe("matched")
+    expect(results[0].matches).toHaveLength(1)
+    expect(results[0].matches[0].id).toBe("11111111-1111-4111-8111-111111111111")
+  })
+
+  it("when top-1 and top-2 are close (gap < threshold), marks the query 'ambiguous' and returns both", () => {
+    // top-1 = 0.80, top-2 = 0.75 → gap 0.05 < 0.10 → ambiguous;
+    // the agent needs both to either disambiguate from context or ask the user.
+    const queries = ["press"]
+    const rows = [
+      makeRow({ exercise_id: "11111111-1111-4111-8111-111111111111", score: 0.8 }),
+      makeRow({ exercise_id: "22222222-2222-4222-8222-222222222222", score: 0.75 }),
+    ]
+
+    const results = assembleResolutionResults(queries, rows)
+
+    expect(results[0].status).toBe("ambiguous")
+    expect(results[0].matches.map((m) => m.id)).toEqual([
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+    ])
+  })
+
+  it("when ambiguous, includes all rows the RPC returned (up to top-3) so the agent can pick", () => {
+    // Three close candidates — verifies we don't accidentally cap at top-2
+    // when the RPC gave us three. The SQL already enforces LIMIT 3 per query.
+    const queries = ["press"]
+    const rows = [
+      makeRow({ exercise_id: "11111111-1111-4111-8111-111111111111", score: 0.8 }),
+      makeRow({ exercise_id: "22222222-2222-4222-8222-222222222222", score: 0.75 }),
+      makeRow({ exercise_id: "33333333-3333-4333-8333-333333333333", score: 0.72 }),
+    ]
+
+    const results = assembleResolutionResults(queries, rows)
+
+    expect(results[0].status).toBe("ambiguous")
+    expect(results[0].matches).toHaveLength(3)
+  })
+
+  it("derives weight_convention from each match's equipment (not from the table — it isn't a column)", () => {
+    // Single sanity check that we correctly invoke formatWeightConvention.
+    // Exhaustive equipment→convention coverage lives in lib/format.test.ts (T73).
+    const queries = ["dumbbell row"]
+    const rows = [makeRow({ equipment: "dumbbell" })]
+
+    const results = assembleResolutionResults(queries, rows)
+
+    expect(results[0].matches[0].weight_convention).toBe("per_hand")
+    expect(results[0].matches[0].equipment).toBe("dumbbell") // raw column still passed through
+  })
+
+  it("preserves INPUT order even when the RPC returns rows for query_idx out of order", () => {
+    // The Tech Plan flagged this footgun: the SQL emits rows ordered first by
+    // the FOR loop iteration, then by the inner ORDER BY — but a future schema
+    // change (e.g. wrapping in a CTE + final ORDER BY) could shuffle them.
+    // The helper must rely on query_idx, NOT row arrival order.
+    const queries = ["bench", "squat"]
+    const rows = [
+      // Rows for the SECOND query (idx 1) arrive first
+      makeRow({
+        query_idx: 1,
+        query_text: "squat",
+        exercise_id: "22222222-2222-4222-8222-222222222222",
+        name: "Squat",
+        score: 0.9,
+      }),
+      // Then the row for the FIRST query (idx 0)
+      makeRow({
+        query_idx: 0,
+        query_text: "bench",
+        exercise_id: "11111111-1111-4111-8111-111111111111",
+        name: "Bench",
+        score: 0.9,
+      }),
+    ]
+
+    const results = assembleResolutionResults(queries, rows)
+
+    expect(results.map((r) => r.query)).toEqual(["bench", "squat"])
+    expect(results[0].matches[0].id).toBe("11111111-1111-4111-8111-111111111111")
+    expect(results[1].matches[0].id).toBe("22222222-2222-4222-8222-222222222222")
+  })
+
+  it("when the original query was empty/whitespace, marks it 'empty_query' even though the RPC returned no rows", () => {
+    // The SQL CONTINUEs on whitespace queries → zero rows for that query_idx,
+    // same shape as no_match. The helper must distinguish based on the ORIGINAL
+    // query string so the agent gets a useful error category, not a false "no_match".
+    const queries = ["   "]
+    const rows: ResolveBatchRow[] = []
+
+    const results = assembleResolutionResults(queries, rows)
+
+    expect(results[0].status).toBe("empty_query")
+    expect(results[0].matches).toEqual([])
+  })
+
+  it("when the RPC returned no rows for a non-empty query, marks it 'no_match' with empty matches", () => {
+    const queries = ["xqzkblargh"]
+    const rows: ResolveBatchRow[] = []
+
+    const results = assembleResolutionResults(queries, rows)
+
+    expect(results[0].status).toBe("no_match")
+    expect(results[0].matches).toEqual([])
+  })
+
+  it("flags a single-row response as 'matched' and returns just that match", () => {
+    const queries = ["bench press"]
+    const rows = [makeRow()]
+
+    const results = assembleResolutionResults(queries, rows)
+
+    expect(results).toHaveLength(1)
+    expect(results[0].query).toBe("bench press")
+    expect(results[0].status).toBe("matched")
+    expect(results[0].matches).toHaveLength(1)
+    expect(results[0].matches[0].id).toBe("11111111-1111-4111-8111-111111111111")
+  })
+})

--- a/supabase/functions/mcp/lib/assembleResolution.ts
+++ b/supabase/functions/mcp/lib/assembleResolution.ts
@@ -1,0 +1,89 @@
+/**
+ * Assembles per-query resolution results from the flat row stream returned by
+ * the `resolve_exercises_batch` Postgres RPC (see
+ * `supabase/migrations/20260506000736_resolve_exercises_batch.sql`).
+ *
+ * Pure function — input: original queries + RPC rows; output: one
+ * ResolvedQuery per input position, in input order, with status verdict.
+ *
+ * Status verdict (per-query):
+ *   - "empty_query"  → query was whitespace/empty (RPC skipped it)
+ *   - "no_match"     → RPC returned zero rows
+ *   - "ambiguous"    → top-2 score gap is below threshold (see lib/scoreGap.ts)
+ *   - "matched"      → otherwise (single match OR clear winner)
+ *
+ * `weight_convention` is derived from `equipment` via formatWeightConvention
+ * (see `lib/format.ts`) — it is NOT a column on the exercises table.
+ */
+
+import { isAmbiguous } from "./scoreGap.ts"
+import { formatWeightConvention, type WeightConvention } from "./format.ts"
+
+export type ResolutionStatus = "matched" | "ambiguous" | "no_match" | "empty_query"
+
+export interface ResolveBatchRow {
+  query_idx: number
+  query_text: string
+  exercise_id: string
+  name: string
+  name_en: string | null
+  muscle_group: string
+  equipment: string
+  measurement_type: string
+  default_duration_seconds: number | null
+  score: number
+}
+
+export interface ResolvedExercise {
+  id: string
+  name: string
+  name_en: string | null
+  muscle_group: string
+  equipment: string
+  measurement_type: string
+  default_duration_seconds: number | null
+  weight_convention: WeightConvention
+  score: number
+}
+
+export interface ResolvedQuery {
+  query: string
+  status: ResolutionStatus
+  matches: ResolvedExercise[]
+}
+
+export function assembleResolutionResults(
+  queries: string[],
+  rows: ResolveBatchRow[],
+  gap?: number,
+): ResolvedQuery[] {
+  return queries.map((query, idx) => {
+    if (query.trim().length === 0) {
+      return { query, status: "empty_query" as ResolutionStatus, matches: [] }
+    }
+    const allMatches = rows
+      .filter((r) => r.query_idx === idx)
+      .map(toResolvedExercise)
+    if (allMatches.length === 0) {
+      return { query, status: "no_match" as ResolutionStatus, matches: [] }
+    }
+    const ambiguous = isAmbiguous(allMatches, gap)
+    const matches = ambiguous ? allMatches : allMatches.slice(0, 1)
+    const status: ResolutionStatus = ambiguous ? "ambiguous" : "matched"
+    return { query, status, matches }
+  })
+}
+
+function toResolvedExercise(row: ResolveBatchRow): ResolvedExercise {
+  return {
+    id: row.exercise_id,
+    name: row.name,
+    name_en: row.name_en,
+    muscle_group: row.muscle_group,
+    equipment: row.equipment,
+    measurement_type: row.measurement_type,
+    default_duration_seconds: row.default_duration_seconds,
+    weight_convention: formatWeightConvention(row.equipment),
+    score: row.score,
+  }
+}

--- a/supabase/functions/mcp/lib/scoreGap.test.ts
+++ b/supabase/functions/mcp/lib/scoreGap.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+import { DEFAULT_AMBIGUITY_GAP, isAmbiguous, resolveAmbiguityGap } from "./scoreGap"
+
+describe("isAmbiguous", () => {
+  it("returns false when there are no matches (nothing to compare)", () => {
+    expect(isAmbiguous([])).toBe(false)
+  })
+
+  it("returns false when there is a single match (no runner-up to compete)", () => {
+    expect(isAmbiguous([{ score: 0.5 }])).toBe(false)
+  })
+
+  it("returns true when the gap between top-1 and top-2 is below the default threshold", () => {
+    // top-1 = 0.80, top-2 = 0.75 → gap 0.05 < 0.10 → ambiguous
+    expect(isAmbiguous([{ score: 0.8 }, { score: 0.75 }])).toBe(true)
+  })
+
+  it("is NaN-safe — returns false when scores are NaN (defensive: no crash, no false-ambiguous)", () => {
+    expect(isAmbiguous([{ score: NaN }, { score: NaN }])).toBe(false)
+    expect(isAmbiguous([{ score: 0.5 }, { score: NaN }])).toBe(false)
+  })
+
+  it("returns false when the gap clearly exceeds the default threshold", () => {
+    // top-1 = 1.00, top-2 = 0.50 → gap 0.50 (well above 0.10) → not ambiguous.
+    // Boundary-at-exactly-0.10 is intentionally NOT tested: float subtraction
+    // (e.g. 0.9 - 0.8 = 0.0999999...) makes "exactly at threshold" semantically
+    // ill-defined for similarity scores. The behaviour we care about is "clearly
+    // close" vs "clearly apart"; the boundary itself is a noise zone.
+    expect(isAmbiguous([{ score: 1.0 }, { score: 0.5 }])).toBe(false)
+  })
+
+  it("considers only the top-2 — a close third match doesn't make a clearly-separated top-2 pair ambiguous", () => {
+    // top-1 = 1.0, top-2 = 0.5 (gap 0.5, NOT ambiguous), top-3 = 0.45 (close to top-2)
+    // The top-3 closeness must NOT influence the verdict — only top-1 vs top-2 matters.
+    expect(isAmbiguous([{ score: 1.0 }, { score: 0.5 }, { score: 0.45 }])).toBe(false)
+  })
+
+  it("honors a custom gap when provided (env-overridden threshold path)", () => {
+    // Gap 0.05 between scores: ambiguous under default (0.10), NOT ambiguous under
+    // a tighter threshold (0.01) — verifies the override propagates and the
+    // strict `<` semantics still hold.
+    const matches = [{ score: 0.8 }, { score: 0.75 }]
+    expect(isAmbiguous(matches)).toBe(true) // default 0.10
+    expect(isAmbiguous(matches, 0.01)).toBe(false) // tighter override
+  })
+})
+
+describe("resolveAmbiguityGap", () => {
+  it("returns the default gap when the env value is undefined (env var not set)", () => {
+    expect(resolveAmbiguityGap(undefined)).toBe(DEFAULT_AMBIGUITY_GAP)
+  })
+
+  it("returns the parsed float when the env value is a valid number in (0, 1]", () => {
+    expect(resolveAmbiguityGap("0.05")).toBe(0.05)
+    expect(resolveAmbiguityGap("0.25")).toBe(0.25)
+    expect(resolveAmbiguityGap("1")).toBe(1)
+  })
+
+  it("falls back to default for invalid inputs (empty, null, non-numeric, out-of-range)", () => {
+    // Each case represents a real misconfiguration mode we'd rather absorb
+    // silently than crash the handler on. Default is the safe fallback.
+    expect(resolveAmbiguityGap("")).toBe(DEFAULT_AMBIGUITY_GAP)
+    expect(resolveAmbiguityGap(null)).toBe(DEFAULT_AMBIGUITY_GAP)
+    expect(resolveAmbiguityGap("abc")).toBe(DEFAULT_AMBIGUITY_GAP)
+    expect(resolveAmbiguityGap("0")).toBe(DEFAULT_AMBIGUITY_GAP) // boundary: must be > 0
+    expect(resolveAmbiguityGap("-0.1")).toBe(DEFAULT_AMBIGUITY_GAP)
+    expect(resolveAmbiguityGap("1.5")).toBe(DEFAULT_AMBIGUITY_GAP) // > 1 makes no sense for a score gap
+    expect(resolveAmbiguityGap("NaN")).toBe(DEFAULT_AMBIGUITY_GAP)
+  })
+})

--- a/supabase/functions/mcp/lib/scoreGap.ts
+++ b/supabase/functions/mcp/lib/scoreGap.ts
@@ -1,0 +1,45 @@
+/**
+ * Score-gap ambiguity helper for `resolve_exercises`.
+ *
+ * Pure functions, no env access — the handler boundary in
+ * `tools/resolveExercises.ts` reads `Deno.env` once and passes the parsed
+ * gap through `resolveAmbiguityGap`, mirroring the `lib/pat.ts`
+ * "no-Deno-in-lib" convention so tests don't need to fake `Deno.env`.
+ */
+
+export const DEFAULT_AMBIGUITY_GAP = 0.1
+
+export function isAmbiguous(
+  matches: { score: number }[],
+  gap: number = DEFAULT_AMBIGUITY_GAP,
+): boolean {
+  if (matches.length < 2) return false
+  return matches[0].score - matches[1].score < gap
+}
+
+/**
+ * Parse the raw `MCP_AMBIGUITY_GAP` env value into a usable threshold.
+ *
+ * The handler boundary (`tools/resolveExercises.ts`) is the only place that
+ * touches `Deno.env`; this stays pure to keep the lib trivially testable.
+ *
+ * Falls back to `DEFAULT_AMBIGUITY_GAP` for: unset, empty, non-numeric, or
+ * out-of-range `(0, 1]`. Permissive on whitespace.
+ *
+ * TUNING: production traces should distinguish "false-ambiguous rate"
+ * (status=ambiguous on names that turned out to have one obvious match) from
+ * "false-confident rate" (status=matched on names where the agent had to
+ * retry / asked the user). Lower the env to widen the ambiguous net,
+ * raise it to silence false-ambiguous flags. Default 0.10 is a starter bet
+ * informed only by the existing pg_trgm similarity floor (0.15) used by
+ * search_exercises.
+ */
+export function resolveAmbiguityGap(
+  envValue: string | null | undefined,
+): number {
+  if (envValue == null) return DEFAULT_AMBIGUITY_GAP
+  const parsed = parseFloat(envValue)
+  if (!Number.isFinite(parsed)) return DEFAULT_AMBIGUITY_GAP
+  if (parsed <= 0 || parsed > 1) return DEFAULT_AMBIGUITY_GAP
+  return parsed
+}

--- a/supabase/functions/mcp/tools/createProgram.ts
+++ b/supabase/functions/mcp/tools/createProgram.ts
@@ -107,7 +107,7 @@ Reps formats:
   - "8"     → linear progression (rep_range frozen at 8/8). Weight bumps when target hit.
   - "8-12"  → double progression (rep_range frozen at 8/12). Reps grow first, then weight bumps and reps reset.
 
-Weight conventions: per_hand for dumbbells/kettlebells, total for barbells/machines/cables. Call \`get_exercise_details\` first to confirm the convention (\`weight_convention\` field). Bodyweight exercises must use weight_kg=0; weighted bodyweight (weighted dips/pull-ups) is tracked in #281.
+Weight conventions: per_hand for dumbbells/kettlebells, total for barbells/machines/cables. Use \`resolve_exercises\` first to get UUIDs + the \`weight_convention\` field for each exercise in one call — no need to follow up with \`get_exercise_details\` per exercise. Bodyweight exercises must use weight_kg=0; weighted bodyweight (weighted dips/pull-ups) is tracked in #281.
 
 Bounds: sets [1,10], reps [1,50] for reps exercises (use "0" ONLY for duration exercises, paired with target_duration_seconds), weight_kg [0,500], rest_seconds [0,600], target_duration_seconds [5,600].
 
@@ -151,7 +151,7 @@ export const createProgram: ToolDefinition = {
                     properties: {
                       exercise_id: {
                         type: "string",
-                        description: "UUID from search_exercises / get_exercise_details.",
+                        description: "UUID from `resolve_exercises` (preferred for batch program-building) or `search_exercises`.",
                       },
                       sets: {
                         type: "integer",
@@ -168,7 +168,7 @@ export const createProgram: ToolDefinition = {
                         type: "number",
                         minimum: 0,
                         maximum: 500,
-                        description: "Working weight per set. Per hand for dumbbells/kettlebells, total for barbells/machines (see get_exercise_details).",
+                        description: "Working weight per set. Per hand for dumbbells/kettlebells, total for barbells/machines (see `weight_convention` returned by `resolve_exercises`).",
                       },
                       rest_seconds: {
                         type: "integer",

--- a/supabase/functions/mcp/tools/getExerciseDetails.ts
+++ b/supabase/functions/mcp/tools/getExerciseDetails.ts
@@ -73,15 +73,18 @@ export const getExerciseDetails: ToolDefinition = {
   description:
     "Get full details for ONE exercise by its UUID. Returns instructions (setup, movement, " +
     "breathing, common mistakes), muscle targets, equipment, difficulty, and media links. " +
-    "You MUST call search_exercises first to obtain the exercise_id. " +
-    "search_exercises only returns the ID when there is a single match — if multiple results " +
-    "come back, present the list to the user and let them pick before searching again.",
+    "Use this when the user wants to LEARN about a specific exercise (form cues, video, " +
+    "common mistakes) — NOT when building a program. " +
+    "**To obtain the UUID, prefer `resolve_exercises` (one batch call by name, also bundles " +
+    "`weight_convention` / `measurement_type` / `default_duration_seconds` if you go on to " +
+    "`create_program` / `update_program`). Use `search_exercises` only when browsing the " +
+    "catalog by filter without a specific name in mind.**",
   inputSchema: {
     type: "object",
     properties: {
       exercise_id: {
         type: "string",
-        description: "UUID of the exercise. Obtain this from search_exercises (only provided for single-match results).",
+        description: "UUID of the exercise. Obtain it from `resolve_exercises` (preferred — by name) or `search_exercises` (when browsing by filter).",
       },
     },
     required: ["exercise_id"],
@@ -99,14 +102,14 @@ export const getExerciseDetails: ToolDefinition = {
 
     if (!exerciseId) {
       return {
-        content: [{ type: "text", text: "exercise_id is required. Use search_exercises first to find the UUID." }],
+        content: [{ type: "text", text: "exercise_id is required. Use `resolve_exercises` (by name, preferred) or `search_exercises` (browse by filter) to find the UUID." }],
         isError: true,
       }
     }
 
     if (!UUID_RE.test(exerciseId)) {
       return {
-        content: [{ type: "text", text: `Invalid exercise_id format: "${exerciseId}". Expected a UUID — use search_exercises to find it.` }],
+        content: [{ type: "text", text: `Invalid exercise_id format: "${exerciseId}". Expected a UUID — use \`resolve_exercises\` (by name) or \`search_exercises\` (browse) to find it.` }],
         isError: true,
       }
     }
@@ -119,7 +122,7 @@ export const getExerciseDetails: ToolDefinition = {
 
     if (error || !data) {
       return {
-        content: [{ type: "text", text: `Exercise not found (id: ${exerciseId}). Try search_exercises to find the right one.` }],
+        content: [{ type: "text", text: `Exercise not found (id: ${exerciseId}). Try \`resolve_exercises\` with the name, or \`search_exercises\` to browse by filter.` }],
         isError: true,
       }
     }

--- a/supabase/functions/mcp/tools/registry.ts
+++ b/supabase/functions/mcp/tools/registry.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.103.3"
 import { searchExercises } from "./searchExercises.ts"
+import { resolveExercises } from "./resolveExercises.ts"
 import { getExerciseDetails } from "./getExerciseDetails.ts"
 import { getWorkoutHistory } from "./getWorkoutHistory.ts"
 import { getTrainingStats } from "./getTrainingStats.ts"
@@ -25,6 +26,7 @@ export interface ToolDefinition {
 
 const tools: ToolDefinition[] = [
   searchExercises,
+  resolveExercises,
   getExerciseDetails,
   getWorkoutHistory,
   getTrainingStats,

--- a/supabase/functions/mcp/tools/resolveExercises.ts
+++ b/supabase/functions/mcp/tools/resolveExercises.ts
@@ -1,0 +1,143 @@
+import {
+  assembleResolutionResults,
+  type ResolvedExercise,
+  type ResolvedQuery,
+  type ResolveBatchRow,
+} from "../lib/assembleResolution.ts"
+import { resolveAmbiguityGap } from "../lib/scoreGap.ts"
+import type { ToolDefinition } from "./registry.ts"
+
+const MAX_BATCH_SIZE = 30
+
+const TOOL_DESCRIPTION =
+  "Resolve a batch of exercise names to catalog UUIDs in ONE round-trip. " +
+  "Prefer this over `search_exercises` when you already know the names you want " +
+  "(e.g. when building a program from a user request like \"bench press, squat, " +
+  "overhead press\"). Returns the matched exercise plus everything needed to call " +
+  "`create_program` (id, equipment, weight_convention, measurement_type, " +
+  "default_duration_seconds), so you do NOT need to follow up with " +
+  "`get_exercise_details` for these. " +
+  "Each query yields one of four statuses: " +
+  "\"matched\" (single clear winner), " +
+  "\"ambiguous\" (top results are close — pick one or ask the user), " +
+  "\"no_match\" (nothing similar enough — try search_exercises with broader filters), " +
+  "\"empty_query\" (whitespace-only input)."
+
+export const resolveExercises: ToolDefinition = {
+  name: "resolve_exercises",
+  description: TOOL_DESCRIPTION,
+  inputSchema: {
+    type: "object",
+    properties: {
+      queries: {
+        type: "array",
+        items: { type: "string" },
+        minItems: 1,
+        maxItems: MAX_BATCH_SIZE,
+        description:
+          `Up to ${MAX_BATCH_SIZE} exercise names (free-text, French or English, ` +
+          "diacritic-insensitive). Each is resolved to its top catalog match plus " +
+          "alternates if scores are close.",
+      },
+    },
+    required: ["queries"],
+  },
+
+  async handler(args, supabase) {
+    if (!supabase) {
+      return {
+        content: [{ type: "text", text: "Authentication required — please provide a valid Bearer token." }],
+        isError: true,
+      }
+    }
+
+    const queries = args.queries
+    if (!Array.isArray(queries) || queries.length === 0) {
+      return {
+        content: [{
+          type: "text",
+          text: "queries must be a non-empty array of exercise names. Example: { \"queries\": [\"bench press\", \"squat\"] }.",
+        }],
+        isError: true,
+      }
+    }
+    if (queries.length > MAX_BATCH_SIZE) {
+      return {
+        content: [{
+          type: "text",
+          text: `Too many queries (${queries.length}). Maximum is ${MAX_BATCH_SIZE} per call — split your request.`,
+        }],
+        isError: true,
+      }
+    }
+    if (!queries.every((q) => typeof q === "string")) {
+      return {
+        content: [{
+          type: "text",
+          text: "Every queries[] entry must be a string. Example: { \"queries\": [\"bench press\", \"squat\"] }.",
+        }],
+        isError: true,
+      }
+    }
+
+    const gap = resolveAmbiguityGap(Deno.env.get("MCP_AMBIGUITY_GAP"))
+
+    const { data, error } = await supabase.rpc("resolve_exercises_batch", { queries })
+
+    if (error) {
+      return {
+        content: [{ type: "text", text: `Error resolving exercises: ${error.message}` }],
+        isError: true,
+      }
+    }
+
+    const rows = (data ?? []) as ResolveBatchRow[]
+    const results = assembleResolutionResults(queries, rows, gap)
+
+    return { content: [{ type: "text", text: formatResolutionResults(results) }] }
+  },
+}
+
+function formatResolutionResults(results: ResolvedQuery[]): string {
+  const sections = results.map(formatResolvedQuery).join("\n\n")
+  const summary = summarizeStatuses(results)
+  const footer =
+    "\n\n_Use the ids above directly with `create_program`. " +
+    "No need to call `search_exercises` or `get_exercise_details` for these — " +
+    "`weight_convention`, `measurement_type` and `default_duration_seconds` are already included._"
+  return `Resolved ${results.length} ${results.length === 1 ? "query" : "queries"} (${summary}):\n\n${sections}${footer}`
+}
+
+function summarizeStatuses(results: ResolvedQuery[]): string {
+  const counts = results.reduce<Record<string, number>>((acc, r) => {
+    acc[r.status] = (acc[r.status] ?? 0) + 1
+    return acc
+  }, {})
+  return Object.entries(counts)
+    .map(([status, count]) => `${count} ${status}`)
+    .join(", ")
+}
+
+function formatResolvedQuery(r: ResolvedQuery): string {
+  const header = `## "${r.query}" → ${r.status}`
+  if (r.status === "no_match") {
+    return `${header}\n- No catalog match. Try \`search_exercises\` with broader filters or check spelling.`
+  }
+  if (r.status === "empty_query") {
+    return `${header}\n- Empty/whitespace query — skipped.`
+  }
+  return `${header}\n${r.matches.map(formatMatch).join("\n")}`
+}
+
+function formatMatch(m: ResolvedExercise): string {
+  const nameLine = m.name_en ? `**${m.name}** (${m.name_en})` : `**${m.name}**`
+  const meta = [
+    m.muscle_group,
+    m.equipment,
+    `weight_convention: ${m.weight_convention}`,
+    m.measurement_type === "duration"
+      ? `duration${m.default_duration_seconds ? ` (${m.default_duration_seconds}s default)` : ""}`
+      : "reps",
+  ].join(" | ")
+  return `- ${nameLine} — ${meta}\n  - id: ${m.id} | score: ${m.score.toFixed(2)}`
+}

--- a/supabase/functions/mcp/tools/searchExercises.ts
+++ b/supabase/functions/mcp/tools/searchExercises.ts
@@ -78,9 +78,14 @@ function resolveMuscleGroups(input: string | string[]): string[] | undefined {
 export const searchExercises: ToolDefinition = {
   name: "search_exercises",
   description:
-    "Search the exercise catalog by name, muscle group, equipment, or difficulty. " +
-    "Supports fuzzy matching and diacritic-insensitive search in both French and English. " +
-    "Use this to find exercises before getting full details with get_exercise_details.",
+    "Browse the exercise catalog by muscle group, equipment, or difficulty filters. " +
+    "Supports fuzzy and diacritic-insensitive search in both French and English. " +
+    "Use this when you don't yet have specific names in mind — e.g. \"find chest exercises with dumbbells\", " +
+    "\"what's a good biceps exercise\". " +
+    "**If you already know the exercise names you want (e.g. building a program from a list), use " +
+    "`resolve_exercises` instead — it batch-resolves names to UUIDs in a single call and bundles the " +
+    "catalog metadata (`weight_convention`, `measurement_type`, `default_duration_seconds`) you'll need " +
+    "for `create_program` / `update_program`, with no follow-up `get_exercise_details` per exercise.**",
   inputSchema: {
     type: "object",
     properties: {

--- a/supabase/migrations/20260506000736_resolve_exercises_batch.sql
+++ b/supabase/migrations/20260506000736_resolve_exercises_batch.sql
@@ -1,0 +1,98 @@
+-- resolve_exercises_batch — batch fuzzy/substring resolution for the MCP
+-- `resolve_exercises` tool. Implements the "one round-trip per program" goal
+-- of issue #310 (Epic Brief / Tech Plan: docs/Tech_Plan_—_MCP_—_Batch_Exercise_Resolution_#310.md).
+--
+-- This RPC mirrors the ranking strategy of search_exercises (see
+-- `supabase/migrations/20260326120000_search_exercises.sql`) — substring
+-- matches first, then pg_trgm similarity DESC, with the same 0.15 similarity
+-- floor. Differences:
+--   • Accepts an array of queries; iterates server-side, one trip total.
+--   • Returns top-3 per query (the score-gap rule in `lib/scoreGap.ts`
+--     decides ambiguous vs matched on the JS side).
+--   • Returns equipment (raw column) — the handler derives `weight_convention`
+--     via `formatWeightConvention()` (see T73 / `lib/format.ts`).
+--   • Empty/whitespace queries yield zero rows for that query_idx; the
+--     handler maps that to status="empty_query".
+--
+-- Extensions (pg_trgm, unaccent) are already enabled by the search_exercises
+-- migration; no need to re-create them here.
+--
+-- KNOWN LIMITATION: input array length is not capped at the SQL layer.
+-- The handler enforces a batch size limit (defined in the tool descriptor)
+-- so abusive callers cannot DoS the function with thousands of queries.
+
+CREATE OR REPLACE FUNCTION resolve_exercises_batch(
+  queries text[]
+)
+RETURNS TABLE (
+  query_idx                int,
+  query_text               text,
+  exercise_id              uuid,
+  name                     text,
+  name_en                  text,
+  muscle_group             text,
+  equipment                text,
+  measurement_type         text,
+  default_duration_seconds int,
+  score                    real
+)
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+AS $$
+DECLARE
+  q_raw  text;
+  q_norm text;
+  qi     int;
+BEGIN
+  IF queries IS NULL OR array_length(queries, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  FOR qi IN 1..array_length(queries, 1) LOOP
+    q_raw  := queries[qi];
+    q_norm := trim(lower(extensions.unaccent(coalesce(q_raw, ''))));
+
+    -- Empty/whitespace queries return zero rows for this query_idx;
+    -- the Edge Function maps absence to status="empty_query".
+    IF length(q_norm) = 0 THEN
+      CONTINUE;
+    END IF;
+
+    RETURN QUERY
+      SELECT
+        qi - 1                                                AS query_idx,
+        q_raw                                                 AS query_text,
+        e.id                                                  AS exercise_id,
+        e.name,
+        e.name_en,
+        e.muscle_group,
+        e.equipment,
+        e.measurement_type::text,
+        e.default_duration_seconds,
+        GREATEST(
+          similarity(extensions.unaccent(lower(e.name)), q_norm),
+          similarity(extensions.unaccent(lower(coalesce(e.name_en, ''))), q_norm)
+        )::real                                               AS score
+      FROM exercises e
+      WHERE
+        extensions.unaccent(lower(e.name)) ILIKE '%' || q_norm || '%'
+        OR extensions.unaccent(lower(coalesce(e.name_en, ''))) ILIKE '%' || q_norm || '%'
+        OR similarity(extensions.unaccent(lower(e.name)), q_norm) > 0.15
+        OR similarity(extensions.unaccent(lower(coalesce(e.name_en, ''))), q_norm) > 0.15
+      ORDER BY
+        CASE
+          WHEN extensions.unaccent(lower(e.name)) ILIKE '%' || q_norm || '%' THEN 0
+          WHEN extensions.unaccent(lower(coalesce(e.name_en, ''))) ILIKE '%' || q_norm || '%' THEN 1
+          ELSE 2
+        END,
+        GREATEST(
+          similarity(extensions.unaccent(lower(e.name)), q_norm),
+          similarity(extensions.unaccent(lower(coalesce(e.name_en, ''))), q_norm)
+        ) DESC,
+        e.name,
+        e.id
+      LIMIT 3;
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.resolve_exercises_batch(text[]) TO authenticated;

--- a/supabase/migrations/20260506004927_resolve_exercises_batch_cap_size.sql
+++ b/supabase/migrations/20260506004927_resolve_exercises_batch_cap_size.sql
@@ -1,0 +1,98 @@
+-- Cap resolve_exercises_batch input array size at the SQL layer to prevent
+-- direct-RPC DoS abuse. Caught by Copilot review on PR #319 (issue #310).
+--
+-- Rationale: the original migration (20260506000736_resolve_exercises_batch.sql)
+-- relied on the Edge Function's MAX_BATCH_SIZE = 30 check in
+-- `tools/resolveExercises.ts` to bound the per-call cost. But the function is
+-- granted EXECUTE to `authenticated`, which means any client with a valid JWT
+-- can call it directly via PostgREST (POST /rest/v1/rpc/resolve_exercises_batch)
+-- and skip the Edge Function entirely — passing an arbitrarily large array
+-- and forcing the inner FOR loop to run that many times.
+--
+-- Defence in depth: enforce the same 30-element cap inside the function body.
+-- Keep the cap value identical to MAX_BATCH_SIZE in resolveExercises.ts;
+-- bump both together if we ever raise the limit.
+--
+-- This migration uses CREATE OR REPLACE FUNCTION with the same signature and
+-- body as the original, plus the IF guard at the top.
+
+CREATE OR REPLACE FUNCTION resolve_exercises_batch(
+  queries text[]
+)
+RETURNS TABLE (
+  query_idx                int,
+  query_text               text,
+  exercise_id              uuid,
+  name                     text,
+  name_en                  text,
+  muscle_group             text,
+  equipment                text,
+  measurement_type         text,
+  default_duration_seconds int,
+  score                    real
+)
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+AS $$
+DECLARE
+  q_raw  text;
+  q_norm text;
+  qi     int;
+BEGIN
+  IF queries IS NULL OR array_length(queries, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- Server-side batch cap (mirrors MAX_BATCH_SIZE in tools/resolveExercises.ts).
+  -- Direct PostgREST callers can't bypass this by skipping the Edge Function.
+  IF array_length(queries, 1) > 30 THEN
+    RAISE EXCEPTION 'queries array exceeds maximum size of 30 (got %)', array_length(queries, 1)
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  FOR qi IN 1..array_length(queries, 1) LOOP
+    q_raw  := queries[qi];
+    q_norm := trim(lower(extensions.unaccent(coalesce(q_raw, ''))));
+
+    -- Empty/whitespace queries return zero rows for this query_idx;
+    -- the Edge Function maps absence to status="empty_query".
+    IF length(q_norm) = 0 THEN
+      CONTINUE;
+    END IF;
+
+    RETURN QUERY
+      SELECT
+        qi - 1                                                AS query_idx,
+        q_raw                                                 AS query_text,
+        e.id                                                  AS exercise_id,
+        e.name,
+        e.name_en,
+        e.muscle_group,
+        e.equipment,
+        e.measurement_type::text,
+        e.default_duration_seconds,
+        GREATEST(
+          similarity(extensions.unaccent(lower(e.name)), q_norm),
+          similarity(extensions.unaccent(lower(coalesce(e.name_en, ''))), q_norm)
+        )::real                                               AS score
+      FROM exercises e
+      WHERE
+        extensions.unaccent(lower(e.name)) ILIKE '%' || q_norm || '%'
+        OR extensions.unaccent(lower(coalesce(e.name_en, ''))) ILIKE '%' || q_norm || '%'
+        OR similarity(extensions.unaccent(lower(e.name)), q_norm) > 0.15
+        OR similarity(extensions.unaccent(lower(coalesce(e.name_en, ''))), q_norm) > 0.15
+      ORDER BY
+        CASE
+          WHEN extensions.unaccent(lower(e.name)) ILIKE '%' || q_norm || '%' THEN 0
+          WHEN extensions.unaccent(lower(coalesce(e.name_en, ''))) ILIKE '%' || q_norm || '%' THEN 1
+          ELSE 2
+        END,
+        GREATEST(
+          similarity(extensions.unaccent(lower(e.name)), q_norm),
+          similarity(extensions.unaccent(lower(coalesce(e.name_en, ''))), q_norm)
+        ) DESC,
+        e.name,
+        e.id
+      LIMIT 3;
+  END LOOP;
+END;
+$$;


### PR DESCRIPTION
Closes #310

## What & Why

Building a multi-day program through the MCP used to cost ~3N tool calls (N × `search_exercises` to disambiguate names, plus N × `get_exercise_details` to fetch `weight_convention` for the prescription). For a 7-exercise program that's ~21 tool calls before any actual writing happens — flagged as an obvious perf cliff in #310. This PR ships a new `resolve_exercises` MCP tool that batch-resolves exercise names to UUIDs in **one** round-trip and returns enough catalog metadata that `create_program` / `update_program` no longer need any follow-up lookups. Net: program-build flow drops from `~3N` calls to `~3` total (1 resolve + 1 dry_run + 1 apply).

## Changes

### T98 — `resolve_exercises` capability (commit `71f74a5`)

- New Postgres RPC `resolve_exercises_batch(text[])` — single round-trip, mirrors the `search_exercises` ranking strategy (substring → `pg_trgm` similarity, 0.15 floor) with a per-query `LIMIT 3`.
- Two pure helpers built TDD-first (19 tests across 19 vertical slices):
  - `lib/scoreGap.ts` — `isAmbiguous` (top-2 score-gap rule, NaN-safe) + `resolveAmbiguityGap` (env parser with safe fallback). No `Deno.env` access — mirrors the `lib/pat.ts` "no-env-in-lib" boundary convention so tests don't fake env.
  - `lib/assembleResolution.ts` — per-query assembly from the flat RPC row stream: status verdict (`matched` / `ambiguous` / `no_match` / `empty_query`), input-order preservation regardless of RPC arrival order, `weight_convention` derived in TS via `formatWeightConvention()` (because `weight_convention` is NOT a column on `exercises` — derived from `equipment` per T73).
- Thin `tools/resolveExercises.ts` handler: input validation (30-batch cap, string-only entries) → RPC → assemble → markdown response. Matches the repo convention of "no handler tests; all logic in lib".
- Registered in `tools/registry.ts`, server bumped `0.4.0 → 0.5.0`, minimal tool-reference row added to SKILL.md (full agent steering deferred to T99).
- Threshold is env-tunable via `MCP_AMBIGUITY_GAP` (default `0.10`).

### T99 — Agent steering (commit `174a0f3`)

Tool-description and SKILL.md changes so agents actually reach for the new tool in the right contexts.

- `searchExercises.ts` description reframed as a BROWSE tool with explicit pointer to `resolve_exercises` for "I already know the names" flows.
- `createProgram.ts` `TOOL_DESCRIPTION` no longer instructs agents to call `get_exercise_details` first for `weight_convention`; points to `resolve_exercises` instead. Schema descriptions for `exercise_id` and `weight_kg` reworded for consistency.
- SKILL.md:
  - New "Catalog tools — which one when" decision table at the top of the Tool reference section, picking the right tool by **what the agent already knows**.
  - Pattern 3 (single exercise lookup) uses `resolve_exercises` before `get_exercise_details`.
  - Pattern 4 (program design) collapsed: one `resolve_exercises` call replaces the per-movement `search_exercises` + standalone `get_exercise_details` for `weight_convention` step. Numbering re-flowed.
  - Both `update_program` worked examples (add Cardio day, swap deadlift) collapsed N × `search_exercises` into one `resolve_exercises` batch.
  - Edge Cases table grew dedicated rows for `ambiguous` / `no_match` / `empty_query` statuses.

### Review feedback follow-ups

- `5d6bdc9` — **T99 omission caught by Copilot**: `getExerciseDetails.ts` still had four touchpoints (tool description, `exercise_id` schema description, three error messages on missing/invalid/not-found) that steered agents back to `search_exercises`. Without this fix, any UUID-validation error would undo the entire steering effort. All four touchpoints now point to `resolve_exercises` (preferred) with `search_exercises` as the browse fallback.
- `bc4bd53` — **DoS surface caught by Copilot**: the original migration's batch-size cap (`MAX_BATCH_SIZE = 30` in `tools/resolveExercises.ts`) is bypassable via direct PostgREST since the RPC is granted to `authenticated`. New migration (`20260506004927_resolve_exercises_batch_cap_size.sql`) does `CREATE OR REPLACE FUNCTION` with the same body plus an `IF array_length(queries, 1) > 30 THEN RAISE EXCEPTION` guard at the top. Defence in depth.

## Docs in this PR

- Epic Brief: `docs/Epic_Brief_—_MCP_—_Batch_Exercise_Resolution_#310.md`
- Tech Plan: `docs/Tech_Plan_—_MCP_—_Batch_Exercise_Resolution_#310.md`
- Tickets: `docs/T98_—_resolve_exercises_Tool_End-to-End.md` and `docs/T99_—_Agent_Steering_for_resolve_exercises.md`

Plan-of-record. Some on-the-fly design pushbacks vs the Tech Plan are documented in the T98 commit message (`weight_convention` derivation in TS not SQL; pure `resolveAmbiguityGap(envValue)` instead of cached `getAmbiguityGap()`; extracted `assembleResolution.ts` for testability).

## Test plan

- [x] 1364/1364 Vitest passing, `npx tsc --noEmit` clean
- [x] Manual e2e against Claude Desktop: *"build me a 3-day program"* → ~3 calls (1 resolve + 1 dry_run + 1 apply). Down from ~21 before.
- [x] Manual e2e: hybrid prompt *"best 3 chest exercises with dumbbells, add to push day"* → Claude reached straight for `resolve_exercises` with the 3 names from its training knowledge — no `search_exercises` fallback needed. The decision table generalizes beyond its literal examples.
- [x] Manual e2e: pure-browse prompt *"what's the best exercise for biceps?"* → Claude correctly picked `search_exercises`, NOT `resolve_exercises`. Steering works in both directions.
- [x] Reviewer to: pull the branch and run `supabase db push` to apply both migrations (`20260506000736_resolve_exercises_batch.sql` and `20260506004927_resolve_exercises_batch_cap_size.sql`) before testing locally.

## Follow-ups (separate issues)

- #320 — bodyweight exercises with stale `weight_kg > 0` block `update_program` echo (data hygiene migration). Surfaced by the e2e test above; not a regression from this PR — pre-existing data inconsistency exposed by the new test coverage.