### PR TITLE
fix(#389): key prescription lock per exercise, not per session

### DIFF
--- a/src/components/workout/SetsTable.test.tsx
+++ b/src/components/workout/SetsTable.test.tsx
@@ -282,6 +282,92 @@ describe("SetsTable", () => {
     )
   })
 
+  // Regression: the single SetsTable instance is reused as the user navigates
+  // between exercises (WorkoutPage swaps the `exercise` prop on one un-keyed
+  // <ExerciseDetail>). The prescription lock used to key on sessionId alone, so
+  // the FIRST logged exercise's prescription leaked onto every subsequent
+  // exercise's set_logs (a calf raise inheriting a leg-press's 158.2 kg / 4
+  // reps / 3 sets), poisoning the engine's snapshot. The lock must be
+  // per-exercise.
+  it("does not leak the first exercise's prescription onto the next exercise", async () => {
+    const user = userEvent.setup()
+    const exerciseA = EXERCISE
+    const exerciseB: WorkoutExercise = {
+      ...EXERCISE,
+      id: "workout-ex-2",
+      exercise_id: "library-ex-2",
+      name_snapshot: "Standing Calf Raise",
+      reps: "8",
+      weight: "20",
+      sets: 4,
+    }
+    const suggestionA: ProgressionSuggestion = {
+      rule: "REPS_UP",
+      reps: 4,
+      weight: 158.2,
+      sets: 3,
+      reasonKey: "progression.repsUp",
+      delta: "+1 rep",
+      volumeType: "reps",
+    }
+    const sessionWithBothExercises: SessionState = {
+      ...BASE_SESSION,
+      setsData: {
+        "workout-ex-1": [{ kind: "reps", reps: "4", weight: "158.2", done: false }],
+        "workout-ex-2": [{ kind: "reps", reps: "10", weight: "10", done: false }],
+      },
+    }
+    const { store, rerender } = renderWithProviders(
+      <SetsTable
+        exercise={exerciseA}
+        sessionId="session-1"
+        isReadOnly={false}
+        suggestion={suggestionA}
+      />,
+    )
+    act(() => {
+      store.set(sessionAtom, sessionWithBothExercises)
+    })
+
+    // Log exercise A → captures A's prescription under A's id.
+    const checkboxesA = screen.getAllByRole("checkbox")
+    await user.click(checkboxesA[0])
+    await user.click(screen.getByTestId("rir-confirm"))
+
+    expect(enqueueSetLogMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        exerciseId: "library-ex-1",
+        prescribedReps: 4,
+        prescribedWeight: 158.2,
+        prescribedSets: 3,
+      }),
+    )
+
+    // Same instance, navigate to exercise B (no suggestion → B's template).
+    rerender(
+      <SetsTable
+        exercise={exerciseB}
+        sessionId="session-1"
+        isReadOnly={false}
+        suggestion={null}
+      />,
+    )
+
+    const checkboxesB = screen.getAllByRole("checkbox")
+    await user.click(checkboxesB[0])
+    await user.click(screen.getByTestId("rir-confirm"))
+
+    // B must carry ITS OWN prescription, not A's leaked 4 / 158.2 / 3.
+    expect(enqueueSetLogMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        exerciseId: "library-ex-2",
+        prescribedReps: 8,
+        prescribedWeight: 20,
+        prescribedSets: 4,
+      }),
+    )
+  })
+
   it("falls back to template values for sessionPrescription when no suggestion (bootstrap)", async () => {
     const user = userEvent.setup()
     const { store } = renderWithProviders(

--- a/src/components/workout/SetsTable.tsx
+++ b/src/components/workout/SetsTable.tsx
@@ -125,7 +125,7 @@ export function SetsTable({
   // values — violating the "stable across the session" invariant the engine
   // relies on.
   //
-  // #N: keyed by exercise, not just session. A single SetsTable instance is
+  // #389: keyed by exercise, not just session. A single SetsTable instance is
   // reused as the user navigates between exercises (WorkoutPage renders one
   // un-keyed <ExerciseDetail>, swapping the `exercise` prop), so this ref
   // survives exercise changes. Keying the lock by sessionId alone froze the

--- a/src/components/workout/SetsTable.tsx
+++ b/src/components/workout/SetsTable.tsx
@@ -123,15 +123,33 @@ export function SetsTable({
   // Without this, if the user logs set 1 before useProgressionSuggestion
   // resolves and set 2 after, the two rows carry different prescribed_*
   // values — violating the "stable across the session" invariant the engine
-  // relies on. Re-keyed by sessionId so a new session captures fresh.
+  // relies on.
+  //
+  // #N: keyed by exercise, not just session. A single SetsTable instance is
+  // reused as the user navigates between exercises (WorkoutPage renders one
+  // un-keyed <ExerciseDetail>, swapping the `exercise` prop), so this ref
+  // survives exercise changes. Keying the lock by sessionId alone froze the
+  // FIRST logged exercise's prescription and stamped it onto every other
+  // exercise's set_logs — corrupting the engine's snapshot (e.g. a calf raise
+  // inheriting a leg-press's 4 reps / 158.2 kg / 3 sets). The per-exercise Map
+  // keeps each exercise's snapshot frozen for the whole session, even when the
+  // user navigates away and back, while a new session resets the lot.
   const lockedPrescriptionRef = useRef<{
     sessionId: string
-    value: typeof sessionPrescription
+    byExercise: Map<string, typeof sessionPrescription>
   } | null>(null)
   const readLockedPrescription = (): typeof sessionPrescription => {
     const locked = lockedPrescriptionRef.current
-    if (locked && locked.sessionId === sessionId) return locked.value
-    lockedPrescriptionRef.current = { sessionId, value: sessionPrescription }
+    if (!locked || locked.sessionId !== sessionId) {
+      lockedPrescriptionRef.current = {
+        sessionId,
+        byExercise: new Map([[exercise.id, sessionPrescription]]),
+      }
+      return sessionPrescription
+    }
+    const existing = locked.byExercise.get(exercise.id)
+    if (existing) return existing
+    locked.byExercise.set(exercise.id, sessionPrescription)
     return sessionPrescription
   }
 


### PR DESCRIPTION
## What

- Key the in-session prescription lock in `SetsTable` by **exercise** (`Map<exercise.id, prescription>`) instead of by `sessionId` alone.
- Add a regression test reproducing the carousel instance-reuse (log exercise A, swap the `exercise` prop on the same instance, assert B keeps its own prescription).

## Why

`WorkoutPage` renders a single, **un-keyed** `<ExerciseDetail>` / `<SetsTable>`; navigating between exercises only swaps the `exercise` prop, so the component instance and its refs are reused. The lock keyed only by `sessionId` froze the **first logged exercise's** prescription and stamped it onto **every other exercise's** `set_logs.prescribed_*` — corrupting the progression engine's snapshot on the next session.

Real symptom: an exercise logged at 4×10 @ 10 kg got a "Reps en hausse → 3×5 @ 10 kg" suggestion, because the engine read a 4 reps / 3 sets target inherited from a leg press logged earlier the same day.

Blast radius in production: 11 corrupted sessions across 3 users (2026-06-01 → 2026-06-08). The corrupted `prescribed_*` data has already been repaired (reconstructed from logged values); this PR stops recurrence.

## How

The lock now stores `{ sessionId, byExercise: Map<exerciseId, prescription> }`. A new session resets the map; within a session each exercise freezes its own snapshot on its first set log and keeps it stable for the rest of the session, even when the user navigates away and back.

Closes #389

Made with [Cursor](https://cursor.com)