### PR TITLE
fix(infra): drop /* from mcp-proxy custom domain route

### DIFF
--- a/infra/cloudflare/mcp-proxy/wrangler.toml
+++ b/infra/cloudflare/mcp-proxy/wrangler.toml
@@ -6,7 +6,7 @@ compatibility_date = "2025-01-01"
 # Set up via `wrangler deploy`; DNS lives in this same Cloudflare account
 # (see docs/done/T55_—_Resend_Cloudflare_DNS_&_Domain_Setup_(No-Code).md).
 [[routes]]
-pattern = "mcp.gymlogic.me/*"
+pattern = "mcp.gymlogic.me"
 custom_domain = true
 
 # UPSTREAM_URL is committed because it's not a secret — it's the Supabase


### PR DESCRIPTION
## What

One-line fix in `infra/cloudflare/mcp-proxy/wrangler.toml` — remove the `/*` path suffix from the route pattern.

## Why

`wrangler deploy` rejects `mcp.gymlogic.me/*` with:

> Wildcard operators (*) are not allowed in Custom Domains
> Paths are not allowed in Custom Domains

Cloudflare Custom Domains attach to a hostname and automatically route everything under it; the path-scoping syntax (`/*`) belongs to the older Workers Routes API. Surfaces at deploy time (T105) because that's the first place wrangler validates the route shape against Cloudflare's Custom-Domain rules.

## How

```diff
 [[routes]]
-pattern = "mcp.gymlogic.me/*"
+pattern = "mcp.gymlogic.me"
 custom_domain = true
```

## Test plan

- [x] `cd infra/cloudflare/mcp-proxy && npm test` — 5/5 still green (route config doesn't affect test mocks)
- [ ] `npx wrangler deploy` no longer errors on the route shape (verified by retry after merge)

Refs #296, T105.

Made with [Cursor](https://cursor.com)