### PR TITLE
fix(#362): close the 200-text/html flavor of stale-chunk failures

### DIFF
--- a/src/lib/lazyWithRecover.test.ts
+++ b/src/lib/lazyWithRecover.test.ts
@@ -33,6 +33,16 @@ describe("isChunkLoadFailure", () => {
     ).toBe(true)
   })
 
+  it("matches the iOS 18 Mobile Safari MIME-type variant", () => {
+    // Surfaces when the server returns 200 + text/html (e.g. SPA
+    // fallback) instead of the expected JS module. See GYMLOGIC-C.
+    expect(
+      isChunkLoadFailure(
+        new TypeError("'text/html' is not a valid JavaScript MIME type."),
+      ),
+    ).toBe(true)
+  })
+
   it("returns false for unrelated errors and non-Error values", () => {
     expect(isChunkLoadFailure(new Error("Boom"))).toBe(false)
     expect(isChunkLoadFailure("string")).toBe(false)

--- a/src/lib/lazyWithRecover.ts
+++ b/src/lib/lazyWithRecover.ts
@@ -1,18 +1,35 @@
 import { lazy, type ComponentType, type LazyExoticComponent } from "react"
 
-// #356 — `React.lazy` rejects with `TypeError: Failed to fetch dynamically
-// imported module` when the chunk hash on disk no longer matches what the
-// running tab remembers (typical after a deploy: SW or browser cache holds
-// the old `index.html`, the new server serves a 404 page with `text/html`
-// MIME for the missing chunk, the browser refuses to execute it as JS).
+// #356 — `React.lazy` rejects when the chunk hash on disk no longer
+// matches what the running tab remembers (typical after a deploy: SW or
+// browser cache holds the old `index.html` referencing chunk hashes that
+// no longer exist server-side).
 //
-// Strategy: catch the failure in the loader wrapper, reload the page once
-// to pull a fresh `index.html` + fresh chunk hashes. A sessionStorage
-// guard prevents an infinite reload loop when the reload itself fails to
-// recover (CDN issue, broken build, offline). On the second failure we
-// let the error bubble to `RouteErrorFallback`, which surfaces a "Force
-// refresh" button wired to `forceHardReload` — the nuclear option that
-// also clears caches and unregisters the service worker.
+// Two flavors of failure, depending on how the server reacts:
+//   - Returns a real 404 → `import()` rejects with the browser's
+//     "Failed to fetch dynamically imported module" / "Importing a
+//     module script failed" / "error loading dynamically imported
+//     module" (engine-dependent wording).
+//   - Returns 200 + the SPA fallback `index.html` (Vercel/Netlify
+//     rewrite catch-all) → the response is technically OK but
+//     `Content-Type` is `text/html`. Mobile Safari iOS 18 surfaces this
+//     as `TypeError: 'text/html' is not a valid JavaScript MIME type.`
+//     Chromium just says "Failed to fetch ... module".
+//
+// We fixed the 200-text/html flavor at the Vercel rewrite level
+// (`vercel.json` excludes paths with a `.` from the SPA catch-all) so
+// stale chunks now return a real 404. The MIME-type needle below is
+// belt-and-suspenders: any future CDN/proxy/SW layer that re-introduces
+// the 200-text/html shape will still trip the soft reload.
+//
+// Strategy: catch the failure in the loader wrapper, reload the page
+// once to pull a fresh `index.html` + fresh chunk hashes. A
+// sessionStorage guard prevents an infinite reload loop when the reload
+// itself fails to recover (CDN issue, broken build, offline). On the
+// second failure we let the error bubble to `RouteErrorFallback`, which
+// surfaces a "Force refresh" button wired to `forceHardReload` — the
+// nuclear option that also clears caches and unregisters the service
+// worker.
 
 const RELOAD_KEY = "chunk-load-reload-attempted-at"
 const RELOAD_GUARD_MS = 60_000
@@ -21,6 +38,7 @@ const CHUNK_FAILURE_NEEDLES = [
   "Failed to fetch dynamically imported module",
   "Importing a module script failed",
   "error loading dynamically imported module",
+  "is not a valid JavaScript MIME type",
 ] as const
 
 export function isChunkLoadFailure(error: unknown): boolean {

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,6 @@
     "enabled": false
   },
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/((?!.*\\.).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## What

- **`vercel.json`**: the SPA rewrite catch-all now excludes paths with an extension (`/((?!.*\.).*)`). Stale chunk URLs (e.g. `/assets/foo-OLDHASH.js`) no longer fall through to `index.html` → they get a real 404.
- **`src/lib/lazyWithRecover.ts`**: `isChunkLoadFailure` learns the iOS 18 Mobile Safari needle `"is not a valid JavaScript MIME type"`. Doc comment refreshed to describe the two failure modes (404 vs 200 + text/html) instead of the previous half-truth that only covered 404.
- **`src/lib/lazyWithRecover.test.ts`**: regression test pinning the new needle, referencing Sentry `GYMLOGIC-C` for traceability.

## Why

Follow-up to #356 / PR #357. Sentry `GYMLOGIC-C` surfaced a Mobile Safari iOS 18.7 user on `/library/programs` crashing with:

```
TypeError: 'text/html' is not a valid JavaScript MIME type.
```

`RouteErrorFallback` captured it correctly (tag `feature: route-load`) but classified it as `error_kind: unknown` → user got the generic error UI instead of the dedicated "New version available — Refresh now" recovery flow. PR #357's classifier only knew the Chrome / Firefox / Safari ≤ 17 variants.

The deeper root cause is the catch-all SPA rewrite in `vercel.json`:

```json
{ "source": "/(.*)", "destination": "/index.html" }
```

When a stale chunk URL hits Vercel and the file doesn't exist anymore (post-deploy hash rotation), Vercel can't serve the asset → applies the rewrite → returns `index.html` with **200 OK + Content-Type: text/html**. iOS 18 Safari refuses to execute that as a JS module → the new error message.

Two flavors of the same bug, fixed at two layers:

| Flavor              | Trigger                           | Without fix         | With fix                                |
| ------------------- | --------------------------------- | ------------------- | --------------------------------------- |
| 404                 | Asset doesn't exist server-side   | Was already covered | Now triggered by the rewrite exclusion  |
| 200 + `text/html`   | SPA rewrite caught an asset path  | iOS 18 hit this     | Vercel rewrite no longer catches assets |
| 200 + `text/html` (residual, any CDN/proxy/SW layer) | Future regressions          | n/a                 | Needle catches it client-side anyway    |

## How

**Layer 1 — Vercel (the real fix)**

Replaced `"/(.*)"` with `"/((?!.*\\.).*)"`. Any path containing a `.` is excluded from the SPA fallback → stale chunks, `/sw.js`, `.map` files, `.webmanifest`, etc. now return real 404s instead of `index.html`. SPA routes don't have dots in them, so `/library/programs`, `/history`, etc. still fall through correctly.

**Layer 2 — Client classifier (defense in depth)**

Added `"is not a valid JavaScript MIME type"` to `CHUNK_FAILURE_NEEDLES`. Belt-and-suspenders for:
- existing users with a SW poisoned **before** the Vercel-side fix reaches them (their next chunk-load failure will still hit the residual 200 + text/html shape from the cached `index.html`),
- any future CDN / reverse proxy / Workbox runtime cache config that re-introduces the same response shape.

**Tests**

`isChunkLoadFailure` gets a regression test for the iOS 18 message exactly as Sentry reports it. Existing recovery tests already exercise the soft-reload + guard logic — they're indifferent to the needle list as long as `isChunkLoadFailure` returns `true`.

Local run: `lazyWithRecover.test.ts` (11/11 ✅) + `RouteErrorFallback.test.tsx` (8/8 ✅) green. The full `npm run test` run has 23 pre-existing flaky timeouts on touched-elsewhere files (`QuestionnaireStep`, `CreatePATDialog`, `ExerciseLibraryPicker`, …) — verified those same tests pass in isolation on `main`, so unrelated to this PR.

Closes #362

Refs Sentry GYMLOGIC-C (https://oim.sentry.io/issues/GYMLOGIC-C)

Made with [Cursor](https://cursor.com)