### PR TITLE
fix(#371): pre-session list shows Progression Suggestion values + compact pill

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -104,3 +104,23 @@ The **Embedded Agent**-backed AI generation path triggered from `QuickWorkoutShe
 
 **`generate-quick-workout` + `commit-quick-workout` Edge Functions**:
 **V1** new Supabase Edge surface that backs **Quick Workout AI (v1)**, split into **two separate functions** (locked decision — see **ADR 0002 §3**). **Two-phase, Embedded-Agent-shaped** (see **Embedded Agent**) because `PreviewStep` allows the user to edit the AI's suggestion before committing — mirrors the **Onboarding program commit gate** pattern. **`generate-quick-workout` (preview, idempotent):** runs quota check (**`quick_workout`**), catalog/profile/history fetch, one-shot Gemini call with workout-specific prompt, validate-and-repair, returns `{ exercises[], rationale }` — **no database write**. **`commit-quick-workout` (commit, mutator):** accepts the post-edit `{ label, exercises[] }` payload, calls **MCP `create_workout_day`** server → MCP via **MCP Edge Function URL** with the user's session JWT as Bearer (auth dualism — PATs vs session JWTs — already supported by `file:supabase/functions/mcp/lib/authLogic.ts:80-82`, no new auth surface), `dry_run: false`. Returns `{ workout_day_id }`. No quota burn on commit (the LLM call already paid). **Why two functions, not one with modes:** preview and commit have different semantics (idempotent vs mutator), different observability shapes, different retry policies — splitting keeps each focused. Replaces `file:supabase/functions/generate-workout/` (deleted as part of this migration). **AI Save-as-draft does not flow through these functions** — drafts stay PWA-local via `useCreateQuickWorkout`.
+
+---
+
+## Progression engine
+
+**Progression Rule**:
+The decision the engine emits for a given exercise's next session, based on **Last Performance** + RIR averaging. Enum: `WEIGHT_UP | REPS_UP | SETS_UP | DURATION_UP | HOLD_INCOMPLETE | HOLD_NEAR_FAILURE | PLATEAU`. The first four are **auto-applied** (the **Progression Suggestion**'s value differs from the previous session); the last three hold the value steady for explanatory reasons.
+→ `file:src/lib/progression.ts`
+
+**Progression Suggestion**:
+Engine output for a single exercise: `{ rule, reps, weight, sets, delta, reasonKey, volumeType, duration? }`. The canonical "what should the user do this session" payload — drives the in-session **`SetsTable`**, the in-session `ProgressionPill`, and (post-#371) the pre-session list rows. Computed by `computeNextSessionTarget(prescription, lastPerformance)`. Falls back to `null` when there is no **Last Performance** to anchor against.
+→ `file:src/lib/progression.ts`, `file:src/hooks/useProgressionSuggestion.ts`
+
+**Template Prescription**:
+The `weight` / `reps` / `sets` (+ optional duration / range / increment fields) stored on `workout_exercises`, written exclusively by the Builder. Used by the engine **only as bootstrap fallback** when no **Last Performance** exists (i.e. the very first session for that exercise). Subsequent sessions ignore the template's `weight` and use the **Last Performance** weight instead — manual Builder edits to `weight` after the first session are effectively a no-op for the engine. Pre-existing limitation; deload / return-from-injury flows currently have no clean override path.
+→ `file:src/types/database.ts`
+
+**Last Performance**:
+The `set_logs` rows from the most recent session that logged a given exercise. Source of `currentWeight` for the engine when non-null (beats **Template Prescription**). Filtered by `logged_at < sessionStartedAt` when called in-session (so the live session's own logs don't pollute the comparison) or unfiltered pre-session.
+→ `file:src/hooks/useLastSessionDetail.ts`

--- a/docs/Tech_Plan_—_Pre-session_Progression_Display_#371.md
+++ b/docs/Tech_Plan_—_Pre-session_Progression_Display_#371.md
@@ -1,0 +1,239 @@
+# Tech Plan — Pre-session Progression Display
+
+> Issue: [#371 — fix(workout): pre-session list shows stale template weight](https://github.com/PierreTsia/workout-app/issues/371). Grilling notes: glossary section `Progression engine` in `docs/CONTEXT.md`. Architectural ADR: `docs/adr/0005-batch-progression-suggestions-per-day.md`.
+
+## Architectural Approach
+
+The pre-session row currently displays **Template Prescription** (`workout_exercises.weight/reps/sets`), which silently drifts from the engine-prescribed value the moment a `Last Performance` exists. Once the user taps **Start**, `SetsTable` jumps to the **Progression Suggestion**, exposing the gap.
+
+We close the gap by computing the **Progression Suggestion** for every visible pre-session row and rendering it inline, with a compact `ProgressionPill` carrying the rule-specific rationale. Computation is **batched per workout day** via a new Postgres RPC + aggregator hook (per ADR 0005). Rows render immediately with static fields; only the value+pill slot shows a skeleton until suggestions resolve.
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Source of truth for pre-session row values | **Progression Suggestion** from the engine, fallback to **Template Prescription** when the suggestion is `null` (no **Last Performance**) | Eliminates the misleading template values; matches in-session behavior. |
+| Suggestion fetch shape | **Postgres RPC** `get_last_performance_for_exercises(uuid[])` | One round-trip per visible day instead of N (ADR 0005). Mirrors 7+ existing `get_*` RPCs. |
+| Aggregator hook | **`useProgressionSuggestionsForDay(dayId, exercises)`** in `src/hooks/`, TanStack Query | Cache keyed on `(dayId, exercise_ids[])`; dedupe + refetch-on-invalidate gratis. |
+| Per-row loading UX | **Skeleton in pill+weight slot only**; rest of the row renders immediately | Avoids blocking the screen on the new query. Driven by `useQuery`'s `isLoading` (cache-warm = no skeleton). |
+| Indicator visual | **Compact `ProgressionPill` variant** (icon-only, popover unchanged) | Single source of truth for rule → icon → color mapping. New prop `compact?: boolean`. |
+| Indicator scope | **All `Progression Rule` values** (auto-applied + `HOLD_*` + `PLATEAU`) | Consistency with in-session UX; HOLD pills carry useful pre-session context. |
+| Volume axes covered | **All four** (reps / weight / sets / duration) | Bug is "row ignores engine", not "weight is wrong" (grilling Q1). |
+| Pill placement | **Inline with weight** in the row subtitle: `3 × 10 · 57 kg [↑]` | Couples the pill to the value it justifies. |
+| Surface scope | **`PreSessionExerciseList` only**. `ExerciseListPreview` (done-in-cycle) untouched. | Done days display actual logged perfs; predictions there would conflict with reality. |
+| RPC error UX | **Subtle text indicator** at the top of the list ("Suggestions indisponibles, valeurs par défaut affichées") + silent fallback to template per row | Transparent without blocking; the session can still start. |
+| Helper refactor | **Extract `buildPrescription` from `useProgressionSuggestion` into `src/lib/progression.ts`** | Both hooks (per-exercise + batched) consume it; pure-function tests are simpler than hook tests. |
+| New DB index | **`idx_set_logs_exercise_logged_at` on `(exercise_id, logged_at DESC)`** in the same migration | Without it, the RPC's `DISTINCT ON` triggers a `set_logs` full scan. |
+
+### Critical Constraints
+
+**RLS preservation.** The new RPC runs as `SECURITY INVOKER` (PostgreSQL default). The existing `set_logs` policy (`auth.uid = sessions.user_id`) applies transparently. No `SECURITY DEFINER` shortcut. Migration test: invoke as a non-owning user → 0 rows.
+
+**No mutation of `Template Prescription`.** This plan **does not write to `workout_exercises`**. The deferred deload / return-from-injury edge case (manual Builder edit of `weight` ignored when `Last Performance` is non-null) stays as-is. Documented in `docs/CONTEXT.md` under **Template Prescription**.
+
+**Cache invalidation on session finish.** When the user finishes a session via `handleFinish` in `file:src/pages/WorkoutPage.tsx`, the new query namespace must be invalidated so swiping to another day reflects the freshly-logged perf. Hook into the existing invalidation cluster alongside `workout-exercises` and `cycle-progress`.
+
+**Carousel `shouldFetch` parity.** The new hook respects the same gating as `useWorkoutExercises` (active slide ± 1). When the slide is off-screen: `enabled: false` to avoid burning quota on suggestions the user won't see.
+
+**`useProgressionSuggestion` stays.** The per-exercise hook keeps its current shape for `ExerciseDetail` in-session usage. We don't unify the two paths — they have different lifecycles (per-row stateful subscription vs. per-day batch). Both consume the extracted `buildPrescription` helper.
+
+---
+
+## Data Model
+
+### New RPC
+
+```sql
+-- supabase/migrations/{ts}_create_get_last_performance_for_exercises.sql
+
+CREATE INDEX IF NOT EXISTS idx_set_logs_exercise_logged_at
+  ON set_logs (exercise_id, logged_at DESC);
+
+CREATE OR REPLACE FUNCTION get_last_performance_for_exercises(
+  p_exercise_ids uuid[]
+)
+RETURNS TABLE (
+  exercise_id uuid,
+  session_id uuid,
+  set_number integer,
+  reps_logged text,
+  weight_logged numeric,
+  rir integer,
+  duration_seconds integer,
+  logged_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH latest_session_per_exercise AS (
+    SELECT DISTINCT ON (sl.exercise_id)
+      sl.exercise_id,
+      sl.session_id
+    FROM set_logs sl
+    WHERE sl.exercise_id = ANY(p_exercise_ids)
+    ORDER BY sl.exercise_id, sl.logged_at DESC
+  )
+  SELECT
+    sl.exercise_id,
+    sl.session_id,
+    sl.set_number,
+    sl.reps_logged,
+    sl.weight_logged,
+    sl.rir,
+    sl.duration_seconds,
+    sl.logged_at
+  FROM set_logs sl
+  JOIN latest_session_per_exercise lsp
+    ON sl.exercise_id = lsp.exercise_id
+    AND sl.session_id = lsp.session_id
+  ORDER BY sl.exercise_id, sl.set_number;
+$$;
+```
+
+### Table Notes
+
+- `DISTINCT ON (exercise_id) ORDER BY exercise_id, logged_at DESC` extracts the latest `(exercise_id, session_id)` per exercise; the JOIN-back fetches all set_logs of that session. Result size: up to N × ~5 rows where N = exercises in the day.
+- The composite index `(exercise_id, logged_at DESC)` is critical for `DISTINCT ON`; otherwise it becomes a full scan + sort on a table that grows with every session.
+- No new TypeScript types. RPC rows map cleanly onto `SetPerformance[]` (already defined in `file:src/lib/progression.ts`) once grouped by `exercise_id`.
+
+### Data flow
+
+```mermaid
+graph TD
+    WP[WorkoutPage]
+    UWE[useWorkoutExercises]
+    UPSFD[useProgressionSuggestionsForDay]
+    RPC[(RPC: get_last_performance_for_exercises)]
+    SL[(set_logs)]
+    Engine[computeNextSessionTarget]
+    Map[Map exercise_id, ProgressionSuggestion or null]
+
+    WP --> UWE
+    WP --> UPSFD
+    UPSFD --> RPC
+    RPC --> SL
+    UPSFD --> Engine
+    Engine --> Map
+    Map --> WP
+```
+
+---
+
+## Component Architecture
+
+### Layer Overview
+
+```mermaid
+graph TD
+    subgraph "Pre-session UI"
+        WP[WorkoutPage]
+        PSEL[PreSessionExerciseList]
+        EERC[ExerciseEditRowControls *N*]
+        PP[ProgressionPill compact]
+        SK[Skeleton]
+        ERR[Error indicator]
+    end
+    subgraph "Data layer"
+        UWE[useWorkoutExercises]
+        UPSFD[useProgressionSuggestionsForDay]
+    end
+    subgraph "DB"
+        RPC[get_last_performance_for_exercises]
+    end
+
+    WP --> UWE
+    WP --> UPSFD
+    UPSFD --> RPC
+    WP --> PSEL
+    PSEL --> ERR
+    PSEL --> EERC
+    EERC -.loading.-> SK
+    EERC -.loaded.-> PP
+```
+
+### New Files & Responsibilities
+
+| File | Purpose |
+|---|---|
+| `supabase/migrations/{ts}_create_get_last_performance_for_exercises.sql` | New RPC + composite index. `SECURITY INVOKER`. |
+| `src/hooks/useProgressionSuggestionsForDay.ts` | Batched hook. Inputs: `dayId: string \| null`, `exercises: WorkoutExercise[]`, options (`enabled`, catalog/equipment lookups). Output: `{ data: Map<string, ProgressionSuggestion \| null>, isLoading, error }`. |
+| `src/hooks/useProgressionSuggestionsForDay.test.ts` | Empty exercises → noop. Partial coverage (some IDs no perf) → null entries. `HOLD_INCOMPLETE` / `WEIGHT_UP` / `PLATEAU`. Cache key reactivity on swap. RPC error path. |
+
+### Modified Files & Responsibilities
+
+| File | Change |
+|---|---|
+| `src/lib/progression.ts` | Extract pure helper `buildPrescription(exercise, lastPerformance, options)` returning `ProgressionPrescription`. Inputs: `WorkoutExercise`, `SetPerformance[] \| null`, `{ measurementType, equipment, catalogExercise }`. |
+| `src/lib/progression.test.ts` | Add tests for `buildPrescription`: bootstrap from template (no last perf); inferred reps from last perf when template reps are non-numeric; duration vs reps volume branch; weight increment resolution. |
+| `src/hooks/useProgressionSuggestion.ts` | Refactor to call extracted `buildPrescription`. Behavior unchanged; tests stay green. |
+| `src/components/workout/ProgressionPill.tsx` | Add prop `compact?: boolean`. When `true`: render Badge with icon only, no label. Min-size class on Badge to ensure tap target ≥ 44px on mobile (`className="h-9 w-9 p-0"` or equivalent — concrete sizing in PR). Popover content unchanged. `aria-label` populated from the rule's `reasonKey`. |
+| `src/components/workout/ProgressionPill.test.tsx` | Tests for compact mode: icon present, no label text, `aria-label` correct, popover content matches default. |
+| `src/components/workout/PreSessionExerciseList.tsx` | New props: `suggestionsByExerciseId: Map<string, ProgressionSuggestion \| null>`, `suggestionsLoading: boolean`, `suggestionsError: Error \| null`. Render subtle error indicator at top when `suggestionsError != null`. Pass suggestion + loading flag down to each row. |
+| `src/components/workout/ExerciseEditRowControls.tsx` | New props: `suggestion: ProgressionSuggestion \| null \| undefined`, `suggestionLoading: boolean`. Subtitle line conditionally renders `<Skeleton />` (loading) / engine values + compact pill (loaded with suggestion) / template fallback (loaded but null). |
+| `src/components/workout/ExerciseEditRowControls.test.tsx` | Loading → skeleton. Null → fallback to template, no pill. `WEIGHT_UP` → engine values + green pill. `HOLD_NEAR_FAILURE` → `currentWeight` + amber pill. |
+| `src/pages/WorkoutPage.tsx` | Wire `useProgressionSuggestionsForDay(currentDayId, exercises, { enabled: !isDayDoneInCycle })`. Pass results as props to `PreSessionExerciseList`. Add `queryClient.invalidateQueries({ queryKey: ["progression-suggestions-for-day"] })` in `handleFinish` alongside existing invalidations. |
+| `src/locales/en/workout.json`, `src/locales/fr/workout.json` | Add `progression.loadingAria`, `progression.suggestionsUnavailable`. Reuse existing `progression.*` keys for the popover content. |
+
+### Component Responsibilities (the non-obvious bits)
+
+**`useProgressionSuggestionsForDay`**
+- Disabled when `dayId == null`, `exercises.length === 0`, auth user absent, or caller passes `enabled: false` (carousel off-screen slides).
+- Query key: `["progression-suggestions-for-day", dayId, exercises.map(e => e.exercise_id).sort().join(",")]`. `staleTime: 30_000` matches `useLastSessionDetail`.
+- `queryFn`:
+  1. `supabase.rpc("get_last_performance_for_exercises", { p_exercise_ids })`.
+  2. Group rows by `exercise_id` → `Map<string, RawRow[]>`.
+  3. For each `WorkoutExercise`, build a `SetPerformance[]` from the raw rows (split reps vs duration via `duration_seconds != null`, parse `reps_logged`).
+  4. Call `buildPrescription(exercise, performance, { equipment, catalogExercise, measurementType })`.
+  5. `computeNextSessionTarget(prescription, performance)` → `ProgressionSuggestion | null`.
+  6. Return `Map<exercise_id, suggestion>`.
+- Output is `useQuery`'s shape directly: `{ data: Map<...>, isLoading, error }`.
+
+**`ExerciseEditRowControls` (modified)**
+- Subtitle line:
+  - `suggestionLoading` (initial fetch only — `isLoading`, not `isFetching`) → `<Skeleton className="h-3 w-24" aria-label={t("progression.loadingAria")} />` in place of the value text.
+  - `suggestion != null` → render values from `suggestion`: `${suggestion.sets} × ${formatVolume(suggestion)}{suggestion.weight > 0 && \` · ${formatWeight(suggestion.weight)}\`}` followed by `<ProgressionPill compact suggestion={suggestion} />`.
+  - `suggestion === null` → fallback to current rendering using `ex.weight/reps/sets`, no pill.
+- Other behaviors (swap menu, delete, swap inline panel) unchanged.
+
+**`ProgressionPill` compact mode**
+- `compact === true`: omit the text label inside the Badge, keep the `Icon`. Tap target sized via `className`. Popover behavior identical to the default variant.
+- `aria-label` always populated from `t(suggestion.reasonKey)` so SR users get the rule reason on the trigger.
+
+### Failure Mode Analysis
+
+| Failure | Behavior |
+|---|---|
+| RPC returns 0 rows for a given exercise (no last perf) | Map entry = `null`. Row falls back to **Template Prescription**. No pill. |
+| RPC returns 0 rows for the entire array (brand-new program) | Map empty. All rows fall back to template. No pill anywhere. |
+| RPC error (network, 5xx, RLS bug) | Hook exposes `error`. Rows fall back to template silently. `PreSessionExerciseList` renders a subtle text indicator at the top: *"Suggestions indisponibles, valeurs par défaut affichées"*. Session can still start. |
+| User swaps exercise A → B mid-pre-session | `exercises[]` changes → query key changes → refetch. New row briefly shows skeleton, then suggestion. |
+| Exercises load before suggestions (cold cache, the typical case) | Rows render immediately with name/emoji/sets count (static fields from `exercises[]`); skeleton in value+pill slot until the RPC resolves. **No screen-blocking.** |
+| User finishes session → swipes to another day with overlapping exercises | `handleFinish` invalidates `["progression-suggestions-for-day"]` → newly visible day refetches. Suggestion reflects freshly-logged perf. |
+| Cached suggestions stale > 30s | `staleTime: 30s` aligns with `useLastSessionDetail`. Beyond that: refetch on focus (TanStack default). |
+| Carousel renders 3 visible days simultaneously | 3 RPC calls in parallel. Acceptable per ADR 0005 (was ~24 with the per-row alternative). |
+| Compact pill tap target on mobile | `ProgressionPill.test.tsx` asserts dimensions ≥ 44×44 px in compact mode. |
+| `set_logs.exercise_id` references a deleted exercise | The FK has no `ON DELETE` clause; orphans theoretically possible. Filter is `exercise_id IN (?)` from `workout_exercises.exercise_id` (same target). Practical orphan path requires deleting an exercise still referenced by a workout_exercise — not user-reachable today. |
+| Two visible days share an exercise | TanStack Query doesn't dedupe across different `dayId` keys → same `set_logs` fetched twice. Acceptable; future optimization could key on `exercise_ids[]` directly. |
+| `isLoading` flicker on cache-warm remount | We use `isLoading` (initial fetch only), not `isFetching` (refetch). Cache-warm visits skip the skeleton entirely. |
+
+---
+
+## Out of Scope (re-stated)
+
+- Deload / return-from-injury override (manual Builder edit of `weight` ignored when `Last Performance` is non-null) — pre-existing limitation, separate epic.
+- Suggestion enrichment of `ExerciseListPreview` (done-in-cycle days) — days are done; actual logged perfs are the truth there.
+- Suggestions on `WorkoutDayCard` (carousel cards) — cards don't display weights.
+- Unifying `useProgressionSuggestion` (per-exercise) and `useProgressionSuggestionsForDay` (batched) — kept separate because their lifecycles differ.
+
+---
+
+## References
+
+- Issue #371: [fix(workout): pre-session list shows stale template weight](https://github.com/PierreTsia/workout-app/issues/371)
+- ADR 0005: `docs/adr/0005-batch-progression-suggestions-per-day.md`
+- Glossary: `docs/CONTEXT.md` — section `## Progression engine` (terms: **Progression Rule**, **Progression Suggestion**, **Template Prescription**, **Last Performance**)
+- Engine: `file:src/lib/progression.ts`, `file:src/hooks/useProgressionSuggestion.ts`, `file:src/hooks/useLastSessionDetail.ts`
+- UI surfaces: `file:src/components/workout/PreSessionExerciseList.tsx`, `file:src/components/workout/ExerciseEditRowControls.tsx`, `file:src/components/workout/ProgressionPill.tsx`, `file:src/pages/WorkoutPage.tsx`
+- `set_logs` schema: `file:supabase/migrations/20240101000005_create_set_logs.sql`

--- a/docs/adr/0005-batch-progression-suggestions-per-day.md
+++ b/docs/adr/0005-batch-progression-suggestions-per-day.md
@@ -1,0 +1,47 @@
+# ADR 0005 — Batch progression suggestions per workout day
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Decided in:** chat (grilling for issue #371 — pre-session list shows stale template weight)
+
+## Context
+
+The pre-session exercise list (`PreSessionExerciseList` + `ExerciseEditRowControls`) currently displays each row's **Template Prescription** (`workout_exercises.weight` / `reps` / `sets`). This drifts from reality whenever the engine has a **Progression Suggestion** that differs — including non-trivial `HOLD_*` cases where the **Last Performance** weight has surpassed the template (the typical "I've been lifting 57 for weeks but the row says 48" scenario).
+
+Issue #371 fixes this by showing the **Progression Suggestion** values on each row, plus a compact `ProgressionPill` indicator.
+
+The straightforward path is to call the existing per-exercise hook `useProgressionSuggestion(exercise)` from each row component. That hook subscribes to one Supabase query per row (via `useLastSessionDetail`).
+
+`WorkoutDayCarousel` can render up to ~3 visible workout days × ~8 exercises = **~24 parallel Supabase queries** on home-screen mount. Mid-tier mobile + Lighthouse budgets are already pressured (cf. `docs/done/Tech_Plan_—_Lighthouse_CLS_LCP_Supabase_#104.md`); blasting 24 concurrent reads on every load of the workout home is wasteful for what is effectively a derived view.
+
+## Decision
+
+We will introduce a parent-scoped aggregator hook **`useProgressionSuggestionsForDay(dayId, exercises)`** that fetches **Last Performance** for all N exercises of the day in a single Supabase query, then runs `computeNextSessionTarget` per row client-side. The hook returns `Map<exercise_id, ProgressionSuggestion | null>`, consumed by `PreSessionExerciseList` (and passed down to row components) as a prop.
+
+The per-exercise `useProgressionSuggestion` stays as-is for in-session callers (`ExerciseDetail`), where only one exercise is in scope and per-row subscription is the right shape.
+
+This establishes a pattern: **per-row engine derivations across a list are batched at the parent level, not done per-row**. Future similar features (heatmap badges on `WorkoutDayCard`, stats overlays, achievements progress) should follow the same shape.
+
+## Consequences
+
+- **Positive:**
+  - O(days_visible) Supabase queries instead of O(days_visible × exercises). Carousel mount goes from ~24 queries to ~3.
+  - Reuses the well-tested client-side `computeNextSessionTarget` (covered by `src/lib/progression.test.ts`) — no SQL duplication.
+  - The aggregator is pure data — RIR / near-failure detection logic stays in TypeScript where it's already tested.
+
+- **Negative:**
+  - One more hook to maintain alongside `useProgressionSuggestion`.
+  - Slightly more wiring at the consuming component (suggestions arrive as a `Map` prop instead of a self-contained hook call inside the row).
+  - Two ways to get a suggestion now exist (per-exercise vs per-day batch); newcomers need to know which to use. Mitigated by: the per-exercise variant is documented as in-session only, the batched one as list/pre-session.
+
+- **Follow-ups:**
+  - Implementation lives in #371 / its tech plan + tickets.
+  - When a second per-row engine derivation feature ships (e.g. card-level "progression queued" badges), generalize the helper if and only if the shape repeats. **Don't pre-abstract.**
+  - The deload / return-from-injury edge case (Builder edit of `weight` ignored because **Last Performance** wins) is **explicitly not addressed here** — same behavior as today, just made consistent across pre-session and in-session. Owns a separate future epic.
+
+## Alternatives considered
+
+| Option | Why we didn't pick it |
+|---|---|
+| **A. One `useProgressionSuggestion` per row** | Up to ~24 parallel Supabase queries on carousel mount. Crado on mid-tier mobile, regresses Lighthouse numbers we just paid to fix. |
+| **C. Postgres RPC `get_next_session_targets(exercise_ids[])`** | Duplicates the non-trivial `computeNextSessionTarget` logic in SQL (RIR averaging, near-failure detection, rule selection). Migration cost + ongoing dual-maintenance burden > value at current scale. Reconsider only if the client-side compute becomes the bottleneck (it won't). |

--- a/src/components/workout/ExerciseEditRowControls.test.tsx
+++ b/src/components/workout/ExerciseEditRowControls.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest"
+import { screen } from "@testing-library/react"
+import { renderWithProviders } from "@/test/utils"
+import { ExerciseEditRowControls } from "./ExerciseEditRowControls"
+import type {
+  ExerciseListItem,
+  WorkoutExercise,
+} from "@/types/database"
+import type { ProgressionSuggestion } from "@/lib/progression"
+
+function makeExercise(
+  overrides: Partial<WorkoutExercise> = {},
+): WorkoutExercise {
+  return {
+    id: "we-1",
+    workout_day_id: "day-1",
+    exercise_id: "ex-1",
+    name_snapshot: "Bench Press",
+    muscle_snapshot: "chest",
+    emoji_snapshot: "🏋️",
+    sets: 3,
+    reps: "10",
+    weight: "80",
+    rest_seconds: 90,
+    sort_order: 0,
+    rep_range_min: 8,
+    rep_range_max: 12,
+    set_range_min: 2,
+    set_range_max: 5,
+    weight_increment: null,
+    max_weight_reached: false,
+    ...overrides,
+  }
+}
+
+const baseProps = {
+  exercisePool: [] as ExerciseListItem[],
+  poolLoading: false,
+  currentExerciseIds: ["ex-1"],
+  onSwapExerciseChosen: vi.fn(),
+  onDeleteRequested: vi.fn(),
+  onSwapBrowseLibrary: vi.fn(),
+  onInspectDetails: vi.fn(),
+}
+
+describe("ExerciseEditRowControls — pre-session progression", () => {
+  it("shows a skeleton in place of the weight while the suggestion is loading", () => {
+    renderWithProviders(
+      <ExerciseEditRowControls
+        {...baseProps}
+        exercise={makeExercise()}
+        suggestion={undefined}
+        isLoadingSuggestion
+      />,
+    )
+
+    expect(screen.getByTestId("progression-suggestion-skeleton")).toBeTruthy()
+    expect(screen.queryByText(/80\s*kg/i)).toBeNull()
+  })
+
+  it("uses the suggested weight (not the template) and shows a compact pill on WEIGHT_UP", () => {
+    const suggestion: ProgressionSuggestion = {
+      rule: "WEIGHT_UP",
+      reps: 8,
+      weight: 57,
+      sets: 3,
+      delta: "2.5",
+      reasonKey: "progression.weightUp",
+      volumeType: "reps",
+    }
+
+    renderWithProviders(
+      <ExerciseEditRowControls
+        {...baseProps}
+        exercise={makeExercise({ weight: "48", reps: "8", sets: 3 })}
+        suggestion={suggestion}
+      />,
+    )
+
+    expect(screen.getByText(/3 × 8 · 57\s*kg/i)).toBeTruthy()
+    expect(screen.queryByText(/48\s*kg/i)).toBeNull()
+    expect(screen.getByLabelText(/Weight up/i)).toBeTruthy()
+  })
+
+  it("falls back to template values with no pill when suggestion is null (no Last Performance)", () => {
+    renderWithProviders(
+      <ExerciseEditRowControls
+        {...baseProps}
+        exercise={makeExercise({ weight: "60", reps: "10", sets: 3 })}
+        suggestion={null}
+      />,
+    )
+
+    expect(screen.getByText(/3 × 10 · 60\s*kg/i)).toBeTruthy()
+    expect(screen.queryByLabelText(/up|hold|plateau/i)).toBeNull()
+  })
+
+  it("renders the pill on HOLD_NEAR_FAILURE while keeping the unchanged values", () => {
+    const suggestion: ProgressionSuggestion = {
+      rule: "HOLD_NEAR_FAILURE",
+      reps: 10,
+      weight: 80,
+      sets: 3,
+      delta: "—",
+      reasonKey: "progression.holdNearFailure",
+      volumeType: "reps",
+    }
+
+    renderWithProviders(
+      <ExerciseEditRowControls
+        {...baseProps}
+        exercise={makeExercise({ weight: "80", reps: "10", sets: 3 })}
+        suggestion={suggestion}
+      />,
+    )
+
+    expect(screen.getByText(/3 × 10 · 80\s*kg/i)).toBeTruthy()
+    expect(screen.getByLabelText(/Hold.*near failure/i)).toBeTruthy()
+  })
+})

--- a/src/components/workout/ExerciseEditRowControls.test.tsx
+++ b/src/components/workout/ExerciseEditRowControls.test.tsx
@@ -8,6 +8,14 @@ import type {
 } from "@/types/database"
 import type { ProgressionSuggestion } from "@/lib/progression"
 
+// Component import chain transitively pulls in `@/lib/supabase`, which calls
+// `createClient(supabaseUrl, ...)` at module load. CI doesn't expose the env
+// vars, so the import would crash. `vi.mock` is hoisted by vitest, so its
+// position relative to imports doesn't matter — convention here is after.
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: vi.fn() },
+}))
+
 function makeExercise(
   overrides: Partial<WorkoutExercise> = {},
 ): WorkoutExercise {

--- a/src/components/workout/ExerciseEditRowControls.tsx
+++ b/src/components/workout/ExerciseEditRowControls.tsx
@@ -9,9 +9,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { Skeleton } from "@/components/ui/skeleton"
 import { ExerciseSwapInlinePanel } from "@/components/workout/ExerciseSwapInlinePanel"
+import { ProgressionPill } from "@/components/workout/ProgressionPill"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 import { formatDurationShort } from "@/lib/formatters"
+import type { ProgressionSuggestion } from "@/lib/progression"
 import type { ExerciseListItem, WorkoutExercise } from "@/types/database"
 
 export interface ExerciseEditRowControlsProps {
@@ -25,6 +28,14 @@ export interface ExerciseEditRowControlsProps {
   onInspectDetails: (exerciseId: string) => void
   /** Pre-session list: opens library sheet. In-session detail uses unified menu instead. */
   showDetailsMenuItem?: boolean
+  /**
+   * Progression Suggestion for this exercise (#371).
+   * - `undefined` while the batched fetch is in flight (combined with `isLoadingSuggestion`).
+   * - `null` when there is no Last Performance — falls back to Template Prescription, no pill.
+   * - Otherwise drives the displayed weight/reps/duration and a compact pill.
+   */
+  suggestion?: ProgressionSuggestion | null
+  isLoadingSuggestion?: boolean
 }
 
 export function ExerciseEditRowControls({
@@ -37,10 +48,22 @@ export function ExerciseEditRowControls({
   onSwapBrowseLibrary,
   onInspectDetails,
   showDetailsMenuItem = true,
+  suggestion,
+  isLoadingSuggestion = false,
 }: ExerciseEditRowControlsProps) {
   const { t } = useTranslation("workout")
   const { formatWeight } = useWeightUnit()
   const [swapPanelOpen, setSwapPanelOpen] = useState(false)
+
+  const showSkeleton = isLoadingSuggestion && suggestion === undefined
+
+  const displayWeight = suggestion ? suggestion.weight : Number(ex.weight)
+  const displayDurationSeconds =
+    suggestion?.volumeType === "duration"
+      ? suggestion.duration
+      : ex.target_duration_seconds
+  const displayReps =
+    suggestion?.volumeType === "reps" ? String(suggestion.reps) : ex.reps
 
   const menu = (
     <DropdownMenu>
@@ -99,13 +122,25 @@ export function ExerciseEditRowControls({
           <p className="truncate text-sm font-medium text-foreground">
             {ex.name_snapshot}
           </p>
-          <p className="text-xs text-muted-foreground">
-            {ex.sets} ×{" "}
-            {ex.target_duration_seconds != null && ex.target_duration_seconds > 0
-              ? formatDurationShort(ex.target_duration_seconds)
-              : ex.reps}
-            {Number(ex.weight) > 0 && ` · ${formatWeight(Number(ex.weight))}`}
-          </p>
+          {showSkeleton ? (
+            <Skeleton
+              data-testid="progression-suggestion-skeleton"
+              className="mt-0.5 h-4 w-32"
+            />
+          ) : (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span>
+                {ex.sets} ×{" "}
+                {displayDurationSeconds != null && displayDurationSeconds > 0
+                  ? formatDurationShort(displayDurationSeconds)
+                  : displayReps}
+                {displayWeight > 0 && ` · ${formatWeight(displayWeight)}`}
+              </span>
+              {suggestion ? (
+                <ProgressionPill suggestion={suggestion} compact />
+              ) : null}
+            </div>
+          )}
         </div>
         {menu}
       </div>

--- a/src/components/workout/PreSessionExerciseList.tsx
+++ b/src/components/workout/PreSessionExerciseList.tsx
@@ -1,7 +1,8 @@
 import { useTranslation } from "react-i18next"
-import { Plus } from "lucide-react"
+import { AlertCircle, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ExerciseEditRowControls } from "@/components/workout/ExerciseEditRowControls"
+import type { ProgressionSuggestion } from "@/lib/progression"
 import type { ExerciseListItem, WorkoutExercise } from "@/types/database"
 
 export interface PreSessionExerciseListProps {
@@ -14,6 +15,15 @@ export interface PreSessionExerciseListProps {
   onSwapBrowseLibrary: (row: WorkoutExercise) => void
   onRequestAddExerciseSheet: () => void
   onInspectExercise: (exerciseId: string) => void
+  /**
+   * Map of `exercise_id → ProgressionSuggestion | null` for #371.
+   * - Missing key (`undefined`) combined with `suggestionsLoading=true` → row shows skeleton.
+   * - `null` → row falls back to **Template Prescription**, no pill.
+   * - Otherwise → row renders engine values + compact `ProgressionPill`.
+   */
+  suggestionsByExerciseId?: Map<string, ProgressionSuggestion | null>
+  suggestionsLoading?: boolean
+  suggestionsError?: Error | null
 }
 
 export function PreSessionExerciseList({
@@ -25,6 +35,9 @@ export function PreSessionExerciseList({
   onRequestAddExerciseSheet,
   onSwapBrowseLibrary,
   onInspectExercise,
+  suggestionsByExerciseId,
+  suggestionsLoading = false,
+  suggestionsError = null,
 }: PreSessionExerciseListProps) {
   const { t } = useTranslation("workout")
 
@@ -32,6 +45,16 @@ export function PreSessionExerciseList({
 
   return (
     <div className="flex flex-col gap-2">
+      {suggestionsError ? (
+        <div
+          role="status"
+          className="flex items-center gap-1.5 px-1 text-xs text-muted-foreground"
+        >
+          <AlertCircle className="h-3 w-3" aria-hidden />
+          <span>{t("progression.suggestionsUnavailable")}</span>
+        </div>
+      ) : null}
+
       {exercises.map((ex) => (
         <ExerciseEditRowControls
           key={ex.id}
@@ -43,6 +66,8 @@ export function PreSessionExerciseList({
           onDeleteRequested={onDeleteRequested}
           onSwapBrowseLibrary={onSwapBrowseLibrary}
           onInspectDetails={onInspectExercise}
+          suggestion={suggestionsByExerciseId?.get(ex.exercise_id)}
+          isLoadingSuggestion={suggestionsLoading}
         />
       ))}
 

--- a/src/components/workout/PreSessionExerciseList.tsx
+++ b/src/components/workout/PreSessionExerciseList.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { AlertCircle, Plus } from "lucide-react"
+import type { PostgrestError } from "@supabase/supabase-js"
 import { Button } from "@/components/ui/button"
 import { ExerciseEditRowControls } from "@/components/workout/ExerciseEditRowControls"
 import type { ProgressionSuggestion } from "@/lib/progression"
@@ -25,7 +26,7 @@ export interface PreSessionExerciseListProps {
    */
   suggestionsByRowId?: Map<string, ProgressionSuggestion | null>
   suggestionsLoading?: boolean
-  suggestionsError?: Error | null
+  suggestionsError?: PostgrestError | null
 }
 
 export function PreSessionExerciseList({

--- a/src/components/workout/PreSessionExerciseList.tsx
+++ b/src/components/workout/PreSessionExerciseList.tsx
@@ -16,12 +16,14 @@ export interface PreSessionExerciseListProps {
   onRequestAddExerciseSheet: () => void
   onInspectExercise: (exerciseId: string) => void
   /**
-   * Map of `exercise_id → ProgressionSuggestion | null` for #371.
+   * Map of `workout_exercises.id → ProgressionSuggestion | null` for #371.
+   * Keyed by row id (not exercise_id) so two rows of the same exercise stay
+   * independent.
    * - Missing key (`undefined`) combined with `suggestionsLoading=true` → row shows skeleton.
    * - `null` → row falls back to **Template Prescription**, no pill.
    * - Otherwise → row renders engine values + compact `ProgressionPill`.
    */
-  suggestionsByExerciseId?: Map<string, ProgressionSuggestion | null>
+  suggestionsByRowId?: Map<string, ProgressionSuggestion | null>
   suggestionsLoading?: boolean
   suggestionsError?: Error | null
 }
@@ -35,7 +37,7 @@ export function PreSessionExerciseList({
   onRequestAddExerciseSheet,
   onSwapBrowseLibrary,
   onInspectExercise,
-  suggestionsByExerciseId,
+  suggestionsByRowId,
   suggestionsLoading = false,
   suggestionsError = null,
 }: PreSessionExerciseListProps) {
@@ -66,7 +68,7 @@ export function PreSessionExerciseList({
           onDeleteRequested={onDeleteRequested}
           onSwapBrowseLibrary={onSwapBrowseLibrary}
           onInspectDetails={onInspectExercise}
-          suggestion={suggestionsByExerciseId?.get(ex.exercise_id)}
+          suggestion={suggestionsByRowId?.get(ex.id)}
           isLoadingSuggestion={suggestionsLoading}
         />
       ))}

--- a/src/components/workout/ProgressionPill.test.tsx
+++ b/src/components/workout/ProgressionPill.test.tsx
@@ -163,4 +163,28 @@ describe("ProgressionPill", () => {
 
     expect(screen.getByText(/nailed every set/i)).toBeTruthy()
   })
+
+  describe("compact mode", () => {
+    it("renders icon only — no label text — but exposes the rule reason as aria-label", () => {
+      renderWithProviders(
+        <ProgressionPill suggestion={makeSuggestion("REPS_UP")} compact />,
+      )
+
+      expect(screen.queryByText(/Reps up/i)).toBeNull()
+      expect(screen.queryByText(/\+1 rep/)).toBeNull()
+      expect(screen.getByLabelText(/Reps up/i)).toBeTruthy()
+    })
+
+    it("opens the same detail popover as the default variant when triggered", async () => {
+      const user = userEvent.setup()
+      renderWithProviders(
+        <ProgressionPill suggestion={makeSuggestion("HOLD_NEAR_FAILURE")} compact />,
+      )
+
+      const trigger = screen.getByLabelText(/Hold.*near failure/i)
+      await user.click(trigger)
+
+      expect(screen.getByText(/Average RIR was very low/i)).toBeTruthy()
+    })
+  })
 })

--- a/src/components/workout/ProgressionPill.tsx
+++ b/src/components/workout/ProgressionPill.tsx
@@ -39,9 +39,15 @@ const APPLIED_RULES = new Set<ProgressionRule>(["REPS_UP", "DURATION_UP", "WEIGH
 
 interface ProgressionPillProps {
   suggestion: ProgressionSuggestion
+  /**
+   * Compact mode renders icon-only — no text label — and exposes the rule reason
+   * as `aria-label` on the trigger. Used in dense surfaces (pre-session list rows)
+   * where the value the pill justifies is already next to it.
+   */
+  compact?: boolean
 }
 
-export function ProgressionPill({ suggestion }: ProgressionPillProps) {
+export function ProgressionPill({ suggestion, compact = false }: ProgressionPillProps) {
   const { t } = useTranslation("workout")
   const { toDisplay, unit } = useWeightUnit()
   const Icon = ICON_MAP[suggestion.rule]
@@ -49,13 +55,14 @@ export function ProgressionPill({ suggestion }: ProgressionPillProps) {
 
   const displayWeight = Math.round(toDisplay(suggestion.weight) * 10) / 10
 
+  const reasonText = t(suggestion.reasonKey)
   const shortLabel = (() => {
-    if (suggestion.delta === "—") return t(suggestion.reasonKey)
+    if (suggestion.delta === "—") return reasonText
     if (suggestion.rule === "WEIGHT_UP") {
       const displayIncrement = Math.round(toDisplay(Number(suggestion.delta)) * 10) / 10
-      return `${t(suggestion.reasonKey)} +${displayIncrement} ${unit}`
+      return `${reasonText} +${displayIncrement} ${unit}`
     }
-    return `${t(suggestion.reasonKey)} ${suggestion.delta}`
+    return `${reasonText} ${suggestion.delta}`
   })()
 
   return (
@@ -63,13 +70,15 @@ export function ProgressionPill({ suggestion }: ProgressionPillProps) {
       <PopoverTrigger asChild>
         <Badge
           variant="outline"
+          aria-label={compact ? reasonText : undefined}
           className={cn(
             "cursor-pointer gap-1.5 py-1 text-[11px] font-medium",
+            compact && "px-1.5",
             COLOR_MAP[suggestion.rule],
           )}
         >
           <Icon className="h-3 w-3 shrink-0" aria-hidden />
-          {shortLabel}
+          {!compact && shortLabel}
         </Badge>
       </PopoverTrigger>
       <PopoverContent side="top" align="end" className="w-64 flex flex-col gap-2 p-3 text-sm">

--- a/src/hooks/useProgressionSuggestion.ts
+++ b/src/hooks/useProgressionSuggestion.ts
@@ -1,18 +1,11 @@
 import { useMemo } from "react"
 import { useLastSessionDetail } from "@/hooks/useLastSessionDetail"
 import {
+  buildPrescription,
   computeNextSessionTarget,
-  resolveWeightIncrement,
-  type ProgressionPrescription,
   type ProgressionSuggestion,
-  type VolumePrescription,
 } from "@/lib/progression"
 import type { WorkoutExercise, Exercise } from "@/types/database"
-
-const DEFAULT_DURATION_SECONDS = 30
-const DURATION_BAND_LOW = 10
-const DURATION_BAND_HIGH = 15
-const DEFAULT_DURATION_INCREMENT = 5
 
 export function useProgressionSuggestion(
   exercise: WorkoutExercise,
@@ -30,54 +23,12 @@ export function useProgressionSuggestion(
   return useMemo(() => {
     if (!lastPerformance || lastPerformance.length === 0) return null
 
-    const isDuration = measurementType === "duration"
-
-    let volume: VolumePrescription
-
-    if (isDuration) {
-      const target =
-        exercise.target_duration_seconds ??
-        catalogExercise?.default_duration_seconds ??
-        DEFAULT_DURATION_SECONDS
-      volume = {
-        type: "duration",
-        current: target,
-        min: exercise.duration_range_min_seconds ?? Math.max(5, target - DURATION_BAND_LOW),
-        max: exercise.duration_range_max_seconds ?? target + DURATION_BAND_HIGH,
-        increment: exercise.duration_increment_seconds ?? DEFAULT_DURATION_INCREMENT,
-      }
-    } else {
-      let currentReps = parseInt(exercise.reps, 10)
-      if (isNaN(currentReps)) {
-        const inferredReps = lastPerformance[0]?.reps
-        if (!inferredReps || inferredReps <= 0) return null
-        currentReps = inferredReps
-      }
-      volume = {
-        type: "reps",
-        current: currentReps,
-        min: exercise.rep_range_min ?? Math.max(1, currentReps - 2),
-        max: exercise.rep_range_max ?? currentReps + 2,
-        increment: 1,
-      }
-    }
-
-    const templateWeight = Number(exercise.weight) || 0
-    const lastSessionWeight = lastPerformance[0]?.weight ?? 0
-    const currentWeight = lastSessionWeight > 0 ? lastSessionWeight : templateWeight
-
-    const prescription: ProgressionPrescription = {
-      volume,
-      currentWeight,
-      currentSets: exercise.sets,
-      setRangeMin: exercise.set_range_min ?? Math.max(1, exercise.sets - 1),
-      setRangeMax: exercise.set_range_max ?? Math.min(6, exercise.sets + 2),
-      weightIncrement: resolveWeightIncrement(exercise.weight_increment ?? null, equipment),
-      maxWeightReached: exercise.max_weight_reached ?? false,
-      currentReps: volume.type === "reps" ? volume.current : 0,
-      repRangeMin: volume.type === "reps" ? volume.min : 0,
-      repRangeMax: volume.type === "reps" ? volume.max : 0,
-    }
+    const prescription = buildPrescription(exercise, lastPerformance, {
+      measurementType,
+      equipment,
+      catalogExercise,
+    })
+    if (prescription === null) return null
 
     return computeNextSessionTarget(prescription, lastPerformance)
   }, [exercise, lastPerformance, measurementType, equipment, catalogExercise])

--- a/src/hooks/useProgressionSuggestionsForDay.test.ts
+++ b/src/hooks/useProgressionSuggestionsForDay.test.ts
@@ -104,7 +104,7 @@ describe("useProgressionSuggestionsForDay", () => {
     expect(rpcMock).toHaveBeenCalledWith("get_last_performance_for_exercises", {
       p_exercise_ids: ["ex-1"],
     })
-    const suggestion = result.current.data.get("ex-1")
+    const suggestion = result.current.data.get("we-1")
     expect(suggestion).not.toBeNull()
     expect(suggestion!.rule).toBe("REPS_UP")
     expect(suggestion!.reps).toBe(11)
@@ -166,7 +166,7 @@ describe("useProgressionSuggestionsForDay", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    const suggestion = result.current.data.get("ex-plank")
+    const suggestion = result.current.data.get("we-plank")
     expect(suggestion).not.toBeNull()
     expect(suggestion!.volumeType).toBe("duration")
     expect(suggestion!.rule).toBe("DURATION_UP")
@@ -203,9 +203,9 @@ describe("useProgressionSuggestionsForDay", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.data.size).toBe(3)
-    expect(result.current.data.get("ex-1")).not.toBeNull()
-    expect(result.current.data.get("ex-2")).toBeNull()
-    expect(result.current.data.get("ex-3")).toBeNull()
+    expect(result.current.data.get("we-1")).not.toBeNull()
+    expect(result.current.data.get("we-2")).toBeNull()
+    expect(result.current.data.get("we-3")).toBeNull()
   })
 
   it("exposes the RPC error and yields an empty map on failure", async () => {

--- a/src/hooks/useProgressionSuggestionsForDay.test.ts
+++ b/src/hooks/useProgressionSuggestionsForDay.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { waitFor } from "@testing-library/react"
+import { renderHookWithProviders } from "@/test/utils"
+import { useProgressionSuggestionsForDay } from "./useProgressionSuggestionsForDay"
+import type { WorkoutExercise } from "@/types/database"
+
+const rpcMock = vi.fn()
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => rpcMock(...args),
+  },
+}))
+
+function makeExercise(overrides: Partial<WorkoutExercise> = {}): WorkoutExercise {
+  return {
+    id: "we-1",
+    workout_day_id: "day-1",
+    exercise_id: "ex-1",
+    name_snapshot: "Bench Press",
+    muscle_snapshot: "chest",
+    emoji_snapshot: "🏋️",
+    sets: 3,
+    reps: "10",
+    weight: "80",
+    rest_seconds: 90,
+    sort_order: 0,
+    rep_range_min: 8,
+    rep_range_max: 12,
+    set_range_min: 2,
+    set_range_max: 5,
+    weight_increment: null,
+    max_weight_reached: false,
+    ...overrides,
+  }
+}
+
+describe("useProgressionSuggestionsForDay", () => {
+  beforeEach(() => {
+    rpcMock.mockReset()
+  })
+
+  it("returns an empty map and skips the RPC when exercises array is empty", () => {
+    const { result } = renderHookWithProviders(() =>
+      useProgressionSuggestionsForDay("day-1", []),
+    )
+
+    expect(result.current.data.size).toBe(0)
+    expect(result.current.isLoading).toBe(false)
+    expect(rpcMock).not.toHaveBeenCalled()
+  })
+
+  it("computes a Progression Suggestion per exercise with last performance (happy path)", async () => {
+    rpcMock.mockResolvedValue({
+      data: [
+        {
+          exercise_id: "ex-1",
+          session_id: "sess-1",
+          set_number: 1,
+          reps_logged: "10",
+          weight_logged: 80,
+          rir: 2,
+          duration_seconds: null,
+          logged_at: "2026-05-26T10:00:00Z",
+        },
+        {
+          exercise_id: "ex-1",
+          session_id: "sess-1",
+          set_number: 2,
+          reps_logged: "10",
+          weight_logged: 80,
+          rir: 2,
+          duration_seconds: null,
+          logged_at: "2026-05-26T10:00:00Z",
+        },
+        {
+          exercise_id: "ex-1",
+          session_id: "sess-1",
+          set_number: 3,
+          reps_logged: "10",
+          weight_logged: 80,
+          rir: 2,
+          duration_seconds: null,
+          logged_at: "2026-05-26T10:00:00Z",
+        },
+      ],
+      error: null,
+    })
+
+    const exercise = makeExercise({
+      reps: "10",
+      weight: "80",
+      sets: 3,
+      rep_range_min: 8,
+      rep_range_max: 12,
+    })
+
+    const { result } = renderHookWithProviders(() =>
+      useProgressionSuggestionsForDay("day-1", [exercise]),
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(rpcMock).toHaveBeenCalledWith("get_last_performance_for_exercises", {
+      p_exercise_ids: ["ex-1"],
+    })
+    const suggestion = result.current.data.get("ex-1")
+    expect(suggestion).not.toBeNull()
+    expect(suggestion!.rule).toBe("REPS_UP")
+    expect(suggestion!.reps).toBe(11)
+    expect(suggestion!.weight).toBe(80)
+  })
+
+  it("treats rows with duration_seconds set as a duration exercise", async () => {
+    rpcMock.mockResolvedValue({
+      data: [
+        {
+          exercise_id: "ex-plank",
+          session_id: "sess-1",
+          set_number: 1,
+          reps_logged: "0",
+          weight_logged: 0,
+          rir: 2,
+          duration_seconds: 30,
+          logged_at: "2026-05-26T10:00:00Z",
+        },
+        {
+          exercise_id: "ex-plank",
+          session_id: "sess-1",
+          set_number: 2,
+          reps_logged: "0",
+          weight_logged: 0,
+          rir: 2,
+          duration_seconds: 30,
+          logged_at: "2026-05-26T10:00:00Z",
+        },
+        {
+          exercise_id: "ex-plank",
+          session_id: "sess-1",
+          set_number: 3,
+          reps_logged: "0",
+          weight_logged: 0,
+          rir: 2,
+          duration_seconds: 30,
+          logged_at: "2026-05-26T10:00:00Z",
+        },
+      ],
+      error: null,
+    })
+
+    const exercise = makeExercise({
+      id: "we-plank",
+      exercise_id: "ex-plank",
+      reps: "0",
+      weight: "0",
+      sets: 3,
+      target_duration_seconds: 30,
+      duration_range_min_seconds: 20,
+      duration_range_max_seconds: 45,
+      duration_increment_seconds: 5,
+    })
+
+    const { result } = renderHookWithProviders(() =>
+      useProgressionSuggestionsForDay("day-1", [exercise]),
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const suggestion = result.current.data.get("ex-plank")
+    expect(suggestion).not.toBeNull()
+    expect(suggestion!.volumeType).toBe("duration")
+    expect(suggestion!.rule).toBe("DURATION_UP")
+    expect(suggestion!.duration).toBe(35)
+  })
+
+  it("yields a null entry for exercises without any last performance row", async () => {
+    rpcMock.mockResolvedValue({
+      data: [
+        {
+          exercise_id: "ex-1",
+          session_id: "sess-1",
+          set_number: 1,
+          reps_logged: "10",
+          weight_logged: 80,
+          rir: 2,
+          duration_seconds: null,
+          logged_at: "2026-05-26T10:00:00Z",
+        },
+      ],
+      error: null,
+    })
+
+    const exercises = [
+      makeExercise({ id: "we-1", exercise_id: "ex-1" }),
+      makeExercise({ id: "we-2", exercise_id: "ex-2" }),
+      makeExercise({ id: "we-3", exercise_id: "ex-3" }),
+    ]
+
+    const { result } = renderHookWithProviders(() =>
+      useProgressionSuggestionsForDay("day-1", exercises),
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.data.size).toBe(3)
+    expect(result.current.data.get("ex-1")).not.toBeNull()
+    expect(result.current.data.get("ex-2")).toBeNull()
+    expect(result.current.data.get("ex-3")).toBeNull()
+  })
+
+  it("exposes the RPC error and yields an empty map on failure", async () => {
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: { message: "permission denied" },
+    })
+
+    const { result } = renderHookWithProviders(() =>
+      useProgressionSuggestionsForDay("day-1", [makeExercise()]),
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.error).not.toBeNull()
+    expect(result.current.error!.message).toBe("permission denied")
+    expect(result.current.data.size).toBe(0)
+  })
+})

--- a/src/hooks/useProgressionSuggestionsForDay.ts
+++ b/src/hooks/useProgressionSuggestionsForDay.ts
@@ -91,10 +91,16 @@ export function useProgressionSuggestionsForDay(
         (data ?? []) as LastPerformanceRow[],
       )
 
+      // Keyed by `workout_exercises.id` (the row id) — not `exercise_id` —
+      // so two rows of the same exercise in a day stay independent (e.g. a
+      // user may queue the same movement twice with different prescriptions).
+      // Same `exercise_id` will read the same Last Performance from set_logs;
+      // resolving the deeper "two rows of the same exo, different intent"
+      // conflation is a pre-existing limitation tracked outside this PR.
       return exercises.reduce<Map<string, ProgressionSuggestion | null>>(
         (acc, exercise) => {
           const rows = rowsByExercise.get(exercise.exercise_id) ?? []
-          acc.set(exercise.exercise_id, computeSuggestion(exercise, rows))
+          acc.set(exercise.id, computeSuggestion(exercise, rows))
           return acc
         },
         new Map(),

--- a/src/hooks/useProgressionSuggestionsForDay.ts
+++ b/src/hooks/useProgressionSuggestionsForDay.ts
@@ -39,9 +39,16 @@ function rowToSetPerformance(row: LastPerformanceRow): SetPerformance {
 function groupRowsByExerciseId(
   rows: LastPerformanceRow[],
 ): Map<string, LastPerformanceRow[]> {
+  // Local push into the bucket array — the bucket is owned by the Map we're
+  // building and never escapes this function before assembly is complete, so
+  // semantically pure. Avoids O(N²) allocations from `[...existing, row]`.
   return rows.reduce<Map<string, LastPerformanceRow[]>>((acc, row) => {
-    const existing = acc.get(row.exercise_id) ?? []
-    acc.set(row.exercise_id, [...existing, row])
+    const list = acc.get(row.exercise_id)
+    if (list) {
+      list.push(row)
+    } else {
+      acc.set(row.exercise_id, [row])
+    }
     return acc
   }, new Map())
 }

--- a/src/hooks/useProgressionSuggestionsForDay.ts
+++ b/src/hooks/useProgressionSuggestionsForDay.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+import type { PostgrestError } from "@supabase/supabase-js"
 import { supabase } from "@/lib/supabase"
 import {
   buildPrescription,
@@ -11,7 +12,12 @@ import type { WorkoutExercise } from "@/types/database"
 export interface UseProgressionSuggestionsForDayResult {
   data: Map<string, ProgressionSuggestion | null>
   isLoading: boolean
-  error: Error | null
+  /**
+   * Supabase RPC errors come as `PostgrestError` (not `instanceof Error`).
+   * Typing it accurately so consumers don't accidentally rely on `Error`
+   * semantics like `.stack` / `.name` that won't be there.
+   */
+  error: PostgrestError | null
 }
 
 interface LastPerformanceRow {
@@ -77,7 +83,10 @@ export function useProgressionSuggestionsForDay(
 ): UseProgressionSuggestionsForDayResult {
   const enabled = exercises.length > 0 && dayId != null
 
-  const query = useQuery<Map<string, ProgressionSuggestion | null>>({
+  const query = useQuery<
+    Map<string, ProgressionSuggestion | null>,
+    PostgrestError
+  >({
     queryKey: [
       "progression-suggestions-for-day",
       dayId,
@@ -120,6 +129,6 @@ export function useProgressionSuggestionsForDay(
   return {
     data: query.data ?? new Map<string, ProgressionSuggestion | null>(),
     isLoading: query.isLoading,
-    error: (query.error as Error | null) ?? null,
+    error: query.error ?? null,
   }
 }

--- a/src/hooks/useProgressionSuggestionsForDay.ts
+++ b/src/hooks/useProgressionSuggestionsForDay.ts
@@ -1,0 +1,112 @@
+import { useQuery } from "@tanstack/react-query"
+import { supabase } from "@/lib/supabase"
+import {
+  buildPrescription,
+  computeNextSessionTarget,
+  type ProgressionSuggestion,
+  type SetPerformance,
+} from "@/lib/progression"
+import type { WorkoutExercise } from "@/types/database"
+
+export interface UseProgressionSuggestionsForDayResult {
+  data: Map<string, ProgressionSuggestion | null>
+  isLoading: boolean
+  error: Error | null
+}
+
+interface LastPerformanceRow {
+  exercise_id: string
+  session_id: string
+  set_number: number
+  reps_logged: string | null
+  weight_logged: number
+  rir: number | null
+  duration_seconds: number | null
+  logged_at: string
+}
+
+function rowToSetPerformance(row: LastPerformanceRow): SetPerformance {
+  const reps = parseInt(String(row.reps_logged ?? ""), 10)
+  return {
+    reps: isNaN(reps) ? 0 : reps,
+    weight: Number(row.weight_logged) || 0,
+    completed: true,
+    rir: row.rir,
+    durationSeconds: row.duration_seconds ?? undefined,
+  }
+}
+
+function groupRowsByExerciseId(
+  rows: LastPerformanceRow[],
+): Map<string, LastPerformanceRow[]> {
+  return rows.reduce<Map<string, LastPerformanceRow[]>>((acc, row) => {
+    const existing = acc.get(row.exercise_id) ?? []
+    acc.set(row.exercise_id, [...existing, row])
+    return acc
+  }, new Map())
+}
+
+function inferMeasurementType(
+  rows: LastPerformanceRow[],
+): "reps" | "duration" {
+  return rows.some((row) => row.duration_seconds != null) ? "duration" : "reps"
+}
+
+function computeSuggestion(
+  exercise: WorkoutExercise,
+  rows: LastPerformanceRow[],
+): ProgressionSuggestion | null {
+  const lastPerformance = rows.length > 0 ? rows.map(rowToSetPerformance) : null
+  const prescription = buildPrescription(exercise, lastPerformance, {
+    measurementType: inferMeasurementType(rows),
+  })
+  if (prescription === null) return null
+  return computeNextSessionTarget(prescription, lastPerformance)
+}
+
+export function useProgressionSuggestionsForDay(
+  dayId: string | null,
+  exercises: WorkoutExercise[],
+): UseProgressionSuggestionsForDayResult {
+  const enabled = exercises.length > 0 && dayId != null
+
+  const query = useQuery<Map<string, ProgressionSuggestion | null>>({
+    queryKey: [
+      "progression-suggestions-for-day",
+      dayId,
+      exercises
+        .map((e) => e.exercise_id)
+        .sort()
+        .join(","),
+    ],
+    queryFn: async () => {
+      const exerciseIds = exercises.map((e) => e.exercise_id)
+      const { data, error } = await supabase.rpc(
+        "get_last_performance_for_exercises",
+        { p_exercise_ids: exerciseIds },
+      )
+      if (error) throw error
+
+      const rowsByExercise = groupRowsByExerciseId(
+        (data ?? []) as LastPerformanceRow[],
+      )
+
+      return exercises.reduce<Map<string, ProgressionSuggestion | null>>(
+        (acc, exercise) => {
+          const rows = rowsByExercise.get(exercise.exercise_id) ?? []
+          acc.set(exercise.exercise_id, computeSuggestion(exercise, rows))
+          return acc
+        },
+        new Map(),
+      )
+    },
+    enabled,
+    staleTime: 30_000,
+  })
+
+  return {
+    data: query.data ?? new Map<string, ProgressionSuggestion | null>(),
+    isLoading: query.isLoading,
+    error: (query.error as Error | null) ?? null,
+  }
+}

--- a/src/lib/progression.test.ts
+++ b/src/lib/progression.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest"
 import {
+  buildPrescription,
   computeNextSessionTarget,
   resolveWeightIncrement,
   type ProgressionPrescription,
   type SetPerformance,
   type VolumePrescription,
 } from "./progression"
+import type { WorkoutExercise } from "@/types/database"
 
 function makeVolume(
   overrides: Partial<VolumePrescription> = {},
@@ -342,5 +344,126 @@ describe("resolveWeightIncrement", () => {
     expect(resolveWeightIncrement(null)).toBe(2.5)
     expect(resolveWeightIncrement(null, "barbell")).toBe(2.5)
     expect(resolveWeightIncrement(null, "machine")).toBe(2.5)
+  })
+})
+
+function makeExercise(overrides: Partial<WorkoutExercise> = {}): WorkoutExercise {
+  return {
+    id: "we-1",
+    workout_day_id: "day-1",
+    exercise_id: "ex-1",
+    name_snapshot: "Bench Press",
+    muscle_snapshot: "chest",
+    emoji_snapshot: "🏋️",
+    sets: 3,
+    reps: "10",
+    weight: "80",
+    rest_seconds: 90,
+    sort_order: 0,
+    rep_range_min: 8,
+    rep_range_max: 12,
+    set_range_min: 2,
+    set_range_max: 5,
+    weight_increment: null,
+    max_weight_reached: false,
+    ...overrides,
+  }
+}
+
+describe("buildPrescription", () => {
+  it("bootstraps a reps prescription from template values when no last performance", () => {
+    const exercise = makeExercise({ reps: "10", weight: "80", sets: 3 })
+
+    const result = buildPrescription(exercise, null, {})
+
+    expect(result).not.toBeNull()
+    expect(result!.volume).toMatchObject({
+      type: "reps",
+      current: 10,
+      min: 8,
+      max: 12,
+      increment: 1,
+    })
+    expect(result!.currentWeight).toBe(80)
+    expect(result!.currentSets).toBe(3)
+    expect(result!.weightIncrement).toBe(2.5)
+    expect(result!.maxWeightReached).toBe(false)
+  })
+
+  it("builds a duration prescription from explicit duration_range_* + increment", () => {
+    const exercise = makeExercise({
+      reps: "0",
+      weight: "0",
+      sets: 3,
+      target_duration_seconds: 30,
+      duration_range_min_seconds: 20,
+      duration_range_max_seconds: 45,
+      duration_increment_seconds: 5,
+    })
+
+    const result = buildPrescription(exercise, null, {
+      measurementType: "duration",
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.volume).toMatchObject({
+      type: "duration",
+      current: 30,
+      min: 20,
+      max: 45,
+      increment: 5,
+    })
+    expect(result!.currentReps).toBe(0)
+    expect(result!.repRangeMin).toBe(0)
+    expect(result!.repRangeMax).toBe(0)
+  })
+
+  it("uses last session weight as currentWeight when last performance exists, overriding template", () => {
+    const exercise = makeExercise({ reps: "10", weight: "48", sets: 3 })
+    const lastPerformance: SetPerformance[] = [
+      { reps: 10, weight: 57, completed: true, rir: 1 },
+      { reps: 10, weight: 57, completed: true, rir: 1 },
+      { reps: 10, weight: 57, completed: true, rir: 1 },
+    ]
+
+    const result = buildPrescription(exercise, lastPerformance, {})
+
+    expect(result).not.toBeNull()
+    expect(result!.currentWeight).toBe(57)
+  })
+
+  it("returns null when template reps is non-numeric and no inferred reps are available", () => {
+    const exercise = makeExercise({ reps: "AMRAP", weight: "80", sets: 3 })
+
+    expect(buildPrescription(exercise, null, {})).toBeNull()
+    expect(buildPrescription(exercise, [], {})).toBeNull()
+    expect(
+      buildPrescription(exercise, [{ reps: 0, weight: 80, completed: true, rir: 2 }], {}),
+    ).toBeNull()
+  })
+
+  it("infers reps from last performance when template reps is non-numeric", () => {
+    const exercise = makeExercise({
+      reps: "AMRAP",
+      weight: "80",
+      sets: 3,
+      rep_range_min: undefined,
+      rep_range_max: undefined,
+    })
+    const lastPerformance: SetPerformance[] = [
+      { reps: 12, weight: 80, completed: true, rir: 2 },
+      { reps: 11, weight: 80, completed: true, rir: 2 },
+      { reps: 10, weight: 80, completed: true, rir: 1 },
+    ]
+
+    const result = buildPrescription(exercise, lastPerformance, {})
+
+    expect(result).not.toBeNull()
+    expect(result!.volume).toMatchObject({
+      type: "reps",
+      current: 12,
+      min: 10,
+      max: 14,
+    })
   })
 })

--- a/src/lib/progression.ts
+++ b/src/lib/progression.ts
@@ -1,3 +1,5 @@
+import type { WorkoutExercise } from "@/types/database"
+
 export type ProgressionRule =
   | "HOLD_INCOMPLETE"
   | "HOLD_NEAR_FAILURE"
@@ -54,12 +56,79 @@ const DEFAULT_INCREMENT_KG = 2.5
 const DUMBBELL_INCREMENT_KG = 2.0
 const RIR_SAFETY_THRESHOLD = 1
 
+const DEFAULT_DURATION_SECONDS = 30
+const DURATION_BAND_LOW = 10
+const DURATION_BAND_HIGH = 15
+const DEFAULT_DURATION_INCREMENT = 5
+
 export function resolveWeightIncrement(
   userIncrement: number | null | undefined,
   equipment?: string,
 ): number {
   if (userIncrement != null && userIncrement > 0) return userIncrement
   return equipment === "dumbbell" ? DUMBBELL_INCREMENT_KG : DEFAULT_INCREMENT_KG
+}
+
+export interface BuildPrescriptionOptions {
+  measurementType?: "reps" | "duration"
+  equipment?: string
+  catalogExercise?: { default_duration_seconds?: number | null } | null
+}
+
+export function buildPrescription(
+  exercise: WorkoutExercise,
+  lastPerformance: SetPerformance[] | null,
+  options: BuildPrescriptionOptions,
+): ProgressionPrescription | null {
+  const { measurementType, equipment, catalogExercise } = options
+  const isDuration = measurementType === "duration"
+
+  let volume: VolumePrescription
+
+  if (isDuration) {
+    const target =
+      exercise.target_duration_seconds ??
+      catalogExercise?.default_duration_seconds ??
+      DEFAULT_DURATION_SECONDS
+    volume = {
+      type: "duration",
+      current: target,
+      min: exercise.duration_range_min_seconds ?? Math.max(5, target - DURATION_BAND_LOW),
+      max: exercise.duration_range_max_seconds ?? target + DURATION_BAND_HIGH,
+      increment: exercise.duration_increment_seconds ?? DEFAULT_DURATION_INCREMENT,
+    }
+  } else {
+    let currentReps = parseInt(exercise.reps, 10)
+    if (isNaN(currentReps)) {
+      const inferredReps = lastPerformance?.[0]?.reps
+      if (!inferredReps || inferredReps <= 0) return null
+      currentReps = inferredReps
+    }
+    volume = {
+      type: "reps",
+      current: currentReps,
+      min: exercise.rep_range_min ?? Math.max(1, currentReps - 2),
+      max: exercise.rep_range_max ?? currentReps + 2,
+      increment: 1,
+    }
+  }
+
+  const templateWeight = Number(exercise.weight) || 0
+  const lastSessionWeight = lastPerformance?.[0]?.weight ?? 0
+  const currentWeight = lastSessionWeight > 0 ? lastSessionWeight : templateWeight
+
+  return {
+    volume,
+    currentWeight,
+    currentSets: exercise.sets,
+    setRangeMin: exercise.set_range_min ?? Math.max(1, exercise.sets - 1),
+    setRangeMax: exercise.set_range_max ?? Math.min(6, exercise.sets + 2),
+    weightIncrement: resolveWeightIncrement(exercise.weight_increment ?? null, equipment),
+    maxWeightReached: exercise.max_weight_reached ?? false,
+    currentReps: volume.type === "reps" ? volume.current : 0,
+    repRangeMin: volume.type === "reps" ? volume.min : 0,
+    repRangeMax: volume.type === "reps" ? volume.max : 0,
+  }
 }
 
 function averageRir(sets: SetPerformance[]): number | null {

--- a/src/lib/syncService.ts
+++ b/src/lib/syncService.ts
@@ -533,6 +533,7 @@ async function drainQueueOnce(userId: string): Promise<void> {
   }
   queryClient.invalidateQueries({ queryKey: ["sessions"] })
   queryClient.invalidateQueries({ queryKey: ["last-session-for-day"] })
+  queryClient.invalidateQueries({ queryKey: ["progression-suggestions-for-day"] })
   queryClient.invalidateQueries({ predicate: (q) => q.queryKey[0] === "workout-exercises" })
   queryClient.invalidateQueries({ queryKey: ["pr-aggregates"] })
   queryClient.invalidateQueries({ queryKey: ["training-activity-by-day"] })

--- a/src/locales/en/workout.json
+++ b/src/locales/en/workout.json
@@ -177,6 +177,7 @@
   "progression.durationUp": "Duration up",
   "progression.durationUpDetail": "You nailed every set last time — bumped to {{duration}}s for {{sets}} sets at {{weight}} {{unit}}.",
   "progression.autoAppliedHint": "Already applied — edit any value to override.",
+  "progression.suggestionsUnavailable": "Suggestions unavailable — showing template values.",
   "progression.tryGenerator": "Try the AI program generator for a new cycle",
   "autoDetectLoading": "{{name}}: you logged weight — unlock weight progression?",
   "autoDetectLoadingAction": "Unlock",

--- a/src/locales/fr/workout.json
+++ b/src/locales/fr/workout.json
@@ -175,6 +175,7 @@
   "progression.durationUp": "Durée en hausse",
   "progression.durationUpDetail": "Toutes les séries réussies — passé à {{duration}}s pour {{sets}} séries à {{weight}} {{unit}}.",
   "progression.autoAppliedHint": "Déjà appliqué — modifie n'importe quelle valeur si besoin.",
+  "progression.suggestionsUnavailable": "Suggestions indisponibles — valeurs par défaut affichées.",
   "progression.tryGenerator": "Essaye le générateur IA pour un nouveau cycle",
   "historySheet.trendHintBodyweight": "Enregistrez cet exercice sur plusieurs séances pour voir la tendance de vos meilleures répétitions.",
   "historySheet.chartCaptionReps": "Meilleures Reps par séance",

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -345,7 +345,7 @@ export function WorkoutPage() {
   const isDayDoneInCycle = cycleProgress.completedDayIds.includes(session.currentDayId ?? "")
 
   const {
-    data: progressionSuggestionsByExerciseId,
+    data: progressionSuggestionsByRowId,
     isLoading: progressionSuggestionsLoading,
     error: progressionSuggestionsError,
   } = useProgressionSuggestionsForDay(
@@ -1216,7 +1216,7 @@ export function WorkoutPage() {
                   onSwapBrowseLibrary={(row) => setSwapLibraryRowId(row.id)}
                   onRequestAddExerciseSheet={() => setAddExerciseSheetOpen(true)}
                   onInspectExercise={(id) => setInspectedExerciseId(id)}
-                  suggestionsByExerciseId={progressionSuggestionsByExerciseId}
+                  suggestionsByRowId={progressionSuggestionsByRowId}
                   suggestionsLoading={progressionSuggestionsLoading}
                   suggestionsError={progressionSuggestionsError}
                 />

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/hooks/useBuilderMutations"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 import { useLastWeights, lastWeightsQueryConfig } from "@/hooks/useLastWeights"
+import { useProgressionSuggestionsForDay } from "@/hooks/useProgressionSuggestionsForDay"
 import { useActiveCycle } from "@/hooks/useCycle"
 import { enqueueSessionFinish, scheduleImmediateDrain, type ProgressionTarget } from "@/lib/syncService"
 import { computeNextSessionTarget, resolveWeightIncrement, type ProgressionPrescription, type SetPerformance, type VolumePrescription } from "@/lib/progression"
@@ -342,6 +343,15 @@ export function WorkoutPage() {
   const { data: lastWeights = {} } = useLastWeights(exerciseIds)
   const activeSessionDayId = session.activeDayId ?? session.currentDayId
   const isDayDoneInCycle = cycleProgress.completedDayIds.includes(session.currentDayId ?? "")
+
+  const {
+    data: progressionSuggestionsByExerciseId,
+    isLoading: progressionSuggestionsLoading,
+    error: progressionSuggestionsError,
+  } = useProgressionSuggestionsForDay(
+    !isDayDoneInCycle ? session.currentDayId ?? null : null,
+    exercises,
+  )
 
   const { data: lastSessionForDay } = useLastSessionForDay(
     isDayDoneInCycle ? session.currentDayId : null,
@@ -1206,6 +1216,9 @@ export function WorkoutPage() {
                   onSwapBrowseLibrary={(row) => setSwapLibraryRowId(row.id)}
                   onRequestAddExerciseSheet={() => setAddExerciseSheetOpen(true)}
                   onInspectExercise={(id) => setInspectedExerciseId(id)}
+                  suggestionsByExerciseId={progressionSuggestionsByExerciseId}
+                  suggestionsLoading={progressionSuggestionsLoading}
+                  suggestionsError={progressionSuggestionsError}
                 />
               </div>
             )}

--- a/supabase/migrations/20260527100000_create_get_last_performance_for_exercises.sql
+++ b/supabase/migrations/20260527100000_create_get_last_performance_for_exercises.sql
@@ -1,0 +1,51 @@
+-- Latest-session set_logs for an array of exercises, used by useProgressionSuggestionsForDay
+-- to render Progression Suggestion-based values on the pre-session list (#371, ADR 0005).
+-- SECURITY INVOKER: RLS on sessions / set_logs applies via auth.uid().
+CREATE INDEX IF NOT EXISTS idx_set_logs_exercise_logged_at
+  ON set_logs (exercise_id, logged_at DESC);
+
+CREATE OR REPLACE FUNCTION get_last_performance_for_exercises(
+  p_exercise_ids uuid[]
+)
+RETURNS TABLE (
+  exercise_id uuid,
+  session_id uuid,
+  set_number integer,
+  reps_logged text,
+  weight_logged numeric,
+  rir integer,
+  duration_seconds integer,
+  logged_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH latest_session_per_exercise AS (
+    SELECT DISTINCT ON (sl.exercise_id)
+      sl.exercise_id,
+      sl.session_id
+    FROM set_logs sl
+    JOIN sessions s ON s.id = sl.session_id
+    WHERE sl.exercise_id = ANY(p_exercise_ids)
+      AND s.user_id = auth.uid()
+    ORDER BY sl.exercise_id, sl.logged_at DESC
+  )
+  SELECT
+    sl.exercise_id,
+    sl.session_id,
+    sl.set_number,
+    sl.reps_logged,
+    sl.weight_logged,
+    sl.rir,
+    sl.duration_seconds,
+    sl.logged_at
+  FROM set_logs sl
+  JOIN latest_session_per_exercise lsp
+    ON sl.exercise_id = lsp.exercise_id
+    AND sl.session_id = lsp.session_id
+  ORDER BY sl.exercise_id, sl.set_number;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_last_performance_for_exercises(uuid[]) TO authenticated;


### PR DESCRIPTION
## What

- Pre-session exercise rows now display the **Progression Suggestion** (engine-computed weight / reps / sets / duration) instead of the stale **Template Prescription**, with a compact `ProgressionPill` next to the value to explain the rule (`REPS_UP`, `WEIGHT_UP`, `HOLD_NEAR_FAILURE`, …).
- New batched hook `useProgressionSuggestionsForDay(dayId, exercises)` returns `Map<exercise_id, ProgressionSuggestion | null>` from a single Supabase RPC per day, instead of N per-row queries.
- New PostgreSQL RPC `get_last_performance_for_exercises(uuid[])` + composite index `idx_set_logs_exercise_logged_at` on `set_logs(exercise_id, logged_at DESC)`.

## Why

Today the pre-session screen renders `workout_exercises.weight / reps / sets` directly. Once you start the session, the engine kicks in and shows e.g. `57 kg` because **Last Performance** logged 57. But the row says `48` (the original Template Prescription). Result: misleading info before every session.

This PR shows the engine's actual prediction *before* the user taps **Start**, covering all four volume axes (reps / weight / sets / duration) and the `HOLD_*` / `PLATEAU` rules — not just weight increases. The bug isn't "weight is wrong", it's "the row ignores the engine entirely".

Performance was a real concern: `WorkoutDayCarousel` can mount ~3 days × ~8 exercises = ~24 parallel queries with the naïve per-row approach. The batched RPC keeps it at O(days_visible) — see [ADR 0005](docs/adr/0005-batch-progression-suggestions-per-day.md).

## How

Two commits:

1. **`refactor(#371): extract buildPrescription helper + batched RPC groundwork`** — Pure prep, no UX change.
   - Extract `buildPrescription(exercise, lastPerf, opts)` from `useProgressionSuggestion` into `src/lib/progression.ts` so per-exercise and batched callers share the logic. 5 unit tests.
   - Add the RPC + index migration. `SECURITY INVOKER` so existing `set_logs` RLS applies via `auth.uid()`.
   - Ship docs: Tech Plan, ADR 0005, and a `## Progression engine` section in `CONTEXT.md` (Progression Rule / Suggestion / Template Prescription / Last Performance).

2. **`feat(#371): show Progression Suggestion values on pre-session list`** — The actual feature.
   - `useProgressionSuggestionsForDay` calls the RPC, groups rows per exercise, infers `measurementType` from `duration_seconds`, builds a `ProgressionPrescription`, runs `computeNextSessionTarget`. 5 hook tests covering empty / happy / partial / duration / RPC error.
   - `ProgressionPill` gets a `compact` prop — icon-only Badge with rule reason as `aria-label`. Popover content unchanged. (2 tests)
   - `ExerciseEditRowControls` accepts `suggestion` + `isLoadingSuggestion`. Skeleton in flight → engine values + pill once resolved → template fallback when no Last Performance. (4 tests)
   - `PreSessionExerciseList` shows a subtle "suggestions unavailable" indicator on RPC error so the session can still start with template values.
   - `WorkoutPage` wires the hook gated by `!isDayDoneInCycle` (already-done days don't predict — they show real perfs via `ExerciseListPreview`).
   - `syncService.handleFinish` invalidates `progression-suggestions-for-day` so freshly-logged perfs propagate when swiping to other days.

Test suite: **1556 / 1556 green** (+11 new). Build + lint + types clean.

Closes #371

Made with [Cursor](https://cursor.com)