### PR TITLE
fix(connect): use mcp.gymlogic.me brand URL in Claude setup guide

### DIFF
--- a/web/src/content/connect/claude.mdx
+++ b/web/src/content/connect/claude.mdx
@@ -65,7 +65,7 @@ If you can't use OAuth or need a headless setup, see [Alternative authentication
 
 2. In the **Add custom connector** dialog, fill in:
    - **Name**: `Gymlogic`
-   - **URL**: `https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp`
+   - **URL**: `https://mcp.gymlogic.me/functions/v1/mcp`
    - Leave **OAuth Client ID** and **OAuth Client Secret** empty — GymLogic uses dynamic registration.
 
    Click **Add**.
@@ -139,7 +139,7 @@ The cleanest PAT path on Claude Desktop is via the `mcp-remote` adapter (since t
         "command": "/Users/you/.nvm/versions/node/v20.9.0/bin/npx",
         "args": [
           "mcp-remote",
-          "https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp",
+          "https://mcp.gymlogic.me/functions/v1/mcp",
           "--header",
           "Authorization: Bearer <YOUR_PAT>"
         ]
@@ -167,7 +167,7 @@ For Claude Desktop builds where the native Custom Connector UI isn't available, 
         "command": "/Users/you/.nvm/versions/node/v20.9.0/bin/npx",
         "args": [
           "mcp-remote",
-          "https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp"
+          "https://mcp.gymlogic.me/functions/v1/mcp"
         ]
       }
     }


### PR DESCRIPTION
## What

Replace three `https://favusepjqwpcroiolvaz.supabase.co/functions/v1/mcp` references in `web/src/content/connect/claude.mdx` with the brand domain `https://mcp.gymlogic.me/functions/v1/mcp`:

- Custom Connector dialog example (Step 1)
- PAT \`mcp-remote\` config snippet
- OAuth \`mcp-remote\` config snippet

## Why

T103 (\`docs/T103_—_Switch_User-Facing_Docs_to_mcp.gymlogic.me.md\`) handled this same URL substitution across \`skills/gymlogic-mcp/SKILL.md\` and \`docs/mcp-connect/*.md\`, but explicitly marked \`web/src/content/connect/claude.mdx\` as out of scope — the file didn't exist yet at the time. The follow-up plan was: *'will be authored against mcp.gymlogic.me from inception'*. It wasn't. This PR closes that gap.

The only doc currently sending users to the raw Supabase endpoint when they copy-paste was the live \`/connect/claude\` page. Existing connections on the Supabase URL keep working forever per ADR 0001 — this is a documentation-only switch.

## How

Single \`replace_all\` across one file. Sanity check: \`rg favusepjqwpcroiolvaz web/\` returns zero hits post-change; \`rg mcp.gymlogic.me/functions/v1/mcp web/src/content/connect/claude.mdx\` returns the expected three hits.

## Notes

The \`favusepjqwpcroiolvaz.supabase.co\` URL still legitimately appears elsewhere in the repo (ADR 0001 glossary reference, proxy config in \`infra/cloudflare/mcp-proxy/\`, server code, internal tickets). All intentional and out of scope per T103's guidance.

Made with [Cursor](https://cursor.com)