### PR TITLE
fix(builder): keep picker selections across searches and filters

### DIFF
--- a/src/components/builder/ExerciseLibraryPicker.test.tsx
+++ b/src/components/builder/ExerciseLibraryPicker.test.tsx
@@ -398,6 +398,76 @@ describe("ExerciseLibraryPicker", () => {
     expect(mockDeleteExerciseMutateAsync).toHaveBeenCalledWith({ id: "we-1", dayId: "day-1" })
   })
 
+  it("keeps Apply changes visible after filtering hides a selected exercise", async () => {
+    renderPicker()
+    const user = userEvent.setup()
+
+    const checkboxes = screen.getAllByRole("checkbox", { name: "Add" })
+    await user.click(checkboxes[0]) // Développé couché (Pectoraux)
+    await user.click(checkboxes[1]) // Élévations latérales (Épaules)
+
+    expect(
+      screen.getByRole("button", { name: "Apply changes" }),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText("Filters"))
+    await user.click(screen.getByRole("button", { name: "Pectoraux" }))
+
+    expect(screen.queryByText("Élévations latérales")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Apply changes" }),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Apply changes" }))
+    const [vars] = mockAddExercisesMutateAsync.mock.calls[0]
+    expect(vars.exercises).toHaveLength(2)
+  })
+
+  it("keeps selections when a new search triggers a loading state", async () => {
+    // A new search term is a fresh query key with no cache → isLoading flips
+    // true. The picker must not unmount its selection subtree on that flash.
+    mockUseExerciseLibraryPaginated.mockImplementation(
+      (params: {
+        search?: string
+        muscleGroup?: string | null
+        equipment?: string[]
+        difficulty?: string[]
+      }) =>
+        params.search
+          ? {
+              data: [] as Exercise[],
+              isLoading: true,
+              isFetchingNextPage: false,
+              hasNextPage: false,
+              fetchNextPage: mockFetchNextPage,
+            }
+          : paginatedReturn(params),
+    )
+
+    const onCreateBlock = vi.fn().mockResolvedValue(undefined)
+    renderPicker({ onCreateBlock })
+    const user = userEvent.setup()
+
+    const checkboxes = screen.getAllByRole("checkbox", { name: "Add" })
+    await user.click(checkboxes[0])
+    await user.click(checkboxes[1])
+
+    expect(
+      screen.getByRole("button", { name: /create circuit \(2 exercises\)/i }),
+    ).toBeInTheDocument()
+
+    await user.type(
+      screen.getByLabelText("Search exercises..."),
+      "tract",
+    )
+
+    await screen.findByRole(
+      "button",
+      { name: /create circuit \(2 exercises\)/i },
+      { timeout: 2000 },
+    )
+  })
+
   it("keeps create circuit CTA visible after filtering in block mode", async () => {
     const onCreateBlock = vi.fn().mockResolvedValue(undefined)
     renderPicker({ onCreateBlock })

--- a/src/components/builder/ExerciseLibraryPicker.tsx
+++ b/src/components/builder/ExerciseLibraryPicker.tsx
@@ -40,7 +40,6 @@ interface PickerSelectionPanelProps {
   initialSelectedIds: string[]
   existingExercises: ExistingDayExercise[]
   existingSet: Set<string>
-  filtered: Exercise[] | undefined
   grouped: Record<string, Exercise[]>
   dayId: string
   existingExerciseCount: number
@@ -49,6 +48,7 @@ interface PickerSelectionPanelProps {
   addExercises: ReturnType<typeof useAddExercisesToDay>
   deleteExercise: ReturnType<typeof useDeleteExercise>
   onCreateBlock?: (selected: Exercise[]) => Promise<void> | void
+  isLoading: boolean
   hasNextPage: boolean
   isFetchingNextPage: boolean
   onLoadMore: () => void
@@ -56,6 +56,7 @@ interface PickerSelectionPanelProps {
 
 function PickerSelectionPanel({
   selectionKey: _selectionKey,
+  isLoading,
   hasNextPage,
   isFetchingNextPage,
   onLoadMore,
@@ -67,24 +68,32 @@ function PickerSelectionPanel({
   return (
     <>
       <CommandList className="min-h-0 flex-1 max-h-none overflow-x-hidden overflow-y-auto">
-        <ExerciseSelectionList state={selection} />
-        {hasNextPage && (
-          <div className="flex justify-center border-t py-3">
-            <Button
-              variant="link"
-              size="sm"
-              className="text-muted-foreground hover:text-foreground"
-              onClick={onLoadMore}
-              disabled={isFetchingNextPage}
-            >
-              {isFetchingNextPage ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <RefreshCw className="h-4 w-4" />
-              )}
-              {t("loadMore")}
-            </Button>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           </div>
+        ) : (
+          <>
+            <ExerciseSelectionList state={selection} />
+            {hasNextPage && (
+              <div className="flex justify-center border-t py-3">
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="text-muted-foreground hover:text-foreground"
+                  onClick={onLoadMore}
+                  disabled={isFetchingNextPage}
+                >
+                  {isFetchingNextPage ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <RefreshCw className="h-4 w-4" />
+                  )}
+                  {t("loadMore")}
+                </Button>
+              </div>
+            )}
+          </>
         )}
       </CommandList>
       <ExerciseSelectionActions state={selection} />
@@ -259,33 +268,25 @@ export function ExerciseLibraryPicker({
         </div>
       </div>
 
-      {isLoading ? (
-        <CommandList className="min-h-0 flex-1 max-h-none overflow-x-hidden overflow-y-auto">
-          <div className="flex items-center justify-center py-8">
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-          </div>
-        </CommandList>
-      ) : (
-        <PickerSelectionPanel
-          key={selectionKey}
-          selectionKey={selectionKey}
-          initialSelectedIds={existingExercises.map((e) => e.exercise_id)}
-          existingExercises={existingExercises}
-          existingSet={existingSet}
-          filtered={paginatedData}
-          grouped={grouped}
-          dayId={dayId}
-          existingExerciseCount={existingExerciseCount}
-          onMutationStateChange={onMutationStateChange}
-          onClose={() => handleOpenChange(false)}
-          addExercises={addExercises}
-          deleteExercise={deleteExercise}
-          onCreateBlock={onCreateBlock}
-          hasNextPage={!!hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          onLoadMore={() => fetchNextPage()}
-        />
-      )}
+      <PickerSelectionPanel
+        key={selectionKey}
+        selectionKey={selectionKey}
+        initialSelectedIds={existingExercises.map((e) => e.exercise_id)}
+        existingExercises={existingExercises}
+        existingSet={existingSet}
+        grouped={grouped}
+        dayId={dayId}
+        existingExerciseCount={existingExerciseCount}
+        onMutationStateChange={onMutationStateChange}
+        onClose={() => handleOpenChange(false)}
+        addExercises={addExercises}
+        deleteExercise={deleteExercise}
+        onCreateBlock={onCreateBlock}
+        isLoading={isLoading}
+        hasNextPage={!!hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={() => fetchNextPage()}
+      />
     </Command>
   )
 

--- a/src/components/builder/ExerciseSelectionContent.tsx
+++ b/src/components/builder/ExerciseSelectionContent.tsx
@@ -30,7 +30,6 @@ export interface ExerciseSelectionContentProps {
   initialSelectedIds: string[]
   existingExercises: ExistingDayExercise[]
   existingSet: Set<string>
-  filtered: Exercise[] | undefined
   grouped: Record<string, Exercise[]> | undefined
   dayId: string
   existingExerciseCount: number
@@ -46,7 +45,6 @@ export function useExerciseSelection({
   initialSelectedIds,
   existingExercises,
   existingSet,
-  filtered,
   grouped,
   dayId,
   existingExerciseCount,
@@ -62,38 +60,38 @@ export function useExerciseSelection({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(
     () => new Set(isBlockMode ? [] : initialSelectedIds),
   )
-  /** Block mode keeps full Exercise rows so filters/search cannot drop selections. */
+  /**
+   * Keeps full Exercise rows for every exercise the user toggles ON, so a
+   * filter/search that hides a selected row never drops it from the pending
+   * additions (block CTA *and* "Apply changes" both depend on this).
+   */
   const [selectedById, setSelectedById] = useState<Map<string, Exercise>>(
     () => new Map(),
   )
   const [isCreatingBlock, setIsCreatingBlock] = useState(false)
 
-  const toggleSelected = useCallback(
-    (ex: Exercise) => {
-      setSelectedIds((prev) => {
-        const next = new Set(prev)
-        if (next.has(ex.id)) next.delete(ex.id)
-        else next.add(ex.id)
-        return next
-      })
-      if (isBlockMode) {
-        setSelectedById((prev) => {
-          const next = new Map(prev)
-          if (next.has(ex.id)) next.delete(ex.id)
-          else next.set(ex.id, ex)
-          return next
-        })
-      }
-    },
-    [isBlockMode],
-  )
+  const toggleSelected = useCallback((ex: Exercise) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(ex.id)) next.delete(ex.id)
+      else next.add(ex.id)
+      return next
+    })
+    setSelectedById((prev) => {
+      const next = new Map(prev)
+      if (next.has(ex.id)) next.delete(ex.id)
+      else next.set(ex.id, ex)
+      return next
+    })
+  }, [])
 
-  const toAdd = useMemo(() => {
-    if (!filtered) return []
-    return filtered.filter(
-      (ex) => selectedIds.has(ex.id) && !existingSet.has(ex.id),
-    )
-  }, [filtered, selectedIds, existingSet])
+  const toAdd = useMemo(
+    () =>
+      [...selectedById.values()].filter(
+        (ex) => selectedIds.has(ex.id) && !existingSet.has(ex.id),
+      ),
+    [selectedById, selectedIds, existingSet],
+  )
 
   const toRemove = useMemo(
     () =>
@@ -103,10 +101,8 @@ export function useExerciseSelection({
 
   const selectedExercises = useMemo(
     () =>
-      isBlockMode
-        ? [...selectedById.values()]
-        : (filtered ?? []).filter((ex) => selectedIds.has(ex.id)),
-    [isBlockMode, selectedById, filtered, selectedIds],
+      [...selectedById.values()].filter((ex) => selectedIds.has(ex.id)),
+    [selectedById, selectedIds],
   )
 
   const hasChanges = toAdd.length > 0 || toRemove.length > 0

--- a/src/hooks/useExerciseLibraryPaginated.ts
+++ b/src/hooks/useExerciseLibraryPaginated.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from "@tanstack/react-query"
+import { useInfiniteQuery, keepPreviousData } from "@tanstack/react-query"
 import { supabase } from "@/lib/supabase"
 import type { Exercise } from "@/types/database"
 
@@ -39,6 +39,9 @@ export function useExerciseLibraryPaginated({
     getNextPageParam: (lastPage, allPages) =>
       lastPage.length === PAGE_SIZE ? allPages.length : undefined,
     enabled,
+    // Keep the previous results on screen while a new search/filter loads so the
+    // picker subtree (and its selection state) is never unmounted by a loading flash.
+    placeholderData: keepPreviousData,
   })
 
   const data = query.data?.pages.flat() ?? []


### PR DESCRIPTION
## What

- Keep the exercise picker's selection state alive when the search term or filters change
- Move the loading spinner *inside* the list instead of replacing the whole panel
- Add `keepPreviousData` to the paginated library query so the list never flashes empty
- Drop the now-dead `filtered` prop from the selection hook

## Why

Reported follow-up to #395: selecting an exercise, clearing the search, then selecting a second one lost the first selection — the save / "Create circuit" button never appeared. A new search term is a fresh React Query key with no cache, so `isLoading` flipped `true` and the conditional `{isLoading ? <Loader/> : <Panel/>}` **unmounted** the panel that holds `selectedById` / `selectedIds`, remounting it empty.

## How

`PickerSelectionPanel` is now always mounted; it renders the spinner within `CommandList` when loading. `keepPreviousData` keeps the previous results on screen between queries, so there is no loading flash on each keystroke. Added a regression test that flips `isLoading` on a new search and asserts the selection (and CTA) persists.

Made with [Cursor](https://cursor.com)