### PR TITLE
fix(#358): retry on Gemini 5xx in embedded-agent chatModel

### DIFF
--- a/supabase/functions/embedded-agent/chatModel.ts
+++ b/supabase/functions/embedded-agent/chatModel.ts
@@ -49,6 +49,10 @@ export interface CallChatGeminiOptions {
   // setTimeout-backed sleep. Prod code never passes either.
   fetchImpl?: typeof fetch
   sleepImpl?: (ms: number) => Promise<void>
+  // Internal test seam — surfaces the per-call AbortController so tests
+  // can verify abort-during-backoff cancellation without racing real
+  // timers. Production code never sets this.
+  exposeController?: (controller: AbortController) => void
 }
 
 export async function callChatGemini(
@@ -61,9 +65,12 @@ export async function callChatGemini(
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis)
   const sleep = opts.sleepImpl ?? defaultSleep
 
-  // Single shared controller — the 15s budget covers ALL attempts. We
-  // don't want 3 × 15s to add up to a 45s edge function call.
+  // Single shared controller — the 15s budget covers ALL attempts AND
+  // every backoff sleep in between (see `sleepWithAbort` below). Without
+  // racing sleeps against the signal a slow first attempt could push the
+  // total wall-time past TIMEOUT_MS by up to one backoff + jitter.
   const controller = new AbortController()
+  opts.exposeController?.(controller)
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
 
   const url = `${GEMINI_URL}?key=${apiKey}`
@@ -106,7 +113,11 @@ export async function callChatGemini(
 
       const baseBackoff = BACKOFF_MS[attempt - 1]
       const jitter = Math.floor((Math.random() * 2 - 1) * BACKOFF_JITTER_MS)
-      await sleep(Math.max(0, baseBackoff + jitter))
+      // Race the backoff against the shared abort signal so the 15s
+      // total budget actually bounds wall-time. If the timeout fires
+      // mid-sleep we exit immediately instead of finishing the nap and
+      // then handing a doomed fetch an already-aborted signal.
+      await sleepWithAbort(sleep, Math.max(0, baseBackoff + jitter), controller.signal)
     }
     // Unreachable: the loop either returns on a 2xx or throws on an
     // exhausted/non-retryable failure. Kept as a defensive net so the
@@ -132,4 +143,30 @@ function parseSuccess(data: GeminiResponse): ChatModelOutput {
 
 function defaultSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+// #358 PR review (Copilot) — backoff sleeps must observe the shared
+// abort signal so the TIMEOUT_MS budget is strictly bounded. We listen
+// once for "abort" and clean up the listener in `finally` so a sleep
+// that wins the race doesn't leave a dangling subscription on the
+// controller.
+async function sleepWithAbort(
+  sleep: (ms: number) => Promise<void>,
+  ms: number,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) {
+    throw new DOMException("Aborted before backoff", "AbortError")
+  }
+  let onAbort: (() => void) | undefined
+  const aborted = new Promise<never>((_, reject) => {
+    onAbort = () =>
+      reject(new DOMException("Aborted during backoff", "AbortError"))
+    signal.addEventListener("abort", onAbort, { once: true })
+  })
+  try {
+    await Promise.race([sleep(ms), aborted])
+  } finally {
+    if (onAbort) signal.removeEventListener("abort", onAbort)
+  }
 }

--- a/supabase/functions/embedded-agent/chatModel.ts
+++ b/supabase/functions/embedded-agent/chatModel.ts
@@ -1,13 +1,36 @@
 // Thin Gemini adapter for free-form chat turns. Mirrors the patterns in
-// `generate-program/gemini.ts` but skips the JSON response_schema — the
+// `_shared/programGemini.ts` but skips the JSON response_schema — the
 // Embedded Agent emits natural language plus an optional READY_FOR_PROGRAM_DRAFT
 // signal line (parsed downstream in T119).
+//
+// #358 — Retry-on-5xx absorbs transient Gemini capacity hiccups (the most
+// common one is the literal "model is currently experiencing high demand"
+// 503 we saw in prod). Retry budget and backoff are deliberately tiny:
+// Gemini 503s resolve within a second on Google's side, and the 15s total
+// `AbortController` budget is shared across attempts so the edge function
+// stays bounded.
 
 import type { ChatModelInput, ChatModelOutput } from "./handler.ts"
 
 const GEMINI_URL =
   "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
 const TIMEOUT_MS = 15_000
+
+// #358 — Retry policy. Exported so tests can pin the contract (3 attempts,
+// these 4 statuses) without copy-pasting the constants.
+export const MAX_CHAT_MODEL_ATTEMPTS = 3
+// 500 = generic server error, 502 = bad gateway, 503 = capacity (the
+// observed prod case), 504 = upstream timeout. 4xx (including 429) stays
+// out: those are deterministic and retrying just burns budget + wall time.
+export const RETRYABLE_CHAT_MODEL_STATUSES: ReadonlySet<number> = new Set([
+  500, 502, 503, 504,
+])
+// Backoff applied BETWEEN attempts (so length === MAX_ATTEMPTS - 1). Short
+// because the shared 15s timeout is the real ceiling and we don't want to
+// eat half of it in sleeps before the user gets a banner.
+const BACKOFF_MS = [250, 750] as const
+// ±50ms desync between concurrent clients hitting the same Google spike.
+const BACKOFF_JITTER_MS = 50
 
 interface GeminiPart {
   text?: string
@@ -21,54 +44,92 @@ interface GeminiResponse {
   error?: { message: string }
 }
 
-export async function callChatGemini(input: ChatModelInput): Promise<ChatModelOutput> {
+export interface CallChatGeminiOptions {
+  // Test seams — both default to the real `globalThis.fetch` and a
+  // setTimeout-backed sleep. Prod code never passes either.
+  fetchImpl?: typeof fetch
+  sleepImpl?: (ms: number) => Promise<void>
+}
+
+export async function callChatGemini(
+  input: ChatModelInput,
+  opts: CallChatGeminiOptions = {},
+): Promise<ChatModelOutput> {
   const apiKey = Deno.env.get("GEMINI_API_KEY")
   if (!apiKey) throw new Error("GEMINI_API_KEY is not set")
 
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis)
+  const sleep = opts.sleepImpl ?? defaultSleep
+
+  // Single shared controller — the 15s budget covers ALL attempts. We
+  // don't want 3 × 15s to add up to a 45s edge function call.
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
 
+  const url = `${GEMINI_URL}?key=${apiKey}`
+  const body = JSON.stringify({
+    systemInstruction: {
+      role: "system",
+      parts: [{ text: input.systemPrompt }],
+    },
+    contents: input.messages.map((m) => ({
+      // Gemini's API accepts only "user" and "model" roles.
+      role: m.role === "assistant" ? "model" : "user",
+      parts: [{ text: m.content }],
+    })),
+    generationConfig: {
+      temperature: 0.7,
+      maxOutputTokens: 1024,
+      thinkingConfig: { thinkingBudget: 0 },
+    },
+  })
+
   try {
-    const res = await fetch(`${GEMINI_URL}?key=${apiKey}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      signal: controller.signal,
-      body: JSON.stringify({
-        systemInstruction: {
-          role: "system",
-          parts: [{ text: input.systemPrompt }],
-        },
-        contents: input.messages.map((m) => ({
-          // Gemini's API accepts only "user" and "model" roles.
-          role: m.role === "assistant" ? "model" : "user",
-          parts: [{ text: m.content }],
-        })),
-        generationConfig: {
-          temperature: 0.7,
-          maxOutputTokens: 1024,
-          thinkingConfig: { thinkingBudget: 0 },
-        },
-      }),
-    })
+    for (let attempt = 1; attempt <= MAX_CHAT_MODEL_ATTEMPTS; attempt++) {
+      const res = await fetchImpl(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: controller.signal,
+        body,
+      })
 
-    if (!res.ok) {
-      const body = await res.text()
-      throw new Error(`Gemini API error ${res.status}: ${body}`)
+      if (res.ok) return parseSuccess(await res.json())
+
+      const errorBody = await res.text()
+      const isRetryable = RETRYABLE_CHAT_MODEL_STATUSES.has(res.status)
+      const isLastAttempt = attempt === MAX_CHAT_MODEL_ATTEMPTS
+      if (!isRetryable || isLastAttempt) {
+        throw new Error(`Gemini API error ${res.status}: ${errorBody}`)
+      }
+
+      input.onRetry?.({ attempt, upstreamStatus: res.status })
+
+      const baseBackoff = BACKOFF_MS[attempt - 1]
+      const jitter = Math.floor((Math.random() * 2 - 1) * BACKOFF_JITTER_MS)
+      await sleep(Math.max(0, baseBackoff + jitter))
     }
-
-    const data: GeminiResponse = await res.json()
-    if (data.error) throw new Error(`Gemini error: ${data.error.message}`)
-
-    const parts = data.candidates?.[0]?.content?.parts
-    if (!parts?.length) throw new Error("Gemini returned empty response")
-
-    const outputPart = parts.findLast((p) => !p.thought && p.text)
-    if (!outputPart?.text) {
-      throw new Error("Gemini returned no output text (only thinking)")
-    }
-
-    return { content: outputPart.text.trim() }
+    // Unreachable: the loop either returns on a 2xx or throws on an
+    // exhausted/non-retryable failure. Kept as a defensive net so the
+    // function always has a terminal statement.
+    throw new Error("Gemini retry loop exited without resolving")
   } finally {
     clearTimeout(timeout)
   }
+}
+
+function parseSuccess(data: GeminiResponse): ChatModelOutput {
+  if (data.error) throw new Error(`Gemini error: ${data.error.message}`)
+
+  const parts = data.candidates?.[0]?.content?.parts
+  if (!parts?.length) throw new Error("Gemini returned empty response")
+
+  const outputPart = parts.findLast((p) => !p.thought && p.text)
+  if (!outputPart?.text) {
+    throw new Error("Gemini returned no output text (only thinking)")
+  }
+  return { content: outputPart.text.trim() }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/supabase/functions/embedded-agent/chatModel_test.ts
+++ b/supabase/functions/embedded-agent/chatModel_test.ts
@@ -159,6 +159,43 @@ Deno.test("callChatGemini — AbortError from the shared signal is NOT retried",
   assertEquals(retries.length, 0)
 })
 
+Deno.test("callChatGemini — abort during backoff sleep terminates the retry loop", async () => {
+  // PR review (Copilot): the 15s budget covers ALL attempts including the
+  // backoff sleeps between them. If the timeout fires mid-sleep the loop
+  // must bail immediately instead of finishing the nap and burning another
+  // fetch on a doomed signal.
+  const recorder = makeFetch([
+    makeGeminiErrorResponse(503),
+    // The second response is never reached: abort fires inside the sleep
+    // and the race rejects before the loop reaches another fetch.
+    makeGeminiOkResponse("never"),
+  ])
+
+  let capturedController: AbortController | null = null
+  // The sleep aborts the shared controller *synchronously*, then returns
+  // a promise that never resolves. The signal-aware race must rescue us:
+  // if it doesn't, this test will hang and fail by timeout.
+  const sleepImpl = (): Promise<void> => {
+    capturedController?.abort()
+    return new Promise(() => {})
+  }
+
+  await assertRejects(
+    () =>
+      callChatGemini(makeInput(), {
+        fetchImpl: recorder.fetchImpl,
+        sleepImpl,
+        exposeController: (c) => {
+          capturedController = c
+        },
+      }),
+    DOMException,
+    "Aborted",
+  )
+
+  assertEquals(recorder.calls, 1)
+})
+
 Deno.test("callChatGemini — 429 is NOT retried (quota class, not capacity)", async () => {
   // Sanity guard on the status filter: 429 looks like a 5xx-sibling but
   // it's a deterministic quota signal. Retrying it just burns budget.

--- a/supabase/functions/embedded-agent/chatModel_test.ts
+++ b/supabase/functions/embedded-agent/chatModel_test.ts
@@ -79,7 +79,7 @@ Deno.test("callChatGemini — invariants are sane", () => {
 })
 
 Deno.test("callChatGemini — 503 then 200 succeeds and reports one retry", async () => {
-  const { fetchImpl, calls: _ } = makeFetch([
+  const { fetchImpl } = makeFetch([
     makeGeminiErrorResponse(503),
     makeGeminiOkResponse("hello world"),
   ])
@@ -103,7 +103,7 @@ Deno.test("callChatGemini — three 503s exhaust the retry budget and throw", as
   ])
 
   const retries: Array<{ attempt: number; upstreamStatus: number }> = []
-  const err = await assertRejects(
+  await assertRejects(
     () =>
       callChatGemini(
         makeInput({ onRetry: (info) => retries.push(info) }),
@@ -119,9 +119,6 @@ Deno.test("callChatGemini — three 503s exhaust the retry budget and throw", as
   assertEquals(retries.length, 2)
   assertEquals(retries[0], { attempt: 1, upstreamStatus: 503 })
   assertEquals(retries[1], { attempt: 2, upstreamStatus: 503 })
-  // Cast to silence the unused-binding warning on `err` while keeping the
-  // assertion in the rejection.
-  void err
 })
 
 Deno.test("callChatGemini — 400 is NOT retried", async () => {

--- a/supabase/functions/embedded-agent/chatModel_test.ts
+++ b/supabase/functions/embedded-agent/chatModel_test.ts
@@ -1,0 +1,183 @@
+import { assertEquals, assertRejects } from "https://deno.land/std@0.224.0/assert/mod.ts"
+import {
+  callChatGemini,
+  MAX_CHAT_MODEL_ATTEMPTS,
+  RETRYABLE_CHAT_MODEL_STATUSES,
+} from "./chatModel.ts"
+import type { ChatModelInput } from "./handler.ts"
+
+// #358 — Retry on Gemini 5xx. Tests pin the public surface (retry budget,
+// status filter, abort behaviour) without coupling to the exact backoff
+// schedule — the sleep impl is injected so tests stay deterministic and
+// fast.
+
+// ---------- helpers ----------
+
+// Set the API key once so the env guard short-circuit doesn't trip during
+// tests. The fetch impl is stubbed below, so no real Gemini call is made.
+Deno.env.set("GEMINI_API_KEY", "test-key")
+
+function makeGeminiOkResponse(text = "ok"): Response {
+  return new Response(
+    JSON.stringify({
+      candidates: [{ content: { parts: [{ text }] } }],
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  )
+}
+
+function makeGeminiErrorResponse(status: number, message = "upstream"): Response {
+  return new Response(
+    JSON.stringify({ error: { code: status, message, status: "UNAVAILABLE" } }),
+    { status, headers: { "Content-Type": "application/json" } },
+  )
+}
+
+function makeInput(overrides: Partial<ChatModelInput> = {}): ChatModelInput {
+  return {
+    systemPrompt: "you are a helpful assistant",
+    messages: [{ role: "user", content: "hi", ts: "2026-05-20T13:00:00.000Z" }],
+    ...overrides,
+  }
+}
+
+interface FetchRecorder {
+  fetchImpl: typeof fetch
+  calls: number
+}
+
+function makeFetch(responses: Array<Response | Error>): FetchRecorder {
+  let i = 0
+  const recorder: FetchRecorder = {
+    calls: 0,
+    fetchImpl: () => {
+      recorder.calls += 1
+      const next = responses[i++]
+      if (next === undefined) {
+        return Promise.reject(new Error(`fetch called more times than expected (${i})`))
+      }
+      if (next instanceof Error) return Promise.reject(next)
+      return Promise.resolve(next)
+    },
+  }
+  return recorder
+}
+
+function noopSleep(): Promise<void> {
+  return Promise.resolve()
+}
+
+// ---------- tests ----------
+
+Deno.test("callChatGemini — invariants are sane", () => {
+  // Guard the test contract: AC fixes 3 attempts max, retry on 500/502/503/504.
+  assertEquals(MAX_CHAT_MODEL_ATTEMPTS, 3)
+  assertEquals(
+    [...RETRYABLE_CHAT_MODEL_STATUSES].sort((a, b) => a - b),
+    [500, 502, 503, 504],
+  )
+})
+
+Deno.test("callChatGemini — 503 then 200 succeeds and reports one retry", async () => {
+  const { fetchImpl, calls: _ } = makeFetch([
+    makeGeminiErrorResponse(503),
+    makeGeminiOkResponse("hello world"),
+  ])
+
+  const retries: Array<{ attempt: number; upstreamStatus: number }> = []
+  const out = await callChatGemini(
+    makeInput({ onRetry: (info) => retries.push(info) }),
+    { fetchImpl, sleepImpl: noopSleep },
+  )
+
+  assertEquals(out.content, "hello world")
+  assertEquals(retries.length, 1)
+  assertEquals(retries[0], { attempt: 1, upstreamStatus: 503 })
+})
+
+Deno.test("callChatGemini — three 503s exhaust the retry budget and throw", async () => {
+  const recorder = makeFetch([
+    makeGeminiErrorResponse(503),
+    makeGeminiErrorResponse(503),
+    makeGeminiErrorResponse(503),
+  ])
+
+  const retries: Array<{ attempt: number; upstreamStatus: number }> = []
+  const err = await assertRejects(
+    () =>
+      callChatGemini(
+        makeInput({ onRetry: (info) => retries.push(info) }),
+        { fetchImpl: recorder.fetchImpl, sleepImpl: noopSleep },
+      ),
+    Error,
+    "Gemini API error 503",
+  )
+
+  assertEquals(recorder.calls, 3)
+  // onRetry only fires when we are GOING to retry — last attempt's failure
+  // does not signal a retry.
+  assertEquals(retries.length, 2)
+  assertEquals(retries[0], { attempt: 1, upstreamStatus: 503 })
+  assertEquals(retries[1], { attempt: 2, upstreamStatus: 503 })
+  // Cast to silence the unused-binding warning on `err` while keeping the
+  // assertion in the rejection.
+  void err
+})
+
+Deno.test("callChatGemini — 400 is NOT retried", async () => {
+  const recorder = makeFetch([
+    makeGeminiErrorResponse(400, "bad request"),
+  ])
+
+  const retries: Array<{ attempt: number; upstreamStatus: number }> = []
+  await assertRejects(
+    () =>
+      callChatGemini(
+        makeInput({ onRetry: (info) => retries.push(info) }),
+        { fetchImpl: recorder.fetchImpl, sleepImpl: noopSleep },
+      ),
+    Error,
+    "Gemini API error 400",
+  )
+
+  assertEquals(recorder.calls, 1)
+  assertEquals(retries.length, 0)
+})
+
+Deno.test("callChatGemini — AbortError from the shared signal is NOT retried", async () => {
+  const recorder = makeFetch([
+    Object.assign(new Error("aborted"), { name: "AbortError" }),
+  ])
+
+  const retries: Array<{ attempt: number; upstreamStatus: number }> = []
+  await assertRejects(
+    () =>
+      callChatGemini(
+        makeInput({ onRetry: (info) => retries.push(info) }),
+        { fetchImpl: recorder.fetchImpl, sleepImpl: noopSleep },
+      ),
+  )
+
+  assertEquals(recorder.calls, 1)
+  assertEquals(retries.length, 0)
+})
+
+Deno.test("callChatGemini — 429 is NOT retried (quota class, not capacity)", async () => {
+  // Sanity guard on the status filter: 429 looks like a 5xx-sibling but
+  // it's a deterministic quota signal. Retrying it just burns budget.
+  const recorder = makeFetch([makeGeminiErrorResponse(429, "quota")])
+
+  const retries: Array<{ attempt: number; upstreamStatus: number }> = []
+  await assertRejects(
+    () =>
+      callChatGemini(
+        makeInput({ onRetry: (info) => retries.push(info) }),
+        { fetchImpl: recorder.fetchImpl, sleepImpl: noopSleep },
+      ),
+    Error,
+    "Gemini API error 429",
+  )
+
+  assertEquals(recorder.calls, 1)
+  assertEquals(retries.length, 0)
+})

--- a/supabase/functions/embedded-agent/handler.ts
+++ b/supabase/functions/embedded-agent/handler.ts
@@ -41,6 +41,12 @@ function isSupportedLocale(value: unknown): value is ThreadLocale {
 export interface ChatModelInput {
   systemPrompt: string
   messages: ThreadMessage[]
+  // #358 — Fired once per retry that the chat model performs against the
+  // upstream provider. Handler binds this to a structured `provider_retry`
+  // warn log so we can observe whether retries are actually saving us or
+  // just delaying the inevitable. Implementations that don't retry simply
+  // never call it.
+  onRetry?: (info: { attempt: number; upstreamStatus: number }) => void
 }
 
 export interface ChatModelOutput {
@@ -644,6 +650,23 @@ async function handleSend(
     modelOutput = await deps.chatModel({
       systemPrompt,
       messages: afterUser.messages ?? [],
+      // #358 — Each retry emits a structured warn log so we can spot
+      // "we saved a turn from a 503" vs "we just delayed the inevitable"
+      // in the Supabase Function logs. Same request_id/user_id/thread_id
+      // shape as `provider_failure` so the two events correlate trivially.
+      onRetry: ({ attempt, upstreamStatus }) => {
+        deps.log({
+          level: "warn",
+          feature: "embedded-agent",
+          route: "/message",
+          purpose,
+          error_kind: "provider_retry",
+          request_id: requestId,
+          user_id: userId,
+          thread_id: active.id,
+          message: `attempt=${attempt} upstream_status=${upstreamStatus}`,
+        })
+      },
     })
   } catch (err) {
     await deps.logBillableCall(userId, "embedded_chat")

--- a/supabase/functions/embedded-agent/handler_test.ts
+++ b/supabase/functions/embedded-agent/handler_test.ts
@@ -1,6 +1,11 @@
 import { assertEquals, assertStringIncludes } from "https://deno.land/std@0.224.0/assert/mod.ts"
-import { handleEmbeddedAgent, type LogEvent } from "./handler.ts"
-import type { Thread, ThreadLocale, ThreadMessage, ThreadPurpose } from "./threadStore.ts"
+import {
+  handleEmbeddedAgent,
+  type ChatModelInput,
+  type ChatModelOutput,
+  type LogEvent,
+} from "./handler.ts"
+import type { Thread, ThreadLocale, ThreadPurpose } from "./threadStore.ts"
 import type { UserContextProfile } from "./prompt/index.ts"
 import type { DraftArgs, DraftResult, LastPreview } from "./draft.ts"
 import type { CallMcpToolResult } from "../_shared/mcpClient.ts"
@@ -90,7 +95,7 @@ interface DepsCalls {
   enforceDraftQuota: Array<{ userId: string }>
   enforceProgramQuota: Array<{ userId: string }>
   logBillableCall: Array<{ userId: string; source: "embedded_chat" | "embedded_draft" }>
-  chatModel: Array<{ systemPrompt: string; messages: ThreadMessage[] }>
+  chatModel: ChatModelInput[]
   loadProfile: Array<{ userId: string }>
   runDraftStep: Array<{
     userId: string
@@ -129,7 +134,7 @@ interface DepsOverrides {
   enforceDraftQuota?: (userId: string) => Promise<{ allowed: boolean; limit: number; used: number }>
   enforceProgramQuota?: (userId: string) => Promise<{ allowed: boolean }>
   logBillableCall?: (userId: string, source: "embedded_chat" | "embedded_draft") => Promise<void>
-  chatModel?: (input: { systemPrompt: string; messages: ThreadMessage[] }) => Promise<{ content: string }>
+  chatModel?: (input: ChatModelInput) => Promise<ChatModelOutput>
   loadProfile?: (userId: string) => Promise<UserContextProfile | null>
   runDraftStep?: (input: {
     userId: string
@@ -251,7 +256,7 @@ function makeDeps(overrides: DepsOverrides = {}) {
       calls.logBillableCall.push({ userId, source })
       if (overrides.logBillableCall) await overrides.logBillableCall(userId, source)
     },
-    chatModel: async (input: { systemPrompt: string; messages: ThreadMessage[] }) => {
+    chatModel: async (input: ChatModelInput) => {
       calls.chatModel.push(input)
       return overrides.chatModel
         ? await overrides.chatModel(input)
@@ -815,6 +820,40 @@ Deno.test("POST /message logs the billable call AND returns 502 even when the mo
   // for this ticket.
   assertEquals(calls.logEvents[0].error_kind, "provider_failure")
   assertEquals(calls.logEvents[0].route, "/message")
+})
+
+// #358 — When the chat model exposes its retry budget via `input.onRetry`,
+// the handler wires it to a structured `provider_retry` warn log. We
+// verify the wire-up, not the chatModel internals (those are pinned in
+// chatModel_test.ts).
+Deno.test("POST /message emits a provider_retry warn log per chat model retry", async () => {
+  const active = makeThread({ id: "t-1", status: "open" })
+  const { deps, calls } = makeDeps({
+    getActiveThread: async () => active,
+    chatModel: async (input) => {
+      input.onRetry?.({ attempt: 1, upstreamStatus: 503 })
+      input.onRetry?.({ attempt: 2, upstreamStatus: 502 })
+      return { content: "recovered" }
+    },
+  })
+
+  const res = await handleEmbeddedAgent(
+    sendRequest({ content: "hi", locale: "en" }),
+    deps,
+  )
+
+  assertEquals(res.status, 200)
+
+  const retries = calls.logEvents.filter((e) => e.error_kind === "provider_retry")
+  assertEquals(retries.length, 2)
+  assertEquals(retries[0].level, "warn")
+  assertEquals(retries[0].route, "/message")
+  assertEquals(retries[0].thread_id, "t-1")
+  assertEquals(retries[0].purpose, "onboarding")
+  assertStringIncludes(retries[0].message ?? "", "attempt=1")
+  assertStringIncludes(retries[0].message ?? "", "upstream_status=503")
+  assertStringIncludes(retries[1].message ?? "", "attempt=2")
+  assertStringIncludes(retries[1].message ?? "", "upstream_status=502")
 })
 
 Deno.test("POST /message rejects empty content with 400 invalid_content", async () => {


### PR DESCRIPTION
## What

- Retry transient Gemini 5xx responses (500/502/503/504) inside the embedded-agent `chatModel` so brief Google capacity blips no longer surface to users as fatal banners.
- New `provider_retry` structured warn log emitted on each retry, sharing the `request_id` / `user_id` / `thread_id` / `purpose` shape of the existing `provider_failure` taxonomy.
- Test coverage: new `chatModel_test.ts` (6 cases pinning the retry policy) plus a handler-level wire-up test for the new log.

## Why

Today's prod Sentry incident — `embedded-agent /message model_failure` on an Android onboarding session — decoded to a Gemini 503 _"This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later."_ Pure upstream capacity, fully transient.

The current code path makes that hurt more than it should:

1. The user message is persisted **before** the model call (correct, by design — Story 19 evidence).
2. Gemini 503 throws on the first attempt with zero retry budget.
3. The handler returns `502 model_failure`, the client renders a generic fatal banner whose "Retry" button just resets error state — it does **not** re-send the orphaned turn.
4. The billable turn quota is counted anyway (`log_everything`).

Net result: one Google hiccup = one orphaned turn in the transcript + one wasted quota tick. A tight retry budget absorbs the vast majority of these without changing the wire contract or any client behavior.

## How

- `chatModel.ts` runs up to **3 attempts** with `[250ms, 750ms]` backoff and `±50ms` jitter (desyncs concurrent clients pinned to the same Google spike). The retry status set is exactly `{500, 502, 503, 504}` — 4xx including 429 stays out: those are deterministic and retrying them just burns budget.
- A **single shared 15s `AbortController`** covers all attempts so total wall-time stays bounded (no 3×15s blow-up on the edge function).
- New optional `onRetry({ attempt, upstreamStatus })` callback on `ChatModelInput` lets the handler emit a `provider_retry` warn log without coupling `chatModel.ts` to the logging infrastructure.
- Injectable `fetchImpl` / `sleepImpl` seams keep the new tests deterministic — no real network calls, no real timers, full suite runs in `<20ms`.
- `/draft` path (via `_shared/programGemini.ts`) and legacy AI surfaces remain explicitly out of scope here; they're covered by #318.

Verified locally:
- `deno test` — 209/209 (including 6 new + 1 handler wire-up)
- `npm run lint` — clean
- `npm run test` — 1526/1526
- `npm run build` — green

Closes #358