### PR TITLE
fix(mcp): use X-MCP-Forwarded-Host (Supabase strips X-Forwarded-Host)

### DIFF
--- a/infra/cloudflare/mcp-proxy/src/index.test.ts
+++ b/infra/cloudflare/mcp-proxy/src/index.test.ts
@@ -40,7 +40,7 @@ describe("mcp-proxy Worker", () => {
     expect((init as RequestInit).method).toBe("POST")
   })
 
-  it("stamps X-Forwarded-Host with the incoming request's host", async () => {
+  it("stamps X-MCP-Forwarded-Host with the incoming request's host", async () => {
     const req = new Request("https://mcp.gymlogic.me/functions/v1/mcp", {
       method: "POST",
     })
@@ -49,7 +49,7 @@ describe("mcp-proxy Worker", () => {
 
     const init = fetchMock.mock.calls[0][1] as RequestInit
     const headers = init.headers as Headers
-    expect(headers.get("X-Forwarded-Host")).toBe("mcp.gymlogic.me")
+    expect(headers.get("X-MCP-Forwarded-Host")).toBe("mcp.gymlogic.me")
   })
 
   it("returns 503 with Retry-After when KILL_SWITCH=true blocks a POST and skips upstream", async () => {

--- a/infra/cloudflare/mcp-proxy/src/index.ts
+++ b/infra/cloudflare/mcp-proxy/src/index.ts
@@ -40,7 +40,11 @@ export default {
     )
 
     const headers = new Headers(req.headers)
-    headers.set("X-Forwarded-Host", incomingUrl.host)
+    // Custom header (not `X-Forwarded-Host`) because Supabase's edge gateway
+    // strips/overrides the standard one before it reaches the Deno deploy
+    // runtime — verified live during T105 smoke. The function-side helper
+    // (lib/publicUrl.ts) reads this same name. See ADR 0001 follow-ups.
+    headers.set("X-MCP-Forwarded-Host", incomingUrl.host)
 
     // Streaming bodies require duplex: 'half' on Node's fetch — Cloudflare's
     // runtime accepts this too. Cast keeps strict TS happy until the type

--- a/supabase/functions/mcp/lib/publicUrl.ts
+++ b/supabase/functions/mcp/lib/publicUrl.ts
@@ -6,18 +6,23 @@
  *   - `https://mcp.gymlogic.me/functions/v1/mcp`  via Cloudflare Worker proxy
  *   - `https://<project>.supabase.co/functions/v1/mcp`  direct
  *
- * When the Worker proxies a request, it sets `X-Forwarded-Host:
+ * When the Worker proxies a request, it sets `X-MCP-Forwarded-Host:
  * mcp.gymlogic.me`. The Edge Function uses that header to stamp the
  * customer-facing hostname into the OAuth `resource:` field and the
  * `WWW-Authenticate: resource_metadata=...` URL — those MUST match the host
  * the client actually called, otherwise OAuth issuer validation fails.
+ *
+ * Why a custom header name (not `X-Forwarded-Host`): Supabase's edge gateway
+ * strips/overrides the standard one before it reaches the Deno deploy
+ * runtime. Verified live during T105 smoke. The custom name passes through
+ * untouched.
  *
  * For requests that hit Supabase directly (local MCP Inspector, legacy
  * clients on the old URL), we fall back to `SUPABASE_URL`. Both paths
  * remain valid forever — the old URL is never deprecated.
  */
 export function getPublicMcpUrl(req: Request, supabaseUrl: string): string {
-  const fwdHost = req.headers.get("X-Forwarded-Host")
+  const fwdHost = req.headers.get("X-MCP-Forwarded-Host")
   if (fwdHost) return `https://${fwdHost}/functions/v1/mcp`
   return `${supabaseUrl}/functions/v1/mcp`
 }

--- a/supabase/functions/mcp/lib/publicUrl_test.ts
+++ b/supabase/functions/mcp/lib/publicUrl_test.ts
@@ -6,21 +6,25 @@
  * The two behaviors map exactly to the two deployment modes documented in
  * ADR 0001:
  *
- *   1. Request arrives via the Cloudflare Worker proxy → `X-Forwarded-Host`
+ *   1. Request arrives via the Cloudflare Worker proxy → `X-MCP-Forwarded-Host`
  *      set → public URL must use the customer-facing hostname so the OAuth
  *      issuer in the metadata matches the one the client actually called.
  *
  *   2. Request hits Supabase directly (local Inspector, legacy clients on
  *      the old URL) → fall back to `SUPABASE_URL`. Both paths remain valid
  *      forever — old URL is never deprecated.
+ *
+ * Custom header name (not `X-Forwarded-Host`) because Supabase's edge
+ * gateway strips/overrides the standard one before it reaches Deno deploy.
+ * Verified live during T105 smoke.
  */
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts"
 import { getPublicMcpUrl } from "./publicUrl.ts"
 
-Deno.test("getPublicMcpUrl: prefers X-Forwarded-Host when the Cloudflare proxy sets it", () => {
+Deno.test("getPublicMcpUrl: prefers X-MCP-Forwarded-Host when the Cloudflare proxy sets it", () => {
   const req = new Request("https://internal.supabase.co/functions/v1/mcp", {
-    headers: { "X-Forwarded-Host": "mcp.gymlogic.me" },
+    headers: { "X-MCP-Forwarded-Host": "mcp.gymlogic.me" },
   })
   assertEquals(
     getPublicMcpUrl(req, "https://internal.supabase.co"),
@@ -28,7 +32,7 @@ Deno.test("getPublicMcpUrl: prefers X-Forwarded-Host when the Cloudflare proxy s
   )
 })
 
-Deno.test("getPublicMcpUrl: falls back to SUPABASE_URL when X-Forwarded-Host is absent", () => {
+Deno.test("getPublicMcpUrl: falls back to SUPABASE_URL when X-MCP-Forwarded-Host is absent", () => {
   const req = new Request("https://abc.supabase.co/functions/v1/mcp")
   assertEquals(
     getPublicMcpUrl(req, "https://abc.supabase.co"),


### PR DESCRIPTION
## What

Renames the host-forwarding header from `X-Forwarded-Host` to `X-MCP-Forwarded-Host` on both sides — the Cloudflare Worker proxy and the function-side `getPublicMcpUrl` helper.

## Why

T105 smoke surfaced the failure mode flagged in the Tech Plan:

```
$ curl https://mcp.gymlogic.me/functions/v1/mcp/.well-known/oauth-protected-resource
{
  "resource": "https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp",  // ← wrong, should be the brand URL
  ...
}
```

Supabase's edge gateway strips/overrides the standard `X-Forwarded-Host` header before the request reaches the Deno deploy runtime. The function sees `null` and falls back to `SUPABASE_URL`. OAuth issuer validation then mismatches the host the client called.

A non-standard header name passes through untouched — Supabase only rewrites well-known forwarding headers.

## How

```diff
 // infra/cloudflare/mcp-proxy/src/index.ts
-headers.set("X-Forwarded-Host", incomingUrl.host)
+headers.set("X-MCP-Forwarded-Host", incomingUrl.host)
```

```diff
 // supabase/functions/mcp/lib/publicUrl.ts
-const fwdHost = req.headers.get("X-Forwarded-Host")
+const fwdHost = req.headers.get("X-MCP-Forwarded-Host")
```

Both unit test suites updated to match.

## Test plan

- [x] `cd infra/cloudflare/mcp-proxy && npm test` — 5/5 green
- [x] `deno test "supabase/functions/mcp/lib/publicUrl_test.ts" --node-modules-dir=auto --allow-env` — 2/2 green
- [ ] Post-merge: redeploy Worker + Edge Function, re-run T105 smoke `.well-known` check on `mcp.gymlogic.me` — `.resource` must return the brand URL.

⚠️ **Coordinated deploy required after merge.** Worker and Edge Function must be on the same header name in the same deployment cycle. Partial rollout = breakage:
- Worker deployed but function not → Worker stamps `X-MCP-Forwarded-Host`, function reads `X-Forwarded-Host`, falls back to `SUPABASE_URL` (current state, just on a different header).
- Function deployed but Worker not → function reads `X-MCP-Forwarded-Host`, gets nothing, falls back.

Refs #296, T105.

Made with [Cursor](https://cursor.com)