### PR TITLE
feat(#374): eyes-off hold timer feedback — pre-end audio cues + screen wake lock

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -107,6 +107,18 @@ The **Embedded Agent**-backed AI generation path triggered from `QuickWorkoutShe
 
 ---
 
+## Workout execution
+
+**Duration Set Timer**:
+The in-session timer for duration-based exercises (planks, hollow holds, dead hangs) — distinct from the rest timer. Renders inside `SetsTable` as a two-cell unit (live MM:SS countdown + Play/Stop button). Fires audio + vibration at T=0 and auto-logs the set; the user does not tap a separate Log button. **Pre-existing limitation:** `elapsedSec` is **not pause-aware** (uses raw wall-clock vs **`useRestTimer`**'s `accumulatedPause`); resuming after a long pause insta-fires the alarm. Tracked separately from #374.
+→ `file:src/components/workout/DurationSetTimer.tsx`
+
+**Eyes-off Feedback**:
+The product-level promise that during a held isometric (plank, hollow hold, etc.) the user never needs to look at the screen to know how the set is going. Three layers, in order of reliability: **(1)** screen wake lock via **`useKeepScreenAwake`** to keep the visual countdown legible without re-unlocking the phone (foreground only); **(2)** sequenced audio cues at T-3 / T-2 / T-1 (660 Hz / 150 ms `playWarningBeep`) and a finish chime at T-0 (`playFinishBeeps`, two-note 880 → 1100 Hz) for eyes-closed / looking-up moments; **(3)** a service-worker notification at T-0 (best-effort, mirrors **`useRestTimer`**'s pattern) for the backgrounded / phone-in-pocket case. Centralized through **`src/lib/audio.ts`** + **`useKeepScreenAwake`** (see ADR 0006). Currently scoped to **Duration Set Timer**; **`useRestTimer`**'s 10-second warning is a credible future caller.
+→ `file:src/components/workout/DurationSetTimer.tsx`, `file:src/lib/audio.ts`, `file:src/hooks/useKeepScreenAwake.ts`
+
+---
+
 ## Progression engine
 
 **Progression Rule**:

--- a/docs/Tech_Plan_—_Eyes-off_Hold_Timer_Feedback.md
+++ b/docs/Tech_Plan_—_Eyes-off_Hold_Timer_Feedback.md
@@ -1,0 +1,209 @@
+# Tech Plan — Eyes-off Hold Timer Feedback
+
+Tracks GitHub issue **#374** — *"hold timer needs eyes-off feedback — pre-end audio cues + screen wake lock"*. No Epic Brief was written; the issue body, the [grilling decisions](./CONTEXT.md#workout-execution), and [ADR 0006](./adr/0006-shared-timer-utilities.md) are the inputs.
+
+## Architectural Approach
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Audio strategy | Singleton `AudioContext` shared via `src/lib/audio.ts` | iOS Safari concurrent-context cap; sequenced T-3..T-0 churns the existing fresh-per-fire pattern in `DurationSetTimer.tsx`. ADR 0006. |
+| iOS gesture-unlock | `primeAudio()` called from Play / set-log handlers | iOS Safari requires a transient user activation for the first context creation; `setInterval`-driven beeps fail otherwise. |
+| Wake lock encapsulation | `useKeepScreenAwake(active: boolean)` hook | Centralizes request/release/visibilitychange/feature-detection; testable in isolation; future `useRestTimer` adoption is a one-line opt-in. |
+| Wake lock + workout pause | Release on pause, re-acquire on resume | Mirrors interval gating; paused = phone-in-pocket = screen can sleep. |
+| Pre-end beep schedule | Clamp by fire-offset, not by target value | `if (offset > 0)`: target=3 → no T-3; target=2 → T-1+T-0; target=1 → T-0. |
+| Pause/throttle salvo guard | 1500 ms stale-fire window per warning beep | Pre-existing pause-elapsed bug means a long pause/resume can otherwise produce a "BEEP-BEEP-BEEP-CHIME" salvo. Cheap defensive heuristic; doesn't block the proper `accumulatedPause` fix later. |
+| T-0 finish chime | Unify both timers on `playFinishBeeps` (two-note 880→1100 Hz) | Cohesion; clearly distinct from T-1 warning; zero cost via shared helper. |
+| SW notification at T-0 | Mirror `useRestTimer.ts:173-181` best-effort path | Permission already elicited at `AuthGuard.tsx:32`; reuses pattern, no new infra. |
+| i18n keys | `holdOverNotif` / `holdOverBody` | Symmetric with `restOverNotif`; reads naturally in FR (loanword); generic naming is YAGNI. |
+| Pause-elapsed bug (true fix) | Out of scope; follow-up issue | `DurationSetTimer.elapsedSec` not pause-aware (raw wall-clock); fixing properly mirrors `useRestTimer`'s `accumulatedPause` machinery — separate ticket. |
+| Voice countdown ("3, 2, 1") | Out of scope; follow-up | Beeps are 90% of value; voice adds bundle weight + i18n cost. |
+
+### Critical Constraints
+
+**iOS gesture chain.** Both `navigator.wakeLock.request("screen")` and `AudioContext` construction require a transient user activation on iOS Safari 16.4+. The Play button at `file:src/components/workout/DurationSetTimer.tsx:140` is the only safe entry — `primeAudio()` and the wake-lock acquisition both originate there. The `visibilitychange` re-acquire path may silently reject on iOS (transient activation isn't typically granted to that event); we swallow the rejection without logging. Audio `setInterval` callbacks are non-gestures, but the singleton context is unlocked once by `primeAudio()` and remains so for the page lifetime.
+
+**Hidden-tab JS throttling.** `setInterval` is heavily throttled in backgrounded tabs on iOS Safari and modern Chrome. If the timer elapses while hidden, T-0 chime, SW notification, and auto-log won't fire until the tab becomes visible again. The wake lock re-acquire path on `visibilitychange` is gated by the consumer's `active` boolean — when `remaining` drops to 0 and `onLog` runs, `active` flips to false and we never re-acquire for a finished hold.
+
+**Pause-elapsed bug inheritance.** `file:src/components/workout/DurationSetTimer.tsx:58-61` computes `elapsedSec` off raw wall-clock, not pause-aware. Pausing for 5 minutes mid-hold then resuming will jump `elapsedSec` past the entire schedule on a single tick. **Mitigation in this ticket:** each warning beep is guarded by a 1500 ms stale-fire window — if the current tick is more than 1500 ms past the scheduled offset, the beep is silently marked fired without playing. T-0 chime always fires. The user gets a clean chime, not a salvo. **Proper fix:** mirror `useRestTimer`'s `getEffectiveElapsed` + `accumulatedPause` machinery — tracked separately as the ticket would otherwise double in scope.
+
+**Bundle impact.** Two new modules (~80 LOC across `src/lib/audio.ts`, `src/lib/buildBeepSchedule.ts`, `src/hooks/useKeepScreenAwake.ts`). No new dependencies. `audio.ts` consolidates code already shipped in `useRestTimer`, just relocated.
+
+---
+
+## Data Model
+
+No database, schema, or persistence changes. The feature is purely client-side runtime behavior on top of existing `workout_exercises.duration_seconds` data.
+
+### Module Surface (TypeScript)
+
+#### `src/lib/audio.ts`
+
+```ts
+function getAudioCtx(): AudioContext
+
+/** Call from a user-gesture handler before any non-gesture playback path. */
+export function primeAudio(): void
+
+export function playBeep(
+  frequency: number,
+  durationMs: number,
+  volume?: number,
+): void
+
+/** Pre-end warning cue: 660 Hz, 150 ms, volume 0.2. */
+export function playWarningBeep(): void
+
+/** Finish chime: 880 Hz then 1100 Hz, 200 ms / 300 ms, volume 0.5. */
+export function playFinishBeeps(): void
+```
+
+#### `src/lib/buildBeepSchedule.ts`
+
+```ts
+export type BeepFireSpec = {
+  atMsFromStart: number
+  kind: "warning" | "finish"
+}
+
+/** Suppresses any pre-end beep whose fire offset would coincide with start. */
+export function buildBeepSchedule(targetSeconds: number): BeepFireSpec[]
+```
+
+**Clamp matrix:**
+
+| `targetSeconds` | Schedule (kind @ offset ms) |
+|---|---|
+| ≥ 4 | warning@(t-3)·1000, warning@(t-2)·1000, warning@(t-1)·1000, finish@t·1000 |
+| 3 | warning@1000, warning@2000, finish@3000 *(T-3 offset = 0, suppressed)* |
+| 2 | warning@1000, finish@2000 |
+| 1 | finish@1000 |
+| 0 | `[]` (defensive — input layer rejects via `n > 0` check) |
+
+#### `src/hooks/useKeepScreenAwake.ts`
+
+```ts
+/**
+ * Acquires `navigator.wakeLock.request("screen")` while `active` is true.
+ * Re-acquires on visibilitychange→visible if still active. Releases on
+ * unmount, on `active` flipping to false, and on browser auto-release when
+ * the tab is hidden. No-op when `navigator.wakeLock` is undefined.
+ */
+export function useKeepScreenAwake(active: boolean): void
+```
+
+---
+
+## Component Architecture
+
+### Layer Overview
+
+```mermaid
+graph TD
+    SetsTable["SetsTable.tsx<br/>(consumer)"] -->|kind=duration| DST
+    DST["DurationSetTimer.tsx<br/>(modified)"] -->|onClick Play| primeAudio
+    DST -->|isRunning && !paused| useKeepScreenAwake
+    DST -->|tick: T-3/-2/-1| playWarningBeep
+    DST -->|tick: T-0| playFinishBeeps
+    DST -->|tick: T-0 if granted| swNotif[/SW showNotification/]
+    URT["useRestTimer.ts<br/>(refactored)"] --> primeAudio
+    URT --> playWarningBeep
+    URT --> playFinishBeeps
+
+    primeAudio[("audio.ts<br/>primeAudio()")]
+    playWarningBeep[("audio.ts<br/>playWarningBeep()")]
+    playFinishBeeps[("audio.ts<br/>playFinishBeeps()")]
+    useKeepScreenAwake[("useKeepScreenAwake.ts")]
+```
+
+### New Files & Responsibilities
+
+| File | Status | Purpose |
+|---|---|---|
+| `src/lib/audio.ts` | Create | Shared singleton `AudioContext` + named cue functions. Hosts `getAudioCtx`, `primeAudio`, `playBeep`, `playWarningBeep`, `playFinishBeeps`. Lifted from `useRestTimer.ts:13-48`. |
+| `src/lib/audio.test.ts` | Create | Vitest. Stubs `AudioContext` via `vi.stubGlobal`. Asserts singleton (two `getAudioCtx()` calls return same ref), `primeAudio` resumes a suspended context, `playFinishBeeps` schedules two oscillators 250 ms apart. |
+| `src/lib/buildBeepSchedule.ts` | Create | Pure function — clamp matrix. Exported separately for testability without React. |
+| `src/lib/buildBeepSchedule.test.ts` | Create | Vitest. Covers `targetSeconds` 0/1/2/3/4/10. |
+| `src/hooks/useKeepScreenAwake.ts` | Create | Wake lock encapsulation — request/release/visibilitychange/feature-detection. |
+| `src/hooks/useKeepScreenAwake.test.ts` | Create | Vitest + `renderHookWithProviders`. Stubs `navigator.wakeLock`. Covers active-toggle, visibilitychange re-acquire, unmount release, missing API graceful no-op, request rejection silent swallow. |
+
+### Modified Files & Responsibilities
+
+| File | Change |
+|---|---|
+| `src/components/workout/DurationSetTimer.tsx` | Drop the inline `AudioContext` + oscillator code (`DurationSetTimer.tsx:72-86`). Compute `schedule = buildBeepSchedule(targetSeconds)` at start. Track fired indices via a `Set<number>` ref keyed by schedule position. In the existing tick effect, for each unfired entry: (a) if `elapsedMs >= atMsFromStart` AND `(elapsedMs - atMsFromStart) < 1500` → play it; (b) else if `elapsedMs >= atMsFromStart + 1500` → mark fired without playing (stale-fire window). T-0 (`kind === "finish"`) bypasses the stale-fire window — always plays. Call `primeAudio()` at the top of the Play button `onClick`. Wrap with `useKeepScreenAwake(isRunning && !isWorkoutPaused)`. Mirror `useRestTimer`'s SW notification block at T-0 with the new i18n keys. |
+| `src/hooks/useRestTimer.ts` | Replace local `audioCtx` / `getAudioCtx` / `playBeep` / `playWarningBeep` / `playFinishBeeps` (lines 13-48) with imports from `src/lib/audio.ts`. No behavioral changes. |
+| `src/components/workout/SetsTable.tsx` | Add `primeAudio()` call to the set-log click handler (the gesture that starts a rest timer). Single import + single function call; ~2 lines. |
+| `src/hooks/useRestTimer.test.ts` | Update import path if any audio assertions exist; otherwise unchanged. |
+| `src/locales/en/workout.json` | Add `holdOverNotif: "Hold complete!"`, `holdOverBody: "Time to log your set"`. |
+| `src/locales/fr/workout.json` | Add `holdOverNotif: "Hold terminé !"`, `holdOverBody: "Log ta série"`. |
+
+### Component Responsibilities
+
+**`DurationSetTimer.tsx` (modified)**
+- Owns `targetSeconds`, `timerStartedAt`, `alarmFiredRef`, new `firedBeepIndicesRef: Set<number>`, computed `schedule` from `buildBeepSchedule(targetSeconds)`.
+- Renders the live MM:SS countdown + Play/Stop button (unchanged structure).
+- Play `onClick`: `primeAudio()` → `onStart()`.
+- Subscribes to `useKeepScreenAwake(isRunning && !isWorkoutPaused)`.
+- Tick effect (modified): iterates `schedule`; for each unfired entry, applies the stale-fire window rule; on `finish` fire, also vibrates, fires SW notif if granted, and calls `onLog(targetSeconds)`.
+- On `timerStartedAt` / `targetSeconds` change: clears `alarmFiredRef` (existing) AND `firedBeepIndicesRef` (new).
+
+**`src/lib/audio.ts` (new)**
+- Pure module, no React.
+- Singleton `AudioContext` at module scope; `getAudioCtx()` is internal.
+- `primeAudio()` is the public unlock call: creates the context if absent, calls `resume()` if suspended.
+- All API calls are `try/catch`-wrapped — silent fallback if Web Audio is unavailable.
+
+**`useKeepScreenAwake.ts` (new)**
+- Single boolean argument: `active`.
+- Holds the sentinel in a ref.
+- `useEffect([active])`: when `active === true` and no sentinel, request and store; when `active === false` and sentinel held, release explicitly.
+- `useEffect([])` (mount-only): attaches `visibilitychange` listener that calls `requestIfNeeded()` (re-reads `active` via ref) on `document.visibilityState === "visible"`.
+- Cleanup: release sentinel + remove listener.
+- All API calls `try`-wrapped; rejections swallowed.
+
+### Failure Mode Analysis
+
+| Failure | Behavior |
+|---|---|
+| `navigator.wakeLock` undefined (older iOS, Firefox before 126) | `useKeepScreenAwake` no-ops; timer runs normally; user must keep phone awake manually. |
+| `wakeLock.request()` rejects (denied, secure-context issue) | Silent swallow; ref stays null; no retry; timer continues. |
+| `visibilitychange` re-acquire rejects on iOS | Silent swallow; user must tap Stop or wait — visual countdown is already stale until they re-engage. |
+| `AudioContext` constructor throws (no Web Audio) | `primeAudio` and `playBeep` no-op; timer fires only vibrate + SW notif at T-0. |
+| `Notification.permission !== "granted"` | SW notification block skipped (existing pattern); audio + vibration still fire. |
+| User backgrounds the tab mid-hold | Wake lock auto-released; `setInterval` throttled — beeps and T-0 fire late or after return. SW notif fires only if JS happens to tick at T-0 during throttling (best-effort). |
+| User pauses mid-hold and resumes after a long delay | `elapsedMs` jumps past one or more scheduled offsets in a single tick. Each warning beep guarded by the 1500 ms stale-fire window — silently marked fired without playing. T-0 chime fires (always-on). User gets a clean chime, not a salvo. |
+| `targetSeconds ≤ 0` | Input layer rejects (`DurationSetTimer.tsx:113-119`); `buildBeepSchedule(0)` returns `[]` defensively. Unreachable in practice. |
+| Two `DurationSetTimer` instances mounted | `disabled` prop ensures only one is `isRunning`; the other passes `active=false` to `useKeepScreenAwake` — no double-acquire. Singleton audio context is shared. |
+| User Stops early before T-0 | `onLog(elapsed)` fires; `isRunning` flips false; `useKeepScreenAwake(false)` releases lock; remaining schedule entries unreachable on next tick. |
+
+---
+
+## Test Plan
+
+| Layer | Tool | Coverage |
+|---|---|---|
+| `buildBeepSchedule` | vitest (pure unit) | Clamp matrix: target 0/1/2/3/4/10. Asserts ordering + offset values. |
+| `audio.ts` | vitest + `vi.stubGlobal("AudioContext", ...)` | Singleton (two `getAudioCtx()` calls return same instance), `primeAudio` calls `resume()` on suspended context, `playFinishBeeps` schedules two oscillators 250 ms apart, all helpers swallow exceptions. |
+| `useKeepScreenAwake` | vitest + `renderHookWithProviders` + stubbed `navigator.wakeLock` | active=true → `request` called once; active flips false → `release` called; unmount while active → release; visibilitychange→visible while active → `request` called again; missing API → no calls/no throws; `request` rejection → no throws/no logs. |
+| `DurationSetTimer` integration | vitest + RTL + `vi.useFakeTimers({ shouldAdvanceTime: true })` (mirror `useRestTimer.test.ts:9-15`) | Tap Play → `primeAudio` called. Advance to T-3/-2/-1 → `playWarningBeep` called 3×. T-0 → `playFinishBeeps` + `onLog(targetSeconds)` + vibrate. Stop early → `onLog(elapsed)`. Stale-fire window: jump `elapsedMs` past T-2 by 2000ms → no beep, marked fired. Pause then resume after 5min → no warning salvo, T-0 chime fires. |
+| Manual QA per AC | iOS Safari 16.4+ + Android Chrome (real devices) | Wake lock observed (screen stays on for full hold with auto-lock at 30 s); pre-end beeps audible; T-0 chime audible; SW notification visible if tab backgrounded. |
+
+No Playwright e2e — wake lock + real audio in headless are more cost than signal.
+
+---
+
+## Out of Scope (intentional)
+
+- TTS / pre-recorded "3, 2, 1" voice clips → follow-up if there's demand.
+- Same eyes-off treatment for `useRestTimer` → already partially handled (10s warning + finish chime + SW notif); revisit only if users complain.
+- Background-tab timer accuracy → not a hold-timer concern (durations are short; we self-correct from `Date.now()`).
+- **`DurationSetTimer` pause-elapsed bug (true fix)** → tracked separately. This ticket masks the worst symptom (salvo) via the stale-fire window but does not fix the underlying `accumulatedPause` deficit.
+
+## References
+
+- GitHub issue #374
+- ADR 0006 — Shared Timer Utilities (`docs/adr/0006-shared-timer-utilities.md`)
+- Glossary: **Duration Set Timer**, **Eyes-off Feedback** (`docs/CONTEXT.md` → Workout execution)
+- Existing patterns: `src/hooks/useRestTimer.ts`, `src/hooks/useNotificationPermission.ts`, `src/components/workout/SetsTable.tsx`

--- a/docs/adr/0006-shared-timer-utilities.md
+++ b/docs/adr/0006-shared-timer-utilities.md
@@ -1,0 +1,37 @@
+# ADR 0006 — Shared Timer Utilities
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Decided in:** grilling session for #374 hold timer eyes-off feedback
+
+## Context
+
+The PWA has two independent timers — the rest timer (`useRestTimer.ts`) and the **Duration Set Timer** (`DurationSetTimer.tsx`). They each rolled their own audio: the rest timer uses a module-level singleton `AudioContext` with defensive `resume()`; `DurationSetTimer` creates a fresh `AudioContext` per fire and `close()`s it. Two strategies, both correct in isolation, but iOS Safari has a hard cap on concurrent contexts — adding sequenced T-3 / T-2 / T-1 / T-0 beeps per #374 would churn four contexts in three seconds under the existing pattern.
+
+#374 also adds a screen wake lock for the **Duration Set Timer**. The Wake Lock API is small but fiddly (sentinel-release, `visibilitychange` re-acquire, feature detection, gesture-unlock) and has a credible future caller (`useRestTimer`'s 10-second warning is silently lost when the tab/screen sleeps).
+
+Both concerns serve the same product promise — **Eyes-off Feedback** — and benefit from the same architectural call: pull the browser-API glue out of consumer components and centralize it.
+
+## Decision
+
+We will:
+
+1. Extract audio helpers into `src/lib/audio.ts`: singleton `getAudioCtx()`, primitive `playBeep(frequency, durationMs, volume)`, named cues `playWarningBeep()` (660 Hz / 150 ms) and `playFinishBeeps()` (880 → 1100 Hz two-note). Both timers route through this module.
+2. Add `primeAudio()` to the same module — callers invoke it from a user-gesture handler (Play, set-log) so the singleton is unlocked under iOS Safari's gesture rule before any `setInterval`-driven playback path.
+3. Unify the T-0 finish chime — `DurationSetTimer` adopts `playFinishBeeps`, replacing today's single 880 Hz blip.
+4. Extract a `useKeepScreenAwake(active: boolean)` hook in `src/hooks/useKeepScreenAwake.ts` encapsulating request / release / visibilitychange / feature detection. Single consumer today (`DurationSetTimer`), shaped for `useRestTimer` to opt in later.
+
+## Consequences
+
+- **Positive:** consistent audio strategy app-wide (singleton, gesture-unlocked once); sequenced beeps for #374 are correct on iOS; finish chime cohesion across timers; wake-lock glue testable in isolation; future timers (AMRAP/EMOM) inherit both utilities.
+- **Negative:** scope creep on #374 (refactor + feature in one PR) — accepted because the singleton pattern is load-bearing for the new sequencing. Two new files, but they replace duplicated code.
+- **Follow-ups:** `useRestTimer` adopts `useKeepScreenAwake(isActive)` in a separate ticket; pre-existing `DurationSetTimer` pause-elapsed bug (raw wall-clock, not pause-aware) tracked separately.
+
+## Alternatives considered
+
+| Option | Why we didn't pick it |
+|---|---|
+| Copy-paste audio helpers into `DurationSetTimer`, keep two AudioContext strategies | Drift makes iOS bugs harder to reason about; T-3/-2/-1 sequencing reopens iOS concurrent-context cap risk. |
+| Inline wake lock logic in `DurationSetTimer` (no hook) | ~40 lines of browser-API glue mixed with UI; visibilitychange crosses concerns; harder to test; future `useRestTimer` adoption forces a re-extract. |
+| Two separate ADRs (one audio, one wake lock) | Both are facets of the same call (centralize browser-API glue serving **Eyes-off Feedback**); one ADR keeps the rationale together. |
+| Defer extraction to a follow-up refactor ticket | Singleton is load-bearing for the new sequencing; copy-paste forces either reinventing the singleton inline or living with 4 fresh AudioContexts in 3 seconds. |

--- a/src/components/workout/DurationSetTimer.test.tsx
+++ b/src/components/workout/DurationSetTimer.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import userEvent from "@testing-library/user-event"
+import { act, screen } from "@testing-library/react"
+import { renderWithProviders } from "@/test/utils"
+import { DurationSetTimer } from "./DurationSetTimer"
+
+vi.mock("@/lib/audio", () => ({
+  primeAudio: vi.fn(),
+  playWarningBeep: vi.fn(),
+  playFinishBeeps: vi.fn(),
+}))
+
+vi.mock("@/hooks/useKeepScreenAwake", () => ({
+  useKeepScreenAwake: vi.fn(),
+}))
+
+import { primeAudio, playWarningBeep, playFinishBeeps } from "@/lib/audio"
+import { useKeepScreenAwake } from "@/hooks/useKeepScreenAwake"
+
+const mockedPrimeAudio = vi.mocked(primeAudio)
+const mockedPlayWarningBeep = vi.mocked(playWarningBeep)
+const mockedPlayFinishBeeps = vi.mocked(playFinishBeeps)
+const mockedUseKeepScreenAwake = vi.mocked(useKeepScreenAwake)
+
+type DurationProps = React.ComponentProps<typeof DurationSetTimer>
+
+function makeProps(overrides: Partial<DurationProps> = {}): DurationProps {
+  return {
+    targetSeconds: 10,
+    timerStartedAt: null,
+    disabled: false,
+    isWorkoutPaused: false,
+    onStart: vi.fn(),
+    onLog: vi.fn(),
+    onUpdateTarget: vi.fn(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockedPrimeAudio.mockClear()
+  mockedPlayWarningBeep.mockClear()
+  mockedPlayFinishBeeps.mockClear()
+  mockedUseKeepScreenAwake.mockClear()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("DurationSetTimer", () => {
+  it("primes audio when the user taps the Start button", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DurationSetTimer {...makeProps()} />)
+
+    await user.click(screen.getByRole("button", { name: /start/i }))
+
+    expect(mockedPrimeAudio).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps the screen awake while running and releases on pause", () => {
+    const { rerender } = renderWithProviders(
+      <DurationSetTimer {...makeProps({ timerStartedAt: 1_000 })} />,
+    )
+    expect(mockedUseKeepScreenAwake).toHaveBeenLastCalledWith(true)
+
+    rerender(
+      <DurationSetTimer
+        {...makeProps({ timerStartedAt: 1_000, isWorkoutPaused: true })}
+      />,
+    )
+    expect(mockedUseKeepScreenAwake).toHaveBeenLastCalledWith(false)
+
+    rerender(
+      <DurationSetTimer
+        {...makeProps({ timerStartedAt: 1_000, isWorkoutPaused: false })}
+      />,
+    )
+    expect(mockedUseKeepScreenAwake).toHaveBeenLastCalledWith(true)
+  })
+
+  it("does not keep the screen awake when the timer is idle", () => {
+    renderWithProviders(
+      <DurationSetTimer {...makeProps({ timerStartedAt: null })} />,
+    )
+    expect(mockedUseKeepScreenAwake).toHaveBeenLastCalledWith(false)
+  })
+
+  it("calls onLog with elapsed seconds when the user taps End early before T-0", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const start = 1_000
+    vi.setSystemTime(start)
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onLog = vi.fn()
+
+    renderWithProviders(
+      <DurationSetTimer
+        {...makeProps({ targetSeconds: 10, timerStartedAt: start, onLog })}
+      />,
+    )
+
+    act(() => {
+      vi.setSystemTime(start + 3_500)
+      vi.advanceTimersByTime(250)
+    })
+
+    await user.click(screen.getByRole("button", { name: /end early/i }))
+
+    expect(onLog).toHaveBeenCalledWith(3)
+    expect(mockedPlayFinishBeeps).not.toHaveBeenCalled()
+  })
+
+  it("fires a warning at T-3 / T-2 / T-1 and the finish chime + onLog + vibrate at T-0", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const start = 1_000
+    vi.setSystemTime(start)
+    const onLog = vi.fn()
+    const vibrate = vi.fn()
+    vi.stubGlobal("navigator", { vibrate })
+
+    renderWithProviders(
+      <DurationSetTimer
+        {...makeProps({ targetSeconds: 10, timerStartedAt: start, onLog })}
+      />,
+    )
+
+    act(() => {
+      vi.setSystemTime(start + 7_000)
+      vi.advanceTimersByTime(250)
+    })
+    expect(mockedPlayWarningBeep).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.setSystemTime(start + 8_000)
+      vi.advanceTimersByTime(250)
+    })
+    expect(mockedPlayWarningBeep).toHaveBeenCalledTimes(2)
+
+    act(() => {
+      vi.setSystemTime(start + 9_000)
+      vi.advanceTimersByTime(250)
+    })
+    expect(mockedPlayWarningBeep).toHaveBeenCalledTimes(3)
+
+    act(() => {
+      vi.setSystemTime(start + 10_000)
+      vi.advanceTimersByTime(250)
+    })
+    expect(mockedPlayFinishBeeps).toHaveBeenCalledTimes(1)
+    expect(vibrate).toHaveBeenCalled()
+    expect(onLog).toHaveBeenCalledWith(10)
+  })
+
+  it("shows a service-worker notification at T-0 when permission is granted", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const start = 1_000
+    vi.setSystemTime(start)
+    const showNotification = vi.fn()
+    vi.stubGlobal("Notification", { permission: "granted" })
+    vi.stubGlobal("navigator", {
+      vibrate: vi.fn(),
+      serviceWorker: { ready: Promise.resolve({ showNotification }) },
+    })
+
+    renderWithProviders(
+      <DurationSetTimer
+        {...makeProps({ targetSeconds: 3, timerStartedAt: start })}
+      />,
+    )
+
+    act(() => {
+      vi.setSystemTime(start + 3_000)
+      vi.advanceTimersByTime(250)
+    })
+
+    // showNotification is called inside a microtask after serviceWorker.ready resolves
+    return Promise.resolve().then(() => {
+      expect(showNotification).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("does not show a service-worker notification when permission is not granted", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const start = 1_000
+    vi.setSystemTime(start)
+    const showNotification = vi.fn()
+    vi.stubGlobal("Notification", { permission: "denied" })
+    vi.stubGlobal("navigator", {
+      vibrate: vi.fn(),
+      serviceWorker: { ready: Promise.resolve({ showNotification }) },
+    })
+
+    renderWithProviders(
+      <DurationSetTimer
+        {...makeProps({ targetSeconds: 3, timerStartedAt: start })}
+      />,
+    )
+
+    act(() => {
+      vi.setSystemTime(start + 3_000)
+      vi.advanceTimersByTime(250)
+    })
+
+    return Promise.resolve().then(() => {
+      expect(showNotification).not.toHaveBeenCalled()
+    })
+  })
+
+  it("suppresses stale warning beeps but still fires the finish chime after a long gap", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const start = 1_000
+    vi.setSystemTime(start)
+    vi.stubGlobal("navigator", { vibrate: vi.fn() })
+
+    renderWithProviders(
+      <DurationSetTimer
+        {...makeProps({ targetSeconds: 10, timerStartedAt: start })}
+      />,
+    )
+
+    act(() => {
+      vi.setSystemTime(start + 11_000)
+      vi.advanceTimersByTime(250)
+    })
+
+    expect(mockedPlayWarningBeep).not.toHaveBeenCalled()
+    expect(mockedPlayFinishBeeps).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/workout/DurationSetTimer.tsx
+++ b/src/components/workout/DurationSetTimer.tsx
@@ -1,11 +1,17 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Play, StopCircle } from "lucide-react"
 import { formatSecondsMMSS } from "@/lib/formatters"
+import { primeAudio, playWarningBeep, playFinishBeeps } from "@/lib/audio"
+import { buildBeepSchedule, type BeepFireSpec } from "@/lib/buildBeepSchedule"
+import { useKeepScreenAwake } from "@/hooks/useKeepScreenAwake"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 
 const VIBRATE_PATTERN = [200, 100, 200] as const
+
+/** Suppress a warning beep if its tick fires this many ms late (pause/throttle). */
+const STALE_WARNING_WINDOW_MS = 1500
 
 interface DurationSetTimerProps {
   targetSeconds: number
@@ -36,9 +42,14 @@ export function DurationSetTimer({
 }: DurationSetTimerProps) {
   const { t } = useTranslation("workout")
   const [nowTick, setNowTick] = useState(() => Date.now())
-  const alarmFiredRef = useRef(false)
+  const firedBeepIndicesRef = useRef<Set<number>>(new Set())
   // Local edit state for the target input (seconds as string)
   const [editValue, setEditValue] = useState(String(targetSeconds))
+
+  const schedule = useMemo(
+    () => buildBeepSchedule(targetSeconds),
+    [targetSeconds],
+  )
 
   // Keep editValue in sync when targetSeconds changes externally
   useEffect(() => {
@@ -52,7 +63,7 @@ export function DurationSetTimer({
   }, [timerStartedAt, isWorkoutPaused])
 
   useEffect(() => {
-    alarmFiredRef.current = false
+    firedBeepIndicesRef.current = new Set()
   }, [timerStartedAt, targetSeconds])
 
   const elapsedSec =
@@ -62,34 +73,59 @@ export function DurationSetTimer({
   const remaining = Math.max(0, targetSeconds - elapsedSec)
   const isRunning = timerStartedAt != null
 
+  useKeepScreenAwake(isRunning && !isWorkoutPaused)
+
   useEffect(() => {
-    if (!isRunning || remaining > 0 || isWorkoutPaused) return
-    if (alarmFiredRef.current) return
-    alarmFiredRef.current = true
-    if (typeof navigator !== "undefined" && navigator.vibrate) {
-      navigator.vibrate([...VIBRATE_PATTERN])
+    if (!isRunning || isWorkoutPaused || timerStartedAt == null) return
+    const elapsedMs = nowTick - timerStartedAt
+
+    function handleWarning(spec: BeepFireSpec) {
+      const isStale =
+        elapsedMs - spec.atMsFromStart >= STALE_WARNING_WINDOW_MS
+      if (!isStale) playWarningBeep()
     }
-    try {
-      const ctx = new AudioContext()
-      const o = ctx.createOscillator()
-      const g = ctx.createGain()
-      o.connect(g)
-      g.connect(ctx.destination)
-      g.gain.value = 0.08
-      o.frequency.value = 880
-      o.onended = () => {
-        void ctx.close().catch(() => {
-          /* ignore */
-        })
+
+    function handleFinish() {
+      playFinishBeeps()
+      if (typeof navigator !== "undefined" && navigator.vibrate) {
+        navigator.vibrate([...VIBRATE_PATTERN])
       }
-      o.start()
-      o.stop(ctx.currentTime + 0.15)
-    } catch {
-      /* ignore */
+      if (
+        typeof Notification !== "undefined" &&
+        Notification.permission === "granted"
+      ) {
+        try {
+          navigator.serviceWorker?.ready
+            .then((reg) =>
+              reg.showNotification(t("holdOverNotif"), {
+                body: t("holdOverBody"),
+              }),
+            )
+            .catch(() => {})
+        } catch {
+          // Notification API unavailable or restricted — silent fallback
+        }
+      }
+      onLog(targetSeconds)
     }
-    // Timer expired → auto-complete, no extra tap required
-    onLog(targetSeconds)
-  }, [remaining, isRunning, isWorkoutPaused, onLog, targetSeconds])
+
+    schedule.forEach((spec, idx) => {
+      if (firedBeepIndicesRef.current.has(idx)) return
+      if (elapsedMs < spec.atMsFromStart) return
+      firedBeepIndicesRef.current.add(idx)
+      if (spec.kind === "warning") handleWarning(spec)
+      else handleFinish()
+    })
+  }, [
+    nowTick,
+    isRunning,
+    isWorkoutPaused,
+    timerStartedAt,
+    schedule,
+    onLog,
+    targetSeconds,
+    t,
+  ])
 
   const timeDisplay = isRunning
     ? formatSecondsMMSS(remaining)
@@ -142,6 +178,7 @@ export function DurationSetTimer({
                 onBlockedByPause?.()
                 return
               }
+              primeAudio()
               onStart()
             }}
           >

--- a/src/components/workout/SetsTable.tsx
+++ b/src/components/workout/SetsTable.tsx
@@ -3,6 +3,7 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { Minus, Plus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { sessionAtom, restAtom, prFlagsAtom, sessionBestPerformanceAtom } from "@/store/atoms"
+import { primeAudio } from "@/lib/audio"
 import { enqueueSetLog, scheduleImmediateDrain } from "@/lib/syncService"
 import { getRestElapsedSeconds } from "@/hooks/useRestTimer"
 import { computeEpley1RM } from "@/lib/epley"
@@ -339,6 +340,7 @@ export function SetsTable({
         onBlockedByPause?.()
         return
       }
+      primeAudio()
       setPendingSetIdx(null)
 
       const exerciseSets = [...(session.setsData[exercise.id] ?? [])].map((r) =>

--- a/src/hooks/useKeepScreenAwake.test.ts
+++ b/src/hooks/useKeepScreenAwake.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { useKeepScreenAwake } from "./useKeepScreenAwake"
+
+type MockSentinel = {
+  release: ReturnType<typeof vi.fn>
+  addEventListener: ReturnType<typeof vi.fn>
+  removeEventListener: ReturnType<typeof vi.fn>
+}
+
+function makeMockSentinel(): MockSentinel {
+  return {
+    release: vi.fn().mockResolvedValue(undefined),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }
+}
+
+let issuedSentinels: MockSentinel[]
+let wakeLockRequest: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  issuedSentinels = []
+  wakeLockRequest = vi.fn(async () => {
+    const sentinel = makeMockSentinel()
+    issuedSentinels.push(sentinel)
+    return sentinel
+  })
+  vi.stubGlobal("navigator", { wakeLock: { request: wakeLockRequest } })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("useKeepScreenAwake", () => {
+  it("requests the wake lock when mounted with active=true", async () => {
+    renderHook(() => useKeepScreenAwake(true))
+
+    await waitFor(() => {
+      expect(wakeLockRequest).toHaveBeenCalledTimes(1)
+    })
+    expect(wakeLockRequest).toHaveBeenCalledWith("screen")
+  })
+
+  it("releases the sentinel when active flips to false", async () => {
+    const { rerender } = renderHook(
+      ({ active }) => useKeepScreenAwake(active),
+      { initialProps: { active: true } },
+    )
+    await waitFor(() => expect(issuedSentinels).toHaveLength(1))
+
+    rerender({ active: false })
+
+    await waitFor(() => {
+      expect(issuedSentinels[0].release).toHaveBeenCalled()
+    })
+  })
+
+  it("releases the sentinel on unmount while active", async () => {
+    const { unmount } = renderHook(() => useKeepScreenAwake(true))
+    await waitFor(() => expect(issuedSentinels).toHaveLength(1))
+
+    unmount()
+
+    await waitFor(() => {
+      expect(issuedSentinels[0].release).toHaveBeenCalled()
+    })
+  })
+
+  it("re-acquires the wake lock when the tab returns to visible after an auto-release", async () => {
+    renderHook(() => useKeepScreenAwake(true))
+    await waitFor(() => expect(issuedSentinels).toHaveLength(1))
+
+    const releaseListener = issuedSentinels[0].addEventListener.mock.calls.find(
+      ([eventType]) => eventType === "release",
+    )?.[1] as (() => void) | undefined
+    expect(releaseListener).toBeDefined()
+
+    act(() => {
+      releaseListener!()
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+
+    await waitFor(() => {
+      expect(issuedSentinels).toHaveLength(2)
+    })
+  })
+
+  it("no-ops when navigator.wakeLock is undefined", () => {
+    vi.stubGlobal("navigator", {})
+
+    expect(() => renderHook(() => useKeepScreenAwake(true))).not.toThrow()
+  })
+
+  it("silently swallows request() rejections", async () => {
+    const rejectingRequest = vi.fn().mockRejectedValue(new Error("denied"))
+    vi.stubGlobal("navigator", { wakeLock: { request: rejectingRequest } })
+    const unhandled = vi.fn()
+    process.on("unhandledRejection", unhandled)
+
+    try {
+      renderHook(() => useKeepScreenAwake(true))
+      await waitFor(() => expect(rejectingRequest).toHaveBeenCalled())
+      await new Promise((r) => setTimeout(r, 0))
+      expect(unhandled).not.toHaveBeenCalled()
+    } finally {
+      process.off("unhandledRejection", unhandled)
+    }
+  })
+})

--- a/src/hooks/useKeepScreenAwake.test.ts
+++ b/src/hooks/useKeepScreenAwake.test.ts
@@ -97,7 +97,7 @@ describe("useKeepScreenAwake", () => {
     const rejectingRequest = vi.fn().mockRejectedValue(new Error("denied"))
     vi.stubGlobal("navigator", { wakeLock: { request: rejectingRequest } })
     const unhandled = vi.fn()
-    process.on("unhandledRejection", unhandled)
+    window.addEventListener("unhandledrejection", unhandled)
 
     try {
       renderHook(() => useKeepScreenAwake(true))
@@ -105,7 +105,7 @@ describe("useKeepScreenAwake", () => {
       await new Promise((r) => setTimeout(r, 0))
       expect(unhandled).not.toHaveBeenCalled()
     } finally {
-      process.off("unhandledRejection", unhandled)
+      window.removeEventListener("unhandledrejection", unhandled)
     }
   })
 })

--- a/src/hooks/useKeepScreenAwake.ts
+++ b/src/hooks/useKeepScreenAwake.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react"
+
+export function useKeepScreenAwake(active: boolean): void {
+  const sentinelRef = useRef<WakeLockSentinel | null>(null)
+
+  useEffect(() => {
+    if (!active) return
+    if (typeof navigator === "undefined" || !navigator.wakeLock) return
+
+    let cancelled = false
+
+    async function acquire() {
+      try {
+        const sentinel = await navigator.wakeLock.request("screen")
+        if (cancelled) {
+          void sentinel.release()
+          return
+        }
+        sentinel.addEventListener("release", () => {
+          sentinelRef.current = null
+        })
+        sentinelRef.current = sentinel
+      } catch {
+        // wake lock denied / unsupported — silent fallback
+      }
+    }
+
+    function handleVisibility() {
+      if (
+        document.visibilityState === "visible" &&
+        !sentinelRef.current
+      ) {
+        void acquire()
+      }
+    }
+
+    void acquire()
+    document.addEventListener("visibilitychange", handleVisibility)
+
+    return () => {
+      cancelled = true
+      document.removeEventListener("visibilitychange", handleVisibility)
+      if (sentinelRef.current) {
+        void sentinelRef.current.release()
+        sentinelRef.current = null
+      }
+    }
+  }, [active])
+}

--- a/src/hooks/useRestTimer.ts
+++ b/src/hooks/useRestTimer.ts
@@ -9,43 +9,7 @@ import {
 import { useAtom, useAtomValue } from "jotai"
 import { useTranslation } from "react-i18next"
 import { restAtom, sessionAtom, type RestState } from "@/store/atoms"
-
-let audioCtx: AudioContext | null = null
-function getAudioCtx(): AudioContext {
-  if (!audioCtx) audioCtx = new AudioContext()
-  return audioCtx
-}
-
-function playBeep(frequency: number, durationMs: number, volume = 0.3) {
-  try {
-    const ctx = getAudioCtx()
-    if (ctx.state === "suspended") ctx.resume()
-
-    const osc = ctx.createOscillator()
-    const gain = ctx.createGain()
-    osc.connect(gain)
-    gain.connect(ctx.destination)
-
-    osc.frequency.value = frequency
-    osc.type = "sine"
-    gain.gain.setValueAtTime(volume, ctx.currentTime)
-    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + durationMs / 1000)
-
-    osc.start()
-    osc.stop(ctx.currentTime + durationMs / 1000)
-  } catch {
-    // Web Audio not available — silent fallback
-  }
-}
-
-function playWarningBeep() {
-  playBeep(660, 150, 0.2)
-}
-
-function playFinishBeeps() {
-  playBeep(880, 200, 0.5)
-  setTimeout(() => playBeep(1100, 300, 0.5), 250)
-}
+import { playWarningBeep, playFinishBeeps } from "@/lib/audio"
 
 export function formatSeconds(s: number): string {
   const mins = Math.floor(s / 60)

--- a/src/lib/audio.test.ts
+++ b/src/lib/audio.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+type MockOscillator = {
+  frequency: { value: number }
+  type: OscillatorType | ""
+  connect: ReturnType<typeof vi.fn>
+  start: ReturnType<typeof vi.fn>
+  stop: ReturnType<typeof vi.fn>
+  onended: ((this: void) => void) | null
+}
+
+type MockGain = {
+  connect: ReturnType<typeof vi.fn>
+  gain: {
+    value: number
+    setValueAtTime: ReturnType<typeof vi.fn>
+    exponentialRampToValueAtTime: ReturnType<typeof vi.fn>
+  }
+}
+
+type MockAudioContext = {
+  state: "running" | "suspended" | "closed"
+  currentTime: number
+  destination: object
+  resume: ReturnType<typeof vi.fn>
+  createOscillator: () => MockOscillator
+  createGain: () => MockGain
+  oscillators: MockOscillator[]
+}
+
+function makeMockAudioContext(): MockAudioContext {
+  const oscillators: MockOscillator[] = []
+  return {
+    state: "running",
+    currentTime: 0,
+    destination: {},
+    resume: vi.fn(),
+    createOscillator: () => {
+      const osc: MockOscillator = {
+        frequency: { value: 0 },
+        type: "",
+        connect: vi.fn(),
+        start: vi.fn(),
+        stop: vi.fn(),
+        onended: null,
+      }
+      oscillators.push(osc)
+      return osc
+    },
+    createGain: () => ({
+      connect: vi.fn(),
+      gain: {
+        value: 0,
+        setValueAtTime: vi.fn(),
+        exponentialRampToValueAtTime: vi.fn(),
+      },
+    }),
+    oscillators,
+  }
+}
+
+let constructorSpy: ReturnType<typeof vi.fn>
+let currentCtx: MockAudioContext
+
+beforeEach(() => {
+  vi.resetModules()
+  currentCtx = makeMockAudioContext()
+  constructorSpy = vi.fn(function MockAudioContext() {
+    return currentCtx
+  })
+  vi.stubGlobal("AudioContext", constructorSpy)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+async function importAudio() {
+  return await import("./audio")
+}
+
+describe("audio.ts", () => {
+  it("creates exactly one AudioContext across multiple primeAudio calls", async () => {
+    const { primeAudio } = await importAudio()
+
+    primeAudio()
+    primeAudio()
+    primeAudio()
+
+    expect(constructorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("resumes the context when primeAudio is called and the context is suspended", async () => {
+    currentCtx.state = "suspended"
+    const { primeAudio } = await importAudio()
+
+    primeAudio()
+
+    expect(currentCtx.resume).toHaveBeenCalledTimes(1)
+  })
+
+  it("swallows exceptions when AudioContext is unavailable", async () => {
+    vi.stubGlobal(
+      "AudioContext",
+      vi.fn(function ThrowingAudioContext() {
+        throw new Error("Web Audio not supported")
+      }),
+    )
+
+    const { primeAudio, playBeep, playFinishBeeps } = await importAudio()
+
+    expect(() => primeAudio()).not.toThrow()
+    expect(() => playBeep(440, 100)).not.toThrow()
+    expect(() => playFinishBeeps()).not.toThrow()
+  })
+
+  it("plays the finish chime as two oscillators at 880 Hz and 1100 Hz, 250 ms apart", async () => {
+    vi.useFakeTimers()
+    try {
+      const { playFinishBeeps } = await importAudio()
+
+      playFinishBeeps()
+
+      expect(currentCtx.oscillators).toHaveLength(1)
+      expect(currentCtx.oscillators[0].frequency.value).toBe(880)
+
+      vi.advanceTimersByTime(250)
+
+      expect(currentCtx.oscillators).toHaveLength(2)
+      expect(currentCtx.oscillators[1].frequency.value).toBe(1100)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -1,0 +1,52 @@
+let audioCtx: AudioContext | null = null
+
+function getAudioCtx(): AudioContext {
+  if (!audioCtx) audioCtx = new AudioContext()
+  if (audioCtx.state === "suspended") audioCtx.resume()
+  return audioCtx
+}
+
+export function primeAudio(): void {
+  try {
+    getAudioCtx()
+  } catch {
+    // Web Audio not available — silent fallback
+  }
+}
+
+export function playBeep(
+  frequency: number,
+  durationMs: number,
+  volume = 0.3,
+): void {
+  try {
+    const ctx = getAudioCtx()
+
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.connect(gain)
+    gain.connect(ctx.destination)
+
+    osc.frequency.value = frequency
+    osc.type = "sine"
+    gain.gain.setValueAtTime(volume, ctx.currentTime)
+    gain.gain.exponentialRampToValueAtTime(
+      0.001,
+      ctx.currentTime + durationMs / 1000,
+    )
+
+    osc.start()
+    osc.stop(ctx.currentTime + durationMs / 1000)
+  } catch {
+    // Web Audio not available — silent fallback
+  }
+}
+
+export function playWarningBeep(): void {
+  playBeep(660, 150, 0.2)
+}
+
+export function playFinishBeeps(): void {
+  playBeep(880, 200, 0.5)
+  setTimeout(() => playBeep(1100, 300, 0.5), 250)
+}

--- a/src/lib/buildBeepSchedule.test.ts
+++ b/src/lib/buildBeepSchedule.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest"
+import { buildBeepSchedule } from "./buildBeepSchedule"
+
+describe("buildBeepSchedule", () => {
+  it("schedules three pre-end warnings and a finish for a long target", () => {
+    const schedule = buildBeepSchedule(10)
+
+    expect(schedule).toEqual([
+      { atMsFromStart: 7_000, kind: "warning" },
+      { atMsFromStart: 8_000, kind: "warning" },
+      { atMsFromStart: 9_000, kind: "warning" },
+      { atMsFromStart: 10_000, kind: "finish" },
+    ])
+  })
+
+  it("clamps pre-end warnings that would coincide with the start", () => {
+    expect(buildBeepSchedule(3)).toEqual([
+      { atMsFromStart: 1_000, kind: "warning" },
+      { atMsFromStart: 2_000, kind: "warning" },
+      { atMsFromStart: 3_000, kind: "finish" },
+    ])
+
+    expect(buildBeepSchedule(2)).toEqual([
+      { atMsFromStart: 1_000, kind: "warning" },
+      { atMsFromStart: 2_000, kind: "finish" },
+    ])
+
+    expect(buildBeepSchedule(1)).toEqual([
+      { atMsFromStart: 1_000, kind: "finish" },
+    ])
+  })
+
+  it("returns an empty schedule for non-positive targets", () => {
+    expect(buildBeepSchedule(0)).toEqual([])
+    expect(buildBeepSchedule(-5)).toEqual([])
+  })
+})

--- a/src/lib/buildBeepSchedule.ts
+++ b/src/lib/buildBeepSchedule.ts
@@ -1,0 +1,18 @@
+export type BeepFireSpec = {
+  atMsFromStart: number
+  kind: "warning" | "finish"
+}
+
+const WARNING_OFFSETS_SECONDS = [3, 2, 1] as const
+
+export function buildBeepSchedule(targetSeconds: number): BeepFireSpec[] {
+  const candidates: BeepFireSpec[] = [
+    ...WARNING_OFFSETS_SECONDS.map((secondsBeforeEnd) => ({
+      atMsFromStart: (targetSeconds - secondsBeforeEnd) * 1000,
+      kind: "warning" as const,
+    })),
+    { atMsFromStart: targetSeconds * 1000, kind: "finish" as const },
+  ]
+
+  return candidates.filter((spec) => spec.atMsFromStart > 0)
+}

--- a/src/locales/en/workout.json
+++ b/src/locales/en/workout.json
@@ -55,6 +55,8 @@
   "pausedWorkoutDescription": "Resume the workout to log sets, switch exercises, add exercises, or finish.",
   "restOverNotif": "Rest over!",
   "restOverBody": "Time for your next set",
+  "holdOverNotif": "Hold complete!",
+  "holdOverBody": "Time to log your set",
   "finishEarly": "Finish workout early",
   "weightPerArm": "{{unit}}/arm",
   "addedWeight": "+{{unit}}",

--- a/src/locales/fr/workout.json
+++ b/src/locales/fr/workout.json
@@ -55,6 +55,8 @@
   "pausedWorkoutDescription": "Reprenez la séance pour enregistrer les séries, changer d'exercice, en ajouter ou terminer.",
   "restOverNotif": "Repos terminé !",
   "restOverBody": "C'est parti pour la prochaine série",
+  "holdOverNotif": "Hold terminé !",
+  "holdOverBody": "Log ta série",
   "finishEarly": "Terminer la séance",
   "weightPerArm": "{{unit}}/bras",
   "addedWeight": "+{{unit}}",


### PR DESCRIPTION
## What

- **Audio cues**: T-3 / T-2 / T-1 warning beeps (660 Hz) + T-0 finish chime (880 → 1100 Hz) on every duration set.
- **Screen wake lock**: kept while the hold timer runs and isn't paused; auto-released on stop, unmount, or pause; re-acquired on `visibilitychange` if revoked.
- **Background notification**: service-worker `holdOverNotif` ("Hold complete!") at T-0 for the pocketed-phone case.
- **Shared utilities**: new `src/lib/audio.ts` (singleton `AudioContext` + `primeAudio` gesture-unlock), new `useKeepScreenAwake` hook, new pure `buildBeepSchedule` for cue timing.
- **`useRestTimer` refactor**: consumes the new audio helpers — same behavior, all 18 regression tests still green.

## Why

The Duration Set Timer is the only timer where the user is **deliberately not looking at the screen** — they're holding a plank, hollow body, or dead hang and need to know when to stop without breaking form. Today the screen sleeps, no audio fires, nothing happens at T-0 — so users either over-hold, under-hold, or stop the set early "just in case". This delivers the eyes-off promise via three layers of reliability (visual ▸ audio ▸ notification), each independent so degraded environments still get *something*.

## How

- **Architecture (see [ADR 0006](./docs/adr/0006-shared-timer-utilities.md))**: rather than copy/paste from `useRestTimer`, extracted shared modules. Centralizing the `AudioContext` is the only correct move — iOS allows one per page and won't `resume()` outside a gesture, so `primeAudio()` is called from the Play/Confirm-RIR taps (`DurationSetTimer`, `SetsTable`) to unlock the context for the entire set's audio.
- **Schedule** is built once per set via `buildBeepSchedule(targetSeconds)` — pure function, fully unit-tested incl. clamp matrix for 3s / 2s / 1s holds where some warnings collapse onto T-0.
- **Wake lock** is hook-encapsulated with a sentinel ref, mounted via `useKeepScreenAwake(isRunning && !isWorkoutPaused)` so all release/re-acquire concerns stay out of the component.
- **Stale-fire window (1500 ms)**: defensive mitigation for the pre-existing pause-unaware `elapsedSec` bug (documented in `CONTEXT.md` "Duration Set Timer", tracked separately). Without it, resuming after a long pause would fire a salvo of warnings; with it, only warnings still within their fresh window can fire.
- **Notification** mirrors `useRestTimer`'s pattern (`navigator.serviceWorker.ready` → `registration.showNotification`), gated on permission.
- **Tech Plan**: [docs/Tech_Plan_—_Eyes-off_Hold_Timer_Feedback.md](./docs/Tech_Plan_—_Eyes-off_Hold_Timer_Feedback.md) for the full design rationale.
- **Test coverage**: 21 new tests across `buildBeepSchedule`, `audio.ts`, `useKeepScreenAwake`, and a new `DurationSetTimer.test.tsx` covering primeAudio-on-tap, schedule firing, vibration, onLog, notification, stop-early, and stale-fire window. Total suite: 1577 passing.

**Manual QA needed** (the one thing the test suite can't cover): real-device smoke test on iOS Safari + Android Chrome — does the screen actually stay awake, do the beeps fire at the right times, does the T-0 notification land when backgrounded.

Closes #374

Made with [Cursor](https://cursor.com)