### PR TITLE
fix(#379): raise duration progression ceiling so iso holds climb instead of plateauing

### DIFF
--- a/src/hooks/useBuilderMutations.ts
+++ b/src/hooks/useBuilderMutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
 import { supabase } from "@/lib/supabase"
+import { deriveDurationRangeMax } from "@/lib/progression"
 import { authAtom } from "@/store/atoms"
 import type {
   Exercise,
@@ -122,7 +123,7 @@ export function useAddExerciseToDay() {
         set_range_max: 5,
         max_weight_reached: isBodyweight ? true : false,
         duration_range_min_seconds: isDuration ? Math.max(5, defaultSec - 10) : null,
-        duration_range_max_seconds: isDuration ? defaultSec + 15 : null,
+        duration_range_max_seconds: isDuration ? deriveDurationRangeMax(defaultSec + 15) : null,
         duration_increment_seconds: isDuration ? 5 : null,
       })
       if (error) throw error
@@ -172,7 +173,7 @@ export function useAddExercisesToDay() {
           set_range_max: 5,
           max_weight_reached: isBodyweight ? true : false,
           duration_range_min_seconds: isDuration ? Math.max(5, defaultSec - 10) : null,
-          duration_range_max_seconds: isDuration ? defaultSec + 15 : null,
+          duration_range_max_seconds: isDuration ? deriveDurationRangeMax(defaultSec + 15) : null,
           duration_increment_seconds: isDuration ? 5 : null,
         }
       })

--- a/src/hooks/useGenerateProgram.ts
+++ b/src/hooks/useGenerateProgram.ts
@@ -3,6 +3,7 @@ import { useAtomValue } from "jotai"
 import { getDefaultStore } from "jotai"
 import { supabase } from "@/lib/supabase"
 import { adaptForExperience, resolveEquipmentSwap } from "@/lib/generateProgram"
+import { deriveDurationRangeMax } from "@/lib/progression"
 import { fetchExercisesByIds } from "@/lib/fetchExercisesByIds"
 import { authAtom, hasProgramAtom, activeProgramIdAtom } from "@/store/atoms"
 import type { UserProfile, ExerciseAlternative, ProgramTemplate } from "@/types/onboarding"
@@ -143,7 +144,7 @@ export function useGenerateProgram() {
               set_range_max: Math.min(6, adapted.sets + 2),
               max_weight_reached: isBodyweight ? true : false,
               duration_range_min_seconds: isDuration ? Math.max(5, defaultSec - 10) : null,
-              duration_range_max_seconds: isDuration ? defaultSec + 15 : null,
+              duration_range_max_seconds: isDuration ? deriveDurationRangeMax(defaultSec + 15) : null,
               duration_increment_seconds: isDuration ? 5 : null,
             }
           })

--- a/src/lib/programPersistence.ts
+++ b/src/lib/programPersistence.ts
@@ -1,3 +1,4 @@
+import { deriveDurationRangeMax } from "@/lib/progression"
 import type { GeneratedExercise } from "@/types/generator"
 
 /** Emojis assigned to each program day index when persisting AI-generated programs (matches UI preview). */
@@ -120,9 +121,7 @@ function buildWorkoutExerciseInsertRow(
         : Math.max(5, defaultSec - 10),
     duration_range_max_seconds: !isDuration
       ? null
-      : useExplicitDuration
-        ? effectiveDurationSec
-        : defaultSec + 15,
+      : deriveDurationRangeMax(useExplicitDuration ? effectiveDurationSec : defaultSec + 15),
     duration_increment_seconds: isDuration ? 5 : null,
   }
 }

--- a/src/lib/progression.test.ts
+++ b/src/lib/progression.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest"
 import {
   buildPrescription,
   computeNextSessionTarget,
+  deriveDurationRangeMax,
   resolveWeightIncrement,
+  DURATION_TARGET_CEILING_SECONDS,
   type ProgressionPrescription,
   type SetPerformance,
   type VolumePrescription,
@@ -320,6 +322,44 @@ describe("computeNextSessionTarget — duration exercises", () => {
     expect(result.rule).toBe("PLATEAU")
     expect(result.duration).toBe(45)
     expect(result.sets).toBe(5)
+  })
+
+  // Regression for #379: an iso bodyweight hold (hollow hold / planche) sitting at
+  // its STARTING target must keep climbing the time axis, not plateau. The bug was a
+  // persistence freeze that set volume.max === volume.current; with the 90s ceiling
+  // the engine correctly suggests DURATION_UP.
+  it("DURATION_UP — iso hold at 5×35s with 90s ceiling keeps climbing (#379)", () => {
+    const rx = makePrescription({
+      volume: durationVolume({ current: 35, min: 35, max: 90 }),
+      currentWeight: 0,
+      currentSets: 5,
+      maxWeightReached: true,
+      setRangeMax: 5,
+    })
+    const perf = makeDurationSets(5, 35)
+    const result = computeNextSessionTarget(rx, perf)!
+
+    expect(result.rule).toBe("DURATION_UP")
+    expect(result.duration).toBe(40)
+    expect(result.delta).toBe("+5s")
+    expect(result.sets).toBe(5)
+  })
+
+  // The flip side: once the hold reaches the 90s ceiling and every other axis is
+  // maxed, a real PLATEAU is the correct verdict (time to vary the stimulus).
+  it("PLATEAU — iso hold only once it reaches the 90s ceiling (#379)", () => {
+    const rx = makePrescription({
+      volume: durationVolume({ current: 90, min: 35, max: 90 }),
+      currentWeight: 0,
+      currentSets: 5,
+      maxWeightReached: true,
+      setRangeMax: 5,
+    })
+    const perf = makeDurationSets(5, 90)
+    const result = computeNextSessionTarget(rx, perf)!
+
+    expect(result.rule).toBe("PLATEAU")
+    expect(result.duration).toBe(90)
   })
 
   it("first session for duration — returns null", () => {
@@ -786,5 +826,18 @@ describe("buildPrescription", () => {
     const result = computeNextSessionTarget(prescription, lastPerformance)!
     expect(result.rule).toBe("REPS_UP")
     expect(result.reps).toBe(11)
+  })
+})
+
+describe("deriveDurationRangeMax (#379)", () => {
+  it("raises a low ceiling up to the 90s progression ceiling", () => {
+    expect(deriveDurationRangeMax(35)).toBe(90) // explicit freeze case
+    expect(deriveDurationRangeMax(45)).toBe(90) // default 30 + band
+    expect(DURATION_TARGET_CEILING_SECONDS).toBe(90)
+  })
+
+  it("preserves a deliberately higher explicit ceiling", () => {
+    expect(deriveDurationRangeMax(120)).toBe(120)
+    expect(deriveDurationRangeMax(90)).toBe(90)
   })
 })

--- a/src/lib/progression.ts
+++ b/src/lib/progression.ts
@@ -70,6 +70,26 @@ const DURATION_BAND_LOW = 10
 const DURATION_BAND_HIGH = 15
 const DEFAULT_DURATION_INCREMENT = 5
 
+/**
+ * Progression ceiling for isometric/duration exercises (planks, hollow holds, hangs).
+ * Unlike weighted lifts — which progress on load — bodyweight holds have only one
+ * meaningful lever: time. Freezing `duration_range_max_seconds` to the starting
+ * target (T75 behavior) made the engine declare PLATEAU on the very first successful
+ * session. We instead keep climbing the hold in `DEFAULT_DURATION_INCREMENT` steps up
+ * to this ceiling before a real plateau — past which a new stimulus beats raw seconds.
+ * See issue #379.
+ */
+export const DURATION_TARGET_CEILING_SECONDS = 90
+
+/**
+ * Resolve the persisted `duration_range_max_seconds` so the progression engine always
+ * has headroom: never cap below {@link DURATION_TARGET_CEILING_SECONDS}, but preserve a
+ * higher explicit ceiling if a caller deliberately prescribed one (e.g. a 120s plank).
+ */
+export function deriveDurationRangeMax(baseMax: number): number {
+  return Math.max(baseMax, DURATION_TARGET_CEILING_SECONDS)
+}
+
 export function resolveWeightIncrement(
   userIncrement: number | null | undefined,
   equipment?: string,

--- a/supabase/functions/mcp/lib/programPersistence.ts
+++ b/supabase/functions/mcp/lib/programPersistence.ts
@@ -11,6 +11,18 @@
 
 export const AI_PROGRAM_DAY_EMOJIS = ["💪", "🔥", "⚡", "🏋️", "🎯", "🚀"] as const
 
+/**
+ * Web-parity copy of `DURATION_TARGET_CEILING_SECONDS` / `deriveDurationRangeMax`
+ * from `file:src/lib/progression.ts` — Deno can't import the web module. Keep in sync.
+ * Isometric holds progress on time, not load: never freeze the ceiling below this so
+ * the engine keeps suggesting DURATION_UP up to it before a real plateau. See #379.
+ */
+export const DURATION_TARGET_CEILING_SECONDS = 90
+
+export function deriveDurationRangeMax(baseMax: number): number {
+  return Math.max(baseMax, DURATION_TARGET_CEILING_SECONDS)
+}
+
 export function dayEmojiForProgramDayIndex(dayIndex: number): string {
   return AI_PROGRAM_DAY_EMOJIS[dayIndex % AI_PROGRAM_DAY_EMOJIS.length]
 }
@@ -170,9 +182,7 @@ function buildWorkoutExerciseInsertRow(
         : Math.max(5, defaultSec - 10),
     duration_range_max_seconds: !isDuration
       ? null
-      : useExplicitDuration
-        ? effectiveDurationSec
-        : defaultSec + 15,
+      : deriveDurationRangeMax(useExplicitDuration ? effectiveDurationSec : defaultSec + 15),
     duration_increment_seconds: isDuration ? 5 : null,
   }
 }

--- a/supabase/functions/mcp/lib/programPersistence_fixtures.json
+++ b/supabase/functions/mcp/lib/programPersistence_fixtures.json
@@ -106,7 +106,7 @@
       "set_range_max": 5,
       "max_weight_reached": true,
       "duration_range_min_seconds": 20,
-      "duration_range_max_seconds": 45,
+      "duration_range_max_seconds": 90,
       "duration_increment_seconds": 5
     }
   },
@@ -143,7 +143,7 @@
       "set_range_max": 4,
       "max_weight_reached": true,
       "duration_range_min_seconds": 35,
-      "duration_range_max_seconds": 60,
+      "duration_range_max_seconds": 90,
       "duration_increment_seconds": 5
     }
   },
@@ -395,7 +395,7 @@
     }
   },
   {
-    "name": "T75 DURATION-FREEZE — plank 4×30s with targetDurationSeconds=30 freezes duration_range_min/max_seconds to 30 (no spread)",
+    "name": "#379 DURATION-HEADROOM — plank 4×30s with targetDurationSeconds=30 freezes min to 30 but opens max to the 90s progression ceiling",
     "exercise": {
       "id": "ex-plank",
       "name": "Plank",
@@ -429,12 +429,12 @@
       "set_range_max": 6,
       "max_weight_reached": true,
       "duration_range_min_seconds": 30,
-      "duration_range_max_seconds": 30,
+      "duration_range_max_seconds": 90,
       "duration_increment_seconds": 5
     }
   },
   {
-    "name": "T75 DURATION-OVERRIDES-CATALOG — hang 3×60s with targetDurationSeconds=60 overrides catalog default 45",
+    "name": "#379 DURATION-OVERRIDES-CATALOG — hang 3×60s with targetDurationSeconds=60 overrides catalog default 45, max opens to 90s ceiling",
     "exercise": {
       "id": "ex-hang",
       "name": "Hang",
@@ -468,7 +468,7 @@
       "set_range_max": 5,
       "max_weight_reached": true,
       "duration_range_min_seconds": 60,
-      "duration_range_max_seconds": 60,
+      "duration_range_max_seconds": 90,
       "duration_increment_seconds": 5
     }
   }

--- a/supabase/migrations/20260529100000_raise_duration_range_max_ceiling.sql
+++ b/supabase/migrations/20260529100000_raise_duration_range_max_ceiling.sql
@@ -1,0 +1,15 @@
+-- #379 — Isometric/duration exercises plateau prematurely.
+-- T75 froze `duration_range_max_seconds` to the starting target, so the progression
+-- engine declared PLATEAU on the first successful session (planks, hollow holds, hangs
+-- stuck at e.g. 5×35s). Bodyweight holds progress on TIME, not load — raise the ceiling
+-- to 90s so the engine keeps suggesting DURATION_UP before a real plateau.
+--
+-- `GREATEST` preserves any deliberately higher ceiling (e.g. a 120s plank stays 120),
+-- and since we only raise the max, the `we_duration_range_order_chk` (min <= max)
+-- invariant always holds. Mirrors the new web/Edge persistence default
+-- (`deriveDurationRangeMax` in src/lib/progression.ts).
+
+UPDATE workout_exercises
+SET duration_range_max_seconds = GREATEST(duration_range_max_seconds, 90)
+WHERE duration_range_max_seconds IS NOT NULL
+  AND duration_range_max_seconds < 90;


### PR DESCRIPTION
## What

- Isometric/duration exercises (planks, hollow holds, hangs) no longer hit a premature **PLATEAU** at their starting target. The progression engine now keeps suggesting **DURATION_UP** (+5s) up to a shared **90s ceiling** before declaring a real plateau.
- Introduces `DURATION_TARGET_CEILING_SECONDS = 90` + `deriveDurationRangeMax()` in `src/lib/progression.ts`, mirrored in the Edge module (`supabase/functions/mcp/lib/programPersistence.ts`).
- Applies it across **all five** persistence write paths: web + Edge `programPersistence`, `useBuilderMutations` (×2), `useGenerateProgram`.
- Adds a backfill migration (`20260529100000_raise_duration_range_max_ceiling.sql`) so existing rows get the new ceiling.

## Why

Bodyweight holds progress on **time**, not load. T75 froze `duration_range_max_seconds` to the prescribed target, so `volume.max === volume.current` from day one — the engine maxed the duration axis, found weight locked (`max_weight_reached`) and sets at their cap, and fell straight to PLATEAU. Concretely, `Gainage planche` and `Hollow hold` showed *"Plateau atteint"* at 5×35s, which is a starting point, not a ceiling.

## How

- `deriveDurationRangeMax(baseMax)` returns `Math.max(baseMax, 90)`: it raises low ceilings but **preserves a deliberately higher explicit one** (a prescribed 120s plank stays 120). The `min` stays frozen to the target — no regression downward.
- The migration uses `GREATEST(duration_range_max_seconds, 90)`, which keeps the `min <= max` invariant intact (only the max moves up).
- Shared web/Deno fixtures updated (4 expected maxes → 90; 2 case names corrected since they no longer "freeze" the max).
- Tests: 2 regression cases in `progression.test.ts` (DURATION_UP at 5×35s with a 90s ceiling, PLATEAU only once it reaches 90s) + a unit block for `deriveDurationRangeMax`.

Checks: `vitest` 1589 passed · `tsc --noEmit` clean · `deno check` + `deno test` (23) green · `npm run lint` 0 errors · `npm run build` OK.

Closes #379

Made with [Cursor](https://cursor.com)