### PR TITLE
fix(builder): keep circuit CTA visible when filtering exercises

### DIFF
--- a/src/components/builder/ExerciseLibraryPicker.test.tsx
+++ b/src/components/builder/ExerciseLibraryPicker.test.tsx
@@ -397,4 +397,26 @@ describe("ExerciseLibraryPicker", () => {
     await user.click(screen.getByRole("button", { name: "Apply changes" }))
     expect(mockDeleteExerciseMutateAsync).toHaveBeenCalledWith({ id: "we-1", dayId: "day-1" })
   })
+
+  it("keeps create circuit CTA visible after filtering in block mode", async () => {
+    const onCreateBlock = vi.fn().mockResolvedValue(undefined)
+    renderPicker({ onCreateBlock })
+    const user = userEvent.setup()
+
+    const checkboxes = screen.getAllByRole("checkbox", { name: "Add" })
+    await user.click(checkboxes[0])
+    await user.click(checkboxes[1])
+
+    expect(
+      screen.getByRole("button", { name: /create circuit \(2 exercises\)/i }),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText("Filters"))
+    await user.click(screen.getByRole("button", { name: "Pectoraux" }))
+
+    expect(screen.queryByText("Élévations latérales")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /create circuit \(2 exercises\)/i }),
+    ).toBeInTheDocument()
+  })
 })

--- a/src/components/builder/ExerciseLibraryPicker.tsx
+++ b/src/components/builder/ExerciseLibraryPicker.tsx
@@ -10,7 +10,11 @@ import {
 import { useMediaQuery } from "@/hooks/useMediaQuery"
 import type { Exercise } from "@/types/database"
 import { ExerciseFilterPanel } from "@/components/builder/ExerciseFilterPanel"
-import { ExerciseSelectionContent } from "@/components/builder/ExerciseSelectionContent"
+import {
+  ExerciseSelectionList,
+  ExerciseSelectionActions,
+  useExerciseSelection,
+} from "@/components/builder/ExerciseSelectionContent"
 import type { ExistingDayExercise } from "@/components/builder/ExerciseSelectionContent"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -30,6 +34,63 @@ import { Command, CommandList } from "@/components/ui/command"
 import { Input } from "@/components/ui/input"
 
 const SEARCH_DEBOUNCE_MS = 300
+
+interface PickerSelectionPanelProps {
+  selectionKey: string
+  initialSelectedIds: string[]
+  existingExercises: ExistingDayExercise[]
+  existingSet: Set<string>
+  filtered: Exercise[] | undefined
+  grouped: Record<string, Exercise[]>
+  dayId: string
+  existingExerciseCount: number
+  onMutationStateChange: (state: "saving" | "saved" | "error") => void
+  onClose: () => void
+  addExercises: ReturnType<typeof useAddExercisesToDay>
+  deleteExercise: ReturnType<typeof useDeleteExercise>
+  onCreateBlock?: (selected: Exercise[]) => Promise<void> | void
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  onLoadMore: () => void
+}
+
+function PickerSelectionPanel({
+  selectionKey: _selectionKey,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+  ...selectionProps
+}: PickerSelectionPanelProps) {
+  const { t } = useTranslation("builder")
+  const selection = useExerciseSelection(selectionProps)
+
+  return (
+    <>
+      <CommandList className="min-h-0 flex-1 max-h-none overflow-x-hidden overflow-y-auto">
+        <ExerciseSelectionList state={selection} />
+        {hasNextPage && (
+          <div className="flex justify-center border-t py-3">
+            <Button
+              variant="link"
+              size="sm"
+              className="text-muted-foreground hover:text-foreground"
+              onClick={onLoadMore}
+              disabled={isFetchingNextPage}
+            >
+              {isFetchingNextPage ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
+              {t("loadMore")}
+            </Button>
+          </div>
+        )}
+      </CommandList>
+      <ExerciseSelectionActions state={selection} />
+    </>
+  )
+}
 
 export type { ExistingDayExercise }
 
@@ -198,49 +259,33 @@ export function ExerciseLibraryPicker({
         </div>
       </div>
 
-      <CommandList className="min-h-0 flex-1 max-h-none overflow-x-hidden overflow-y-auto">
-        {isLoading ? (
+      {isLoading ? (
+        <CommandList className="min-h-0 flex-1 max-h-none overflow-x-hidden overflow-y-auto">
           <div className="flex items-center justify-center py-8">
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           </div>
-        ) : (
-          <>
-            <ExerciseSelectionContent
-              key={selectionKey}
-              initialSelectedIds={existingExercises.map((e) => e.exercise_id)}
-              existingExercises={existingExercises}
-              existingSet={existingSet}
-              filtered={paginatedData}
-              grouped={grouped}
-              dayId={dayId}
-              existingExerciseCount={existingExerciseCount}
-              onMutationStateChange={onMutationStateChange}
-              onClose={() => handleOpenChange(false)}
-              addExercises={addExercises}
-              deleteExercise={deleteExercise}
-              onCreateBlock={onCreateBlock}
-            />
-            {hasNextPage && (
-              <div className="flex justify-center border-t py-3">
-                <Button
-                  variant="link"
-                  size="sm"
-                  className="text-muted-foreground hover:text-foreground"
-                  onClick={() => fetchNextPage()}
-                  disabled={isFetchingNextPage}
-                >
-                  {isFetchingNextPage ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <RefreshCw className="h-4 w-4" />
-                  )}
-                  {t("loadMore")}
-                </Button>
-              </div>
-            )}
-          </>
-        )}
-      </CommandList>
+        </CommandList>
+      ) : (
+        <PickerSelectionPanel
+          key={selectionKey}
+          selectionKey={selectionKey}
+          initialSelectedIds={existingExercises.map((e) => e.exercise_id)}
+          existingExercises={existingExercises}
+          existingSet={existingSet}
+          filtered={paginatedData}
+          grouped={grouped}
+          dayId={dayId}
+          existingExerciseCount={existingExerciseCount}
+          onMutationStateChange={onMutationStateChange}
+          onClose={() => handleOpenChange(false)}
+          addExercises={addExercises}
+          deleteExercise={deleteExercise}
+          onCreateBlock={onCreateBlock}
+          hasNextPage={!!hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          onLoadMore={() => fetchNextPage()}
+        />
+      )}
     </Command>
   )
 

--- a/src/components/builder/ExerciseSelectionContent.tsx
+++ b/src/components/builder/ExerciseSelectionContent.tsx
@@ -42,8 +42,7 @@ export interface ExerciseSelectionContentProps {
   onCreateBlock?: (selected: Exercise[]) => Promise<void> | void
 }
 
-/** Selection state + list + apply. Keyed by parent so it remounts with fresh initial selection (no setState-in-effect). */
-export function ExerciseSelectionContent({
+export function useExerciseSelection({
   initialSelectedIds,
   existingExercises,
   existingSet,
@@ -63,16 +62,31 @@ export function ExerciseSelectionContent({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(
     () => new Set(isBlockMode ? [] : initialSelectedIds),
   )
+  /** Block mode keeps full Exercise rows so filters/search cannot drop selections. */
+  const [selectedById, setSelectedById] = useState<Map<string, Exercise>>(
+    () => new Map(),
+  )
   const [isCreatingBlock, setIsCreatingBlock] = useState(false)
 
-  const toggleSelected = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }, [])
+  const toggleSelected = useCallback(
+    (ex: Exercise) => {
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        if (next.has(ex.id)) next.delete(ex.id)
+        else next.add(ex.id)
+        return next
+      })
+      if (isBlockMode) {
+        setSelectedById((prev) => {
+          const next = new Map(prev)
+          if (next.has(ex.id)) next.delete(ex.id)
+          else next.set(ex.id, ex)
+          return next
+        })
+      }
+    },
+    [isBlockMode],
+  )
 
   const toAdd = useMemo(() => {
     if (!filtered) return []
@@ -88,8 +102,11 @@ export function ExerciseSelectionContent({
   )
 
   const selectedExercises = useMemo(
-    () => (filtered ?? []).filter((ex) => selectedIds.has(ex.id)),
-    [filtered, selectedIds],
+    () =>
+      isBlockMode
+        ? [...selectedById.values()]
+        : (filtered ?? []).filter((ex) => selectedIds.has(ex.id)),
+    [isBlockMode, selectedById, filtered, selectedIds],
   )
 
   const hasChanges = toAdd.length > 0 || toRemove.length > 0
@@ -136,6 +153,31 @@ export function ExerciseSelectionContent({
   const isApplying =
     addExercises.isPending || deleteExercise.isPending
 
+  return {
+    t,
+    isBlockMode,
+    selectedIds,
+    toggleSelected,
+    grouped,
+    canCreateBlock,
+    hasChanges,
+    isCreatingBlock,
+    isApplying,
+    selectedExercises,
+    handleCreateBlock,
+    handleApply,
+  }
+}
+
+export type ExerciseSelectionState = ReturnType<typeof useExerciseSelection>
+
+export function ExerciseSelectionList({
+  state,
+}: {
+  state: ExerciseSelectionState
+}) {
+  const { t, selectedIds, toggleSelected, grouped } = state
+
   return (
     <>
       <CommandEmpty>{t("noExercisesFound")}</CommandEmpty>
@@ -152,7 +194,7 @@ export function ExerciseSelectionContent({
                 <span className="flex min-w-0 flex-1 items-center gap-2.5">
                   <Checkbox
                     checked={selectedIds.has(ex.id)}
-                    onCheckedChange={() => toggleSelected(ex.id)}
+                    onCheckedChange={() => toggleSelected(ex)}
                     onClick={(e) => e.stopPropagation()}
                     onPointerDown={(e) => e.stopPropagation()}
                     aria-label={t("add")}
@@ -190,35 +232,70 @@ export function ExerciseSelectionContent({
             ))}
           </CommandGroup>
         ))}
-      {isBlockMode
-        ? canCreateBlock && (
-            <div className="shrink-0 border-t p-3">
-              <Button
-                className="w-full"
-                onClick={handleCreateBlock}
-                disabled={isCreatingBlock}
-              >
-                {isCreatingBlock ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : null}
-                {t("createBlockCta", { count: selectedExercises.length })}
-              </Button>
-            </div>
-          )
-        : hasChanges && (
-            <div className="shrink-0 border-t p-3">
-              <Button
-                className="w-full"
-                onClick={handleApply}
-                disabled={isApplying}
-              >
-                {isApplying ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : null}
-                {t("applyChanges")}
-              </Button>
-            </div>
-          )}
+    </>
+  )
+}
+
+/** Pinned below the scrollable list — always visible even when filters shrink the viewport. */
+export function ExerciseSelectionActions({
+  state,
+}: {
+  state: ExerciseSelectionState
+}) {
+  const {
+    t,
+    isBlockMode,
+    canCreateBlock,
+    hasChanges,
+    isCreatingBlock,
+    isApplying,
+    selectedExercises,
+    handleCreateBlock,
+    handleApply,
+  } = state
+
+  if (isBlockMode) {
+    if (!canCreateBlock) return null
+    return (
+      <div className="shrink-0 border-t bg-popover p-3">
+        <Button
+          className="w-full"
+          onClick={handleCreateBlock}
+          disabled={isCreatingBlock}
+        >
+          {isCreatingBlock ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : null}
+          {t("createBlockCta", { count: selectedExercises.length })}
+        </Button>
+      </div>
+    )
+  }
+
+  if (!hasChanges) return null
+  return (
+    <div className="shrink-0 border-t bg-popover p-3">
+      <Button
+        className="w-full"
+        onClick={handleApply}
+        disabled={isApplying}
+      >
+        {isApplying ? (
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        ) : null}
+        {t("applyChanges")}
+      </Button>
+    </div>
+  )
+}
+
+/** Selection state + list + apply. Keyed by parent so it remounts with fresh initial selection (no setState-in-effect). */
+export function ExerciseSelectionContent(props: ExerciseSelectionContentProps) {
+  const state = useExerciseSelection(props)
+  return (
+    <>
+      <ExerciseSelectionList state={state} />
+      <ExerciseSelectionActions state={state} />
     </>
   )
 }


### PR DESCRIPTION
## What

- Pin the « Créer le circuit » footer outside the scrollable exercise list in the library picker
- Persist block-mode selections in a `Map` so filtering/search no longer drops the selection count below 2
- Add a regression test for filter + block mode

## Why

After #394, creating a circuit with filters active hid the save button below the fold and could make it disappear entirely when a selected exercise was filtered out.

## How

Split `ExerciseSelectionContent` into list + pinned actions; wire `ExerciseLibraryPicker` so `ExerciseSelectionActions` sits as a sibling of `CommandList`, not inside it.

Made with [Cursor](https://cursor.com)