### PR TITLE
fix(#364): opt out of in-page translation to avoid React reconciler crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,14 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
+    <!--
+      Opt out of in-page translation (Chrome, Safari, Edge, Firefox).
+      Chrome Mobile's translator wraps text nodes in <font> tags, which
+      desyncs React 19's reconciler and throws `NotFoundError` on
+      insertBefore during commit. See #364.
+    -->
+    <meta name="google" content="notranslate" />
     <link rel="icon" type="image/svg+xml" href="/pwa-192x192.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png" />


### PR DESCRIPTION
## What

- Set `translate="no"` on the root `<html>` element in `index.html`.
- Add `<meta name="google" content="notranslate">` for the legacy Google Translate widget signal.

## Why

Sentry caught [`GYMLOGIC-D`](https://oim.sentry.io/issues/7502591388/) — `NotFoundError: Failed to execute 'insertBefore' on 'Node'` — on Chrome Mobile / `fr-FR`. The full stacktrace lives inside `react-dom-client.production.js` (no app frames), which is the signature of an external DOM mutation between two React commits.

The mutator is Chrome's in-page translator: it wraps text nodes in `<font>` tags after load, while React 19's fiber tree still holds refs to the originals. On the next commit, `parent.insertBefore(node, before)` throws because `before` is no longer a child of `parent`. Well-known class — [facebook/react#11538](https://github.com/facebook/react/issues/11538) — still alive in React 19.

We're shipping FR localization end-to-end (#58), so relying on the browser translator was never the plan. Killing the entire bug class with one document-level opt-out is the right trade-off.

## How

Two-line HTML change. No JS, no test changes (this is a static config that can only be verified manually in a real browser):

- `translate="no"` is the W3C standard; honored by Chrome, Edge, Safari, and Firefox.
- The `<meta name="google" content="notranslate">` is belt-and-braces for the legacy Google Translate widget.
- Added an inline comment pointing at this issue so the next person doesn't innocently delete it.

**Manual verification (post-deploy):**

1. Open the site on Chrome desktop, right-click → "Translate to French" should be a no-op / disabled. The address-bar translate icon should not appear.
2. On Chrome Mobile with French device locale, no "Translate this page?" prompt.
3. Watch Sentry for 7 days — no new `NotFoundError` of this class.

**Side note (out of scope but flagged):** Sentry shows `Users Impacted: 0` despite breadcrumbs full of authenticated Supabase activity. Suggests `Sentry.setUser` isn't wired into our auth flow. Not fixing here, but worth a follow-up issue.

Closes #364

Made with [Cursor](https://cursor.com)