### PR TITLE
fix(#366): scatter+trend "Par exercice" chart & paginated table

### DIFF
--- a/src/components/history/ExerciseChart.test.tsx
+++ b/src/components/history/ExerciseChart.test.tsx
@@ -1,0 +1,136 @@
+import { vi, describe, it, expect, beforeEach } from "vitest"
+import { screen, within } from "@testing-library/react"
+import { renderWithProviders } from "@/test/utils"
+import type { Exercise, SetLog } from "@/types/database"
+import { ExerciseChart } from "./ExerciseChart"
+
+const mockUseExerciseById = vi.fn<
+  (id: string) => { data: Exercise | undefined | null; isLoading: boolean }
+>()
+vi.mock("@/hooks/useExerciseById", () => ({
+  useExerciseById: (id: string | null) => mockUseExerciseById(id ?? ""),
+}))
+
+const mockUseExerciseTrend = vi.fn<
+  (id: string) => { data: SetLog[] | undefined; isLoading: boolean }
+>()
+vi.mock("@/hooks/useExerciseTrend", () => ({
+  useExerciseTrend: (id: string | null) => mockUseExerciseTrend(id ?? ""),
+}))
+
+vi.mock("@/hooks/useWeightUnit", () => ({
+  useWeightUnit: () => ({
+    unit: "kg",
+    setUnit: vi.fn(),
+    toKg: (v: number) => v,
+    toDisplay: (kg: number) => kg,
+    formatWeight: (kg: number) => `${kg} kg`,
+  }),
+}))
+
+const BASE_EXERCISE: Exercise = {
+  id: "ex-1",
+  name: "Bench Press",
+  muscle_group: "chest",
+  emoji: "🏋️",
+  is_system: true,
+  created_at: "2025-01-01T00:00:00Z",
+  youtube_url: null,
+  instructions: null,
+  image_url: null,
+  equipment: "barbell",
+  difficulty_level: null,
+  name_en: "Bench Press",
+  source: null,
+  secondary_muscles: null,
+  reviewed_at: null,
+  reviewed_by: null,
+}
+
+let logIdCounter = 0
+function makeLog(overrides: Partial<SetLog> = {}): SetLog {
+  logIdCounter += 1
+  return {
+    id: `log-${logIdCounter}`,
+    session_id: "session-1",
+    exercise_id: "ex-1",
+    exercise_name_snapshot: "Bench Press",
+    set_number: 1,
+    reps_logged: "8",
+    duration_seconds: null,
+    weight_logged: 40,
+    estimated_1rm: null,
+    was_pr: false,
+    logged_at: "2026-05-01T10:00:00Z",
+    rir: null,
+    rest_seconds: null,
+    ...overrides,
+  }
+}
+
+describe("ExerciseChart — table", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseExerciseById.mockReturnValue({ data: BASE_EXERCISE, isLoading: false })
+  })
+
+  it("renders rows in newest-date-first order", () => {
+    const logs: SetLog[] = [
+      makeLog({ logged_at: "2026-05-01T10:00:00Z", reps_logged: "8" }),
+      makeLog({ logged_at: "2026-05-02T10:00:00Z", reps_logged: "10" }),
+      makeLog({ logged_at: "2026-05-03T10:00:00Z", reps_logged: "12" }),
+    ]
+    mockUseExerciseTrend.mockReturnValue({ data: logs, isLoading: false })
+
+    renderWithProviders(<ExerciseChart exerciseId="ex-1" />)
+
+    const rows = screen.getAllByRole("row")
+    // rows[0] is the header row
+    expect(within(rows[1]).getByText(/May 3/)).toBeInTheDocument()
+    expect(within(rows[2]).getByText(/May 2/)).toBeInTheDocument()
+    expect(within(rows[3]).getByText(/May 1/)).toBeInTheDocument()
+  })
+
+  it("shows the first 100 rows and a Load more button when there are more, then reveals the rest on click", async () => {
+    const userEvent = (await import("@testing-library/user-event")).default
+    const user = userEvent.setup()
+
+    const logs: SetLog[] = Array.from({ length: 105 }, (_, i) => {
+      const day = String((i % 28) + 1).padStart(2, "0")
+      const month = String(Math.floor(i / 28) + 1).padStart(2, "0")
+      return makeLog({
+        logged_at: `2026-${month}-${day}T10:00:00Z`,
+        reps_logged: String(8 + (i % 5)),
+      })
+    })
+    mockUseExerciseTrend.mockReturnValue({ data: logs, isLoading: false })
+
+    renderWithProviders(<ExerciseChart exerciseId="ex-1" />)
+
+    expect(screen.getAllByRole("row").length).toBe(101)
+    const button = screen.getByRole("button", { name: /load more/i })
+    expect(button).toBeInTheDocument()
+
+    await user.click(button)
+
+    expect(screen.getAllByRole("row").length).toBe(106)
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument()
+  })
+
+  it("does not render the Load more button when there are 100 or fewer rows", () => {
+    const logs: SetLog[] = Array.from({ length: 100 }, (_, i) => {
+      const day = String((i % 28) + 1).padStart(2, "0")
+      const month = String(Math.floor(i / 28) + 1).padStart(2, "0")
+      return makeLog({
+        logged_at: `2026-${month}-${day}T10:00:00Z`,
+        reps_logged: String(8 + (i % 5)),
+      })
+    })
+    mockUseExerciseTrend.mockReturnValue({ data: logs, isLoading: false })
+
+    renderWithProviders(<ExerciseChart exerciseId="ex-1" />)
+
+    expect(screen.getAllByRole("row").length).toBe(101)
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument()
+  })
+})

--- a/src/components/history/ExerciseChart.tsx
+++ b/src/components/history/ExerciseChart.tsx
@@ -1,5 +1,12 @@
-import { useMemo } from "react"
-import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts"
+import { useMemo, useState } from "react"
+import {
+  ComposedChart,
+  Line,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+} from "recharts"
 import { Trophy } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import {
@@ -9,6 +16,7 @@ import {
   type ChartConfig,
 } from "@/components/ui/chart"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
   Table,
   TableBody,
@@ -21,144 +29,159 @@ import { useExerciseById } from "@/hooks/useExerciseById"
 import { useExerciseTrend } from "@/hooks/useExerciseTrend"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 import { computeEpley1RM } from "@/lib/epley"
+import { buildExerciseTrendSeries } from "@/lib/exerciseTrend"
 import { formatDate, formatSecondsMMSS } from "@/lib/formatters"
+
+const TABLE_PAGE_SIZE = 100
+
+function LoadMoreButton({
+  visible,
+  total,
+  onClick,
+  label,
+}: {
+  visible: number
+  total: number
+  onClick: () => void
+  label: string
+}) {
+  if (visible >= total) return null
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={onClick}
+      className="self-center"
+    >
+      {label}
+    </Button>
+  )
+}
 
 export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
   const { t, i18n } = useTranslation("history")
   const { formatWeight, toDisplay, unit } = useWeightUnit()
   const { data: exercise, isLoading: exerciseLoading } = useExerciseById(exerciseId)
   const { data: logs, isLoading: logsLoading } = useExerciseTrend(exerciseId)
+  const [visibleCount, setVisibleCount] = useState(TABLE_PAGE_SIZE)
   const isDuration = exercise?.measurement_type === "duration"
   const isBodyweight = exercise?.equipment === "bodyweight" && !isDuration
   const loading = logsLoading || exerciseLoading
 
   const chartConfigReps = useMemo<ChartConfig>(
     () => ({
-      reps: {
-        label: t("maxReps"),
-        color: "hsl(var(--primary))",
-      },
+      value: { label: t("maxReps"), color: "hsl(var(--primary))" },
+      trend: { label: t("trend"), color: "hsl(var(--primary))" },
     }),
     [t],
   )
 
   const chartConfigE1rm = useMemo<ChartConfig>(
     () => ({
-      e1rm: {
+      value: {
         label: `${t("oneRm")} (${unit})`,
         color: "hsl(var(--primary))",
       },
+      trend: { label: t("trend"), color: "hsl(var(--primary))" },
     }),
     [t, unit],
   )
 
   const chartConfigDuration = useMemo<ChartConfig>(
     () => ({
-      durationSec: {
-        label: t("holdDuration"),
-        color: "hsl(var(--primary))",
-      },
+      value: { label: t("holdDuration"), color: "hsl(var(--primary))" },
+      trend: { label: t("trend"), color: "hsl(var(--primary))" },
     }),
     [t],
   )
 
   const chartDataReps = useMemo(() => {
     if (!logs) return []
-    return logs.map((log) => {
-      const r = parseInt(log.reps_logged ?? "0", 10)
-      return {
-        date: formatDate(log.logged_at, i18n.language, {
-          month: "short",
-          day: "numeric",
-        }),
-        reps: Number.isFinite(r) ? r : 0,
-      }
-    })
-  }, [logs, i18n.language])
+    const series = buildExerciseTrendSeries(logs, "reps")
+    return series.scatter.map((p, i) => ({
+      timestamp: p.timestamp,
+      value: p.value,
+      trend: Math.round(series.trend[i].value * 10) / 10,
+    }))
+  }, [logs])
 
   const chartDataE1rm = useMemo(() => {
     if (!logs) return []
-    return logs.map((log) => {
-      const w = Number(log.weight_logged)
-      const r = parseInt(log.reps_logged ?? "0", 10)
-      const e1rm =
-        log.estimated_1rm != null
-          ? Number(log.estimated_1rm)
-          : computeEpley1RM(w, r)
-      return {
-        date: formatDate(log.logged_at, i18n.language, {
-          month: "short",
-          day: "numeric",
-        }),
-        e1rm: Math.round(toDisplay(e1rm) * 10) / 10,
-      }
-    })
-  }, [logs, i18n.language, toDisplay])
+    const series = buildExerciseTrendSeries(logs, "e1rm")
+    return series.scatter.map((p, i) => ({
+      timestamp: p.timestamp,
+      value: Math.round(toDisplay(p.value) * 10) / 10,
+      trend: Math.round(toDisplay(series.trend[i].value) * 10) / 10,
+    }))
+  }, [logs, toDisplay])
 
   const chartDataDuration = useMemo(() => {
     if (!logs) return []
-    return logs
-      .filter((log) => log.duration_seconds != null)
-      .map((log) => ({
-        date: formatDate(log.logged_at, i18n.language, {
-          month: "short",
-          day: "numeric",
-        }),
-        durationSec: Number(log.duration_seconds),
-      }))
-  }, [logs, i18n.language])
+    const series = buildExerciseTrendSeries(logs, "duration")
+    return series.scatter.map((p, i) => ({
+      timestamp: p.timestamp,
+      value: p.value,
+      trend: Math.round(series.trend[i].value),
+    }))
+  }, [logs])
 
   const tableRowsBodyweight = useMemo(() => {
     if (!logs) return []
-    return logs.map((log) => ({
-      id: log.id,
-      date: formatDate(log.logged_at, i18n.language, {
-        month: "short",
-        day: "numeric",
-      }),
-      reps: log.reps_logged,
-      wasPr: log.was_pr,
-    }))
-  }, [logs, i18n.language])
-
-  const tableRowsReps = useMemo(() => {
-    if (!logs) return []
-    return logs.map((log) => {
-      const w = Number(log.weight_logged)
-      const r = parseInt(log.reps_logged ?? "0", 10)
-      const e1rm =
-        log.estimated_1rm != null
-          ? Number(log.estimated_1rm)
-          : computeEpley1RM(w, r)
-      return {
+    return logs
+      .map((log) => ({
         id: log.id,
         date: formatDate(log.logged_at, i18n.language, {
           month: "short",
           day: "numeric",
         }),
         reps: log.reps_logged,
-        weightKg: w,
-        e1rm: Math.round(e1rm),
         wasPr: log.was_pr,
-      }
-    })
+      }))
+      .reverse()
+  }, [logs, i18n.language])
+
+  const tableRowsReps = useMemo(() => {
+    if (!logs) return []
+    return logs
+      .map((log) => {
+        const w = Number(log.weight_logged)
+        const r = parseInt(log.reps_logged ?? "0", 10)
+        const e1rm =
+          log.estimated_1rm != null
+            ? Number(log.estimated_1rm)
+            : computeEpley1RM(w, r)
+        return {
+          id: log.id,
+          date: formatDate(log.logged_at, i18n.language, {
+            month: "short",
+            day: "numeric",
+          }),
+          reps: log.reps_logged,
+          weightKg: w,
+          e1rm: Math.round(e1rm),
+          wasPr: log.was_pr,
+        }
+      })
+      .reverse()
   }, [logs, i18n.language])
 
   const tableRowsDuration = useMemo(() => {
     if (!logs) return []
-    return logs.map((log) => ({
-      id: log.id,
-      date: formatDate(log.logged_at, i18n.language, {
-        month: "short",
-        day: "numeric",
-      }),
-      durationLabel:
-        log.duration_seconds != null
-          ? formatSecondsMMSS(log.duration_seconds)
-          : "–",
-      weightKg: Number(log.weight_logged),
-      wasPr: log.was_pr,
-    }))
+    return logs
+      .map((log) => ({
+        id: log.id,
+        date: formatDate(log.logged_at, i18n.language, {
+          month: "short",
+          day: "numeric",
+        }),
+        durationLabel:
+          log.duration_seconds != null
+            ? formatSecondsMMSS(log.duration_seconds)
+            : "–",
+        weightKg: Number(log.weight_logged),
+        wasPr: log.was_pr,
+      }))
+      .reverse()
   }, [logs, i18n.language])
 
   if (loading) {
@@ -177,16 +200,24 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
     return (
       <div className="flex flex-col gap-4">
         <ChartContainer config={chartConfigDuration} className="aspect-2/1 w-full">
-          <LineChart
+          <ComposedChart
             data={chartDataDuration}
             margin={{ top: 8, right: 8, bottom: 0, left: -16 }}
           >
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
             <XAxis
-              dataKey="date"
+              dataKey="timestamp"
+              type="number"
+              domain={["dataMin", "dataMax"]}
               tickLine={false}
               axisLine={false}
               fontSize={11}
+              tickFormatter={(ts) =>
+                formatDate(new Date(Number(ts)), i18n.language, {
+                  month: "short",
+                  day: "numeric",
+                })
+              }
             />
             <YAxis
               tickLine={false}
@@ -196,14 +227,20 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
               tickFormatter={(v) => (Number(v) >= 60 ? formatSecondsMMSS(Number(v)) : `${v}s`)}
             />
             <ChartTooltip content={<ChartTooltipContent />} />
+            <Scatter
+              dataKey="value"
+              fill="var(--color-value)"
+              fillOpacity={0.4}
+              shape="circle"
+            />
             <Line
-              dataKey="durationSec"
+              dataKey="trend"
               type="monotone"
-              stroke="var(--color-durationSec)"
+              stroke="var(--color-trend)"
               strokeWidth={2}
               dot={false}
             />
-          </LineChart>
+          </ComposedChart>
         </ChartContainer>
 
         <Table className="text-xs">
@@ -216,7 +253,7 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {tableRowsDuration.map((row) => (
+            {tableRowsDuration.slice(0, visibleCount).map((row) => (
               <TableRow key={row.id}>
                 <TableCell className="px-2 py-1.5">{row.date}</TableCell>
                 <TableCell className="px-2 py-1.5 font-mono tabular-nums">
@@ -237,6 +274,12 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
             ))}
           </TableBody>
         </Table>
+        <LoadMoreButton
+          visible={visibleCount}
+          total={tableRowsDuration.length}
+          onClick={() => setVisibleCount((n) => n + TABLE_PAGE_SIZE)}
+          label={t("loadMore")}
+        />
       </div>
     )
   }
@@ -245,13 +288,21 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
     return (
       <div className="flex flex-col gap-4">
         <ChartContainer config={chartConfigReps} className="aspect-2/1 w-full">
-          <LineChart data={chartDataReps} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+          <ComposedChart data={chartDataReps} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
             <XAxis
-              dataKey="date"
+              dataKey="timestamp"
+              type="number"
+              domain={["dataMin", "dataMax"]}
               tickLine={false}
               axisLine={false}
               fontSize={11}
+              tickFormatter={(ts) =>
+                formatDate(new Date(Number(ts)), i18n.language, {
+                  month: "short",
+                  day: "numeric",
+                })
+              }
             />
             <YAxis
               tickLine={false}
@@ -261,14 +312,20 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
               allowDecimals={false}
             />
             <ChartTooltip content={<ChartTooltipContent />} />
+            <Scatter
+              dataKey="value"
+              fill="var(--color-value)"
+              fillOpacity={0.4}
+              shape="circle"
+            />
             <Line
-              dataKey="reps"
+              dataKey="trend"
               type="monotone"
-              stroke="var(--color-reps)"
+              stroke="var(--color-trend)"
               strokeWidth={2}
               dot={false}
             />
-          </LineChart>
+          </ComposedChart>
         </ChartContainer>
 
         <Table className="text-xs">
@@ -280,7 +337,7 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {tableRowsBodyweight.map((row) => (
+            {tableRowsBodyweight.slice(0, visibleCount).map((row) => (
               <TableRow key={row.id}>
                 <TableCell className="px-2 py-1.5">{row.date}</TableCell>
                 <TableCell className="px-2 py-1.5 tabular-nums">{row.reps}</TableCell>
@@ -296,6 +353,12 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
             ))}
           </TableBody>
         </Table>
+        <LoadMoreButton
+          visible={visibleCount}
+          total={tableRowsBodyweight.length}
+          onClick={() => setVisibleCount((n) => n + TABLE_PAGE_SIZE)}
+          label={t("loadMore")}
+        />
       </div>
     )
   }
@@ -303,13 +366,21 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
   return (
     <div className="flex flex-col gap-4">
       <ChartContainer config={chartConfigE1rm} className="aspect-2/1 w-full">
-        <LineChart data={chartDataE1rm} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+        <ComposedChart data={chartDataE1rm} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
           <CartesianGrid strokeDasharray="3 3" vertical={false} />
           <XAxis
-            dataKey="date"
+            dataKey="timestamp"
+            type="number"
+            domain={["dataMin", "dataMax"]}
             tickLine={false}
             axisLine={false}
             fontSize={11}
+            tickFormatter={(ts) =>
+              formatDate(new Date(Number(ts)), i18n.language, {
+                month: "short",
+                day: "numeric",
+              })
+            }
           />
           <YAxis
             tickLine={false}
@@ -318,14 +389,20 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
             width={40}
           />
           <ChartTooltip content={<ChartTooltipContent />} />
+          <Scatter
+            dataKey="value"
+            fill="var(--color-value)"
+            fillOpacity={0.4}
+            shape="circle"
+          />
           <Line
-            dataKey="e1rm"
+            dataKey="trend"
             type="monotone"
-            stroke="var(--color-e1rm)"
+            stroke="var(--color-trend)"
             strokeWidth={2}
             dot={false}
           />
-        </LineChart>
+        </ComposedChart>
       </ChartContainer>
 
       <Table className="text-xs">
@@ -339,7 +416,7 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {tableRowsReps.map((row) => (
+          {tableRowsReps.slice(0, visibleCount).map((row) => (
             <TableRow key={row.id}>
               <TableCell className="px-2 py-1.5">{row.date}</TableCell>
               <TableCell className="px-2 py-1.5 tabular-nums">{row.reps}</TableCell>
@@ -359,6 +436,12 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
           ))}
         </TableBody>
       </Table>
+      <LoadMoreButton
+        visible={visibleCount}
+        total={tableRowsReps.length}
+        onClick={() => setVisibleCount((n) => n + TABLE_PAGE_SIZE)}
+        label={t("loadMore")}
+      />
     </div>
   )
 }

--- a/src/components/history/ExerciseChart.tsx
+++ b/src/components/history/ExerciseChart.tsx
@@ -58,6 +58,44 @@ function LoadMoreButton({
   )
 }
 
+type TooltipPayloadItem = {
+  dataKey?: string | number
+  payload?: { timestamp?: number }
+}
+
+/**
+ * Wraps `ChartTooltipContent` to (a) format the X-axis timestamp as a date in
+ * the header and (b) hide the raw `timestamp` row that recharts auto-includes
+ * for Scatter series on a numeric X-axis.
+ */
+function TrendChartTooltip({
+  language,
+  active,
+  payload,
+}: {
+  language: string
+  active?: boolean
+  payload?: TooltipPayloadItem[]
+}) {
+  if (!active || !payload || payload.length === 0) return null
+  const filtered = payload.filter((p) => p.dataKey !== "timestamp")
+  const timestamp = payload[0]?.payload?.timestamp
+  return (
+    <ChartTooltipContent
+      active={active}
+      payload={filtered as never}
+      labelFormatter={() =>
+        timestamp != null
+          ? formatDate(new Date(timestamp), language, {
+              month: "short",
+              day: "numeric",
+            })
+          : ""
+      }
+    />
+  )
+}
+
 export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
   const { t, i18n } = useTranslation("history")
   const { formatWeight, toDisplay, unit } = useWeightUnit()
@@ -226,7 +264,7 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
               width={40}
               tickFormatter={(v) => (Number(v) >= 60 ? formatSecondsMMSS(Number(v)) : `${v}s`)}
             />
-            <ChartTooltip content={<ChartTooltipContent />} />
+            <ChartTooltip content={<TrendChartTooltip language={i18n.language} />} />
             <Scatter
               dataKey="value"
               fill="var(--color-value)"
@@ -311,7 +349,7 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
               width={40}
               allowDecimals={false}
             />
-            <ChartTooltip content={<ChartTooltipContent />} />
+            <ChartTooltip content={<TrendChartTooltip language={i18n.language} />} />
             <Scatter
               dataKey="value"
               fill="var(--color-value)"
@@ -388,7 +426,7 @@ export function ExerciseChart({ exerciseId }: { exerciseId: string }) {
             fontSize={11}
             width={40}
           />
-          <ChartTooltip content={<ChartTooltipContent />} />
+          <ChartTooltip content={<TrendChartTooltip language={i18n.language} />} />
           <Scatter
             dataKey="value"
             fill="var(--color-value)"

--- a/src/components/history/ExerciseTab.tsx
+++ b/src/components/history/ExerciseTab.tsx
@@ -83,7 +83,7 @@ export function ExerciseTab() {
       </Popover>
 
       {selectedId ? (
-        <ExerciseChart exerciseId={selectedId} />
+        <ExerciseChart key={selectedId} exerciseId={selectedId} />
       ) : (
         <p className="py-12 text-center text-sm text-muted-foreground">
           {t("pickExercise")}

--- a/src/lib/exerciseTrend.test.ts
+++ b/src/lib/exerciseTrend.test.ts
@@ -46,6 +46,24 @@ describe("buildExerciseTrendSeries — trend semantics", () => {
     expect(endOfDay2).toBeLessThanOrEqual(endOfDay1)
   })
 
+  it("excludes e1rm points whose reps_logged is missing and no estimated_1rm is provided", () => {
+    const logs: SetLog[] = [
+      makeLog({ logged_at: "2026-05-01T10:00:00Z", reps_logged: "8", weight_logged: 40 }),
+      makeLog({
+        logged_at: "2026-05-02T10:00:00Z",
+        reps_logged: null,
+        weight_logged: 40,
+        estimated_1rm: null,
+      }),
+      makeLog({ logged_at: "2026-05-03T10:00:00Z", reps_logged: "10", weight_logged: 40 }),
+    ]
+
+    const series = buildExerciseTrendSeries(logs, "e1rm")
+
+    expect(series.scatter).toHaveLength(2)
+    expect(series.scatter.every((p) => p.value > 0)).toBe(true)
+  })
+
   it("smooths the trend as a rolling mean of the configured window over set values", () => {
     const logs: SetLog[] = [10, 20, 30, 40, 50].map((e1rm, i) =>
       makeLog({

--- a/src/lib/exerciseTrend.test.ts
+++ b/src/lib/exerciseTrend.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest"
+import { buildExerciseTrendSeries } from "./exerciseTrend"
+import type { SetLog } from "@/types/database"
+
+let logIdCounter = 0
+
+function makeLog(overrides: Partial<SetLog> = {}): SetLog {
+  logIdCounter += 1
+  return {
+    id: `log-${logIdCounter}`,
+    session_id: "session-1",
+    exercise_id: "exercise-1",
+    exercise_name_snapshot: "Bench Press",
+    set_number: 1,
+    reps_logged: "8",
+    duration_seconds: null,
+    weight_logged: 40,
+    estimated_1rm: null,
+    was_pr: false,
+    logged_at: "2026-05-01T10:00:00Z",
+    rir: null,
+    rest_seconds: null,
+    ...overrides,
+  }
+}
+
+describe("buildExerciseTrendSeries — trend semantics", () => {
+  it("does not surface false progression when day-2 has one peak set followed by collapses (8/8/8 → 10/4/4 @ 40 kg)", () => {
+    const day1 = "2026-05-01T10:00:00Z"
+    const day2 = "2026-05-02T10:00:00Z"
+
+    const logs: SetLog[] = [
+      makeLog({ logged_at: day1, reps_logged: "8" }),
+      makeLog({ logged_at: day1, reps_logged: "8" }),
+      makeLog({ logged_at: day1, reps_logged: "8" }),
+      makeLog({ logged_at: day2, reps_logged: "10" }),
+      makeLog({ logged_at: day2, reps_logged: "4" }),
+      makeLog({ logged_at: day2, reps_logged: "4" }),
+    ]
+
+    const series = buildExerciseTrendSeries(logs, "e1rm")
+
+    const endOfDay1 = series.trend[2].value
+    const endOfDay2 = series.trend[5].value
+
+    expect(endOfDay2).toBeLessThanOrEqual(endOfDay1)
+  })
+
+  it("smooths the trend as a rolling mean of the configured window over set values", () => {
+    const logs: SetLog[] = [10, 20, 30, 40, 50].map((e1rm, i) =>
+      makeLog({
+        logged_at: `2026-05-0${i + 1}T10:00:00Z`,
+        estimated_1rm: e1rm,
+      }),
+    )
+
+    const series = buildExerciseTrendSeries(logs, "e1rm", { window: 3 })
+
+    expect(series.trend.map((p) => p.value)).toEqual([10, 15, 20, 30, 40])
+  })
+})
+
+describe("buildExerciseTrendSeries — reps variant", () => {
+  it("uses parsed reps_logged as the value and excludes logs with non-numeric reps", () => {
+    const logs: SetLog[] = [
+      makeLog({ logged_at: "2026-05-01T10:00:00Z", reps_logged: "8" }),
+      makeLog({ logged_at: "2026-05-02T10:00:00Z", reps_logged: "10" }),
+      makeLog({ logged_at: "2026-05-03T10:00:00Z", reps_logged: null }),
+      makeLog({ logged_at: "2026-05-04T10:00:00Z", reps_logged: "12" }),
+    ]
+
+    const series = buildExerciseTrendSeries(logs, "reps", { window: 2 })
+
+    expect(series.scatter.map((p) => p.value)).toEqual([8, 10, 12])
+    expect(series.trend.map((p) => p.value)).toEqual([8, 9, 11])
+  })
+})
+
+describe("buildExerciseTrendSeries — duration variant", () => {
+  it("uses duration_seconds as the value and excludes logs without a duration", () => {
+    const logs: SetLog[] = [
+      makeLog({ logged_at: "2026-05-01T10:00:00Z", duration_seconds: 30 }),
+      makeLog({ logged_at: "2026-05-02T10:00:00Z", duration_seconds: null }),
+      makeLog({ logged_at: "2026-05-03T10:00:00Z", duration_seconds: 45 }),
+      makeLog({ logged_at: "2026-05-04T10:00:00Z", duration_seconds: 60 }),
+    ]
+
+    const series = buildExerciseTrendSeries(logs, "duration", { window: 2 })
+
+    expect(series.scatter.map((p) => p.value)).toEqual([30, 45, 60])
+    expect(series.trend.map((p) => p.value)).toEqual([30, 37.5, 52.5])
+  })
+})

--- a/src/lib/exerciseTrend.ts
+++ b/src/lib/exerciseTrend.ts
@@ -68,8 +68,9 @@ function extractTrendPoint(log: SetLog, variant: TrendVariant): TrendPoint | nul
 }
 
 function rollingMean(values: number[], windowSize: number): number[] {
+  const safeWindow = Math.max(1, Math.floor(windowSize))
   return values.map((_, i) => {
-    const start = Math.max(0, i + 1 - windowSize)
+    const start = Math.max(0, i + 1 - safeWindow)
     const slice = values.slice(start, i + 1)
     return slice.reduce((sum, v) => sum + v, 0) / slice.length
   })

--- a/src/lib/exerciseTrend.ts
+++ b/src/lib/exerciseTrend.ts
@@ -1,0 +1,76 @@
+import { computeEpley1RM } from "./epley"
+import type { SetLog } from "@/types/database"
+
+export type TrendVariant = "e1rm" | "reps" | "duration"
+
+export interface TrendPoint {
+  timestamp: number
+  value: number
+}
+
+export interface TrendSeries {
+  scatter: TrendPoint[]
+  trend: TrendPoint[]
+}
+
+const DEFAULT_WINDOW = 7
+
+export function buildExerciseTrendSeries(
+  logs: SetLog[],
+  variant: TrendVariant,
+  options: { window?: number } = {},
+): TrendSeries {
+  const windowSize = options.window ?? DEFAULT_WINDOW
+
+  const sorted = logs
+    .slice()
+    .sort((a, b) => Date.parse(a.logged_at) - Date.parse(b.logged_at))
+
+  const scatter = sorted
+    .map((log) => extractTrendPoint(log, variant))
+    .filter((point): point is TrendPoint => point !== null)
+
+  const trendValues = rollingMean(
+    scatter.map((p) => p.value),
+    windowSize,
+  )
+  const trend = scatter.map<TrendPoint>((p, i) => ({
+    timestamp: p.timestamp,
+    value: trendValues[i],
+  }))
+
+  return { scatter, trend }
+}
+
+function extractTrendPoint(log: SetLog, variant: TrendVariant): TrendPoint | null {
+  const timestamp = Date.parse(log.logged_at)
+  switch (variant) {
+    case "e1rm": {
+      const value =
+        log.estimated_1rm != null
+          ? Number(log.estimated_1rm)
+          : computeEpley1RM(
+              Number(log.weight_logged),
+              parseInt(log.reps_logged ?? "0", 10),
+            )
+      return { timestamp, value }
+    }
+    case "reps": {
+      const reps = parseInt(log.reps_logged ?? "", 10)
+      if (!Number.isFinite(reps)) return null
+      return { timestamp, value: reps }
+    }
+    case "duration": {
+      if (log.duration_seconds == null) return null
+      return { timestamp, value: log.duration_seconds }
+    }
+  }
+}
+
+function rollingMean(values: number[], windowSize: number): number[] {
+  return values.map((_, i) => {
+    const start = Math.max(0, i + 1 - windowSize)
+    const slice = values.slice(start, i + 1)
+    return slice.reduce((sum, v) => sum + v, 0) / slice.length
+  })
+}

--- a/src/lib/exerciseTrend.ts
+++ b/src/lib/exerciseTrend.ts
@@ -53,6 +53,7 @@ function extractTrendPoint(log: SetLog, variant: TrendVariant): TrendPoint | nul
               Number(log.weight_logged),
               parseInt(log.reps_logged ?? "0", 10),
             )
+      if (!Number.isFinite(value) || value <= 0) return null
       return { timestamp, value }
     }
     case "reps": {

--- a/src/locales/en/history.json
+++ b/src/locales/en/history.json
@@ -34,6 +34,8 @@
   "date": "Date",
   "holdDuration": "Duration",
   "noData": "No data for this exercise yet.",
+  "trend": "Trend",
+  "loadMore": "Load more",
   "loadingSets": "Loading sets…",
   "noSetsRecorded": "No sets recorded.",
   "noSessions": "No sessions yet.",

--- a/src/locales/fr/history.json
+++ b/src/locales/fr/history.json
@@ -34,6 +34,8 @@
   "date": "Date",
   "holdDuration": "Durée",
   "noData": "Pas encore de données pour cet exercice.",
+  "trend": "Tendance",
+  "loadMore": "Voir plus",
   "loadingSets": "Chargement des séries…",
   "noSetsRecorded": "Aucune série enregistrée.",
   "noSessions": "Aucune séance pour l'instant.",


### PR DESCRIPTION
## What

- Replace the per-day cherry-picking line in **Historique → Par exercice** with a **set-level scatter** plus a **rolling-mean trend line** on a time-based numeric X-axis.
- Reverse the per-set table to **newest-first** and paginate at **100 rows** with a `Load more` button.
- New pure module `src/lib/exerciseTrend.ts` shapes the chart data (`{ scatter, trend }`) for all three variants (e1RM / reps / duration).

## Why

Two papercuts in the same view, both rooted in the chart consuming raw `set_logs` (one row per set, ascending) with no aggregation and no truncation:

1. **Duplicate X-axis ticks.** Multiple sets on the same day → labels like `3 mai`, `3 mai`, `3 mai` and a line that jitters around intra-day spread. A first instinct ("just take the daily max") was rejected because it lies: 8/8/8 → 10/4/4 looks like progress on a max chart, but the lifter actually did fewer reps and probably had a worse day. The chart needs to show **all sets** and let the user judge consistency.
2. **Oldest-first, unbounded table.** With 1014+ sets in the wild, the user has to scroll past March entries to see today's session, and the DOM grows linearly forever.

## How

**Chart**:
- `buildExerciseTrendSeries(logs, variant, { window? })` returns `{ scatter, trend }` with one scatter point per set. The trend is a rolling mean (default window: 7 sets — density-adaptive, simpler than calendar-based).
- Per-variant value extraction is a small `extractTrendPoint` switch: e1RM uses `estimated_1rm` if present else falls back to Epley; reps parses `reps_logged` and drops non-numeric; duration drops null `duration_seconds`.
- Component switches `LineChart` → `ComposedChart` with `<Scatter dataKey="value">` (semi-transparent dots) + `<Line dataKey="trend">`. X-axis becomes `type="number"` keyed on `timestamp` with a `tickFormatter` rendering month-day labels — recharts now picks tick density automatically and same-day points stack on a single X coordinate (the duplicate-ticks bug dies for free).

**Table**:
- `useState(100)` paginates each variant's reversed rows; extracted a small inline `LoadMoreButton` to avoid 3× duplicated JSX across the duration / bodyweight / weighted branches.

**TDD coverage** (red → green → refactor):
- 4 unit tests on `buildExerciseTrendSeries` — including the **8/8/8 @ 40 kg → 10/4/4 @ 40 kg** case, asserting the trend at end-of-day-2 is **not above** end-of-day-1 (locks the design choice as a regression-resistant guarantee).
- 3 component tests — newest-first ordering, button hidden ≤100 rows, button present + click reveals next 100 with auto-hide when fully expanded.
- The recharts JSX wiring itself is **not test-driven** (recharts SVG is brittle to assert on); covered transitively by the lib tests + visual review on this PR.

## Visual review checklist

- [ ] Multi-set days stack vertically on a single X position (no duplicate ticks).
- [ ] Trend line stays roughly flat in the 8/8/8 → 10/4/4 scenario.
- [ ] Tooltip shows both `value` and `trend` on hover.
- [ ] Scatter dot density readable on 1000+ sets — drop opacity from 0.4 → 0.25 if it's a mosh pit.
- [ ] Table newest-first, `Load more` reveals 100 more, button disappears at the end.

Closes #366

Made with [Cursor](https://cursor.com)