### PR TITLE
fix(#318): classify embedded-agent model failures + surface cause to Sentry

### DIFF
--- a/src/components/embedded-agent/EmbeddedAgentChatStep.test.tsx
+++ b/src/components/embedded-agent/EmbeddedAgentChatStep.test.tsx
@@ -530,6 +530,84 @@ describe("EmbeddedAgentChatStep", () => {
     ).toBe(false)
   })
 
+  // #318 — the incident scenario: a transient Gemini 503 ("high demand")
+  // must surface the soft "give it a second, resend" banner, NOT the
+  // dead-end "something went wrong" — otherwise a new user bounces
+  // mid-onboarding (exactly what happened to the abandoned signup).
+  it("renders the soft busy banner (not the fatal one) when /message fails with failure_kind=provider_unavailable", async () => {
+    invokeMock
+      .mockResolvedValueOnce({
+        data: { thread_id: "busy0001-0000-0000-0000-000000000000", status: "open", resumed: false, messages: [] },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: Object.assign(new Error("502"), {
+          context: new Response(
+            JSON.stringify({
+              error: "model_failure",
+              failure_kind: "provider_unavailable",
+              upstream_status: 503,
+            }),
+            { status: 502 },
+          ),
+        }),
+      })
+
+    renderWithProviders(<EmbeddedAgentChatStep
+        locale="en"
+        purpose="onboarding"
+        i18nNamespace="onboarding"
+        onBack={() => {}}
+      />)
+    await screen.findByText(/Thread busy0001/)
+
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText(/write a message/i), "boom")
+    await user.click(screen.getByRole("button", { name: /^send$/i }))
+
+    // Soft banner is shown…
+    await screen.findByText(/in high demand/i)
+    // …and the generic dead-end banner is NOT.
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument()
+  })
+
+  // #318 — guard the other half: an UNclassified model_failure (legacy 502
+  // with no failure_kind, e.g. an older server build) keeps the hard
+  // banner. Without this the transient/fatal split could silently swallow
+  // every model_failure into the soft path.
+  it("keeps the fatal banner (not the busy one) for a model_failure with no failure_kind", async () => {
+    invokeMock
+      .mockResolvedValueOnce({
+        data: { thread_id: "busy0002-0000-0000-0000-000000000000", status: "open", resumed: false, messages: [] },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: Object.assign(new Error("502"), {
+          context: new Response(
+            JSON.stringify({ error: "model_failure" }),
+            { status: 502 },
+          ),
+        }),
+      })
+
+    renderWithProviders(<EmbeddedAgentChatStep
+        locale="en"
+        purpose="onboarding"
+        i18nNamespace="onboarding"
+        onBack={() => {}}
+      />)
+    await screen.findByText(/Thread busy0002/)
+
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText(/write a message/i), "boom")
+    await user.click(screen.getByRole("button", { name: /^send$/i }))
+
+    await screen.findByText(/something went wrong/i)
+    expect(screen.queryByText(/in high demand/i)).not.toBeInTheDocument()
+  })
+
   it("renders the friendly cap card on a 429 quota response", async () => {
     invokeMock
       .mockResolvedValueOnce({

--- a/src/components/embedded-agent/EmbeddedAgentChatStep.tsx
+++ b/src/components/embedded-agent/EmbeddedAgentChatStep.tsx
@@ -242,7 +242,16 @@ export function EmbeddedAgentChatStep({
     sendError?.kind === "quota" &&
     sendError.which !== "draft" &&
     sendError.which !== "program"
-  const isFatalError = sendError !== null && sendError.kind !== "quota"
+  // #295 — a Gemini 503 ("high demand") or a 15s timeout is transient and
+  // not the user's fault: surface a softer "give it a second" banner with a
+  // retry, instead of the generic "something went wrong" that reads like a
+  // dead end mid-onboarding. Everything else fatal keeps the hard banner.
+  const isTransientModelError =
+    sendError?.kind === "model_failure" &&
+    (sendError.failure_kind === "provider_unavailable" ||
+      sendError.failure_kind === "timeout")
+  const isFatalError =
+    sendError !== null && sendError.kind !== "quota" && !isTransientModelError
   const composeDisabled = sendMessage.isPending || isTurnQuotaError
 
   return (
@@ -296,6 +305,17 @@ export function EmbeddedAgentChatStep({
             <QuotaBanner
               title={t("embeddedAgent.quotaTitle")}
               body={t("embeddedAgent.quotaBody")}
+            />
+          ) : null}
+
+          {isTransientModelError ? (
+            <ErrorBanner
+              title={t("embeddedAgent.busyTitle")}
+              body={t("embeddedAgent.busyBody")}
+              retryLabel={t("embeddedAgent.retryCta")}
+              onRetry={() => {
+                sendMessage.reset()
+              }}
             />
           ) : null}
 

--- a/src/hooks/useEmbeddedAgentThread.test.ts
+++ b/src/hooks/useEmbeddedAgentThread.test.ts
@@ -299,6 +299,38 @@ describe("useGenerateDraft", () => {
 
     expect(caught).toMatchObject({ kind: "model_failure" })
   })
+
+  // #295 — when the server classified the upstream failure, the parser must
+  // surface `failure_kind` + `upstream_status` so the chat surface can
+  // branch UX (transient vs hard) and Sentry can tag the real cause.
+  it("maps a 502 model_failure with a classified Gemini 503 into failure_kind + upstream_status", async () => {
+    const err = Object.assign(new Error("502"), {
+      context: new Response(
+        JSON.stringify({
+          error: "model_failure",
+          failure_kind: "provider_unavailable",
+          upstream_status: 503,
+        }),
+        { status: 502 },
+      ),
+    })
+    invokeMock.mockResolvedValueOnce({ data: null, error: err })
+
+    const { result } = renderHookWithProviders(() => useSendMessage("onboarding"))
+
+    let caught: unknown = null
+    try {
+      await result.current.mutateAsync({ content: "hi", locale: "en" })
+    } catch (e) {
+      caught = e
+    }
+
+    expect(caught).toMatchObject({
+      kind: "model_failure",
+      failure_kind: "provider_unavailable",
+      upstream_status: 503,
+    })
+  })
 })
 
 describe("useRejectPreview", () => {

--- a/src/hooks/useEmbeddedAgentThread.ts
+++ b/src/hooks/useEmbeddedAgentThread.ts
@@ -125,6 +125,26 @@ export type EmbeddedAgentError =
   | { kind: "commit_failed"; mcp_kind?: string }
   | { kind: "unknown"; message: string }
 
+// Runtime guard for the wire `failure_kind`. Narrows an unknown body field
+// to the typed union, returning `undefined` when absent OR unrecognised —
+// the latter matters for forward-compat: a future server kind this client
+// build doesn't know about degrades to a plain `model_failure` instead of
+// leaking a bogus tag into Sentry.
+const CHAT_MODEL_FAILURE_KINDS = new Set<ChatModelFailureKind>([
+  "provider_unavailable",
+  "provider_error",
+  "client_error",
+  "timeout",
+  "empty_response",
+])
+
+function parseFailureKind(value: unknown): ChatModelFailureKind | undefined {
+  return typeof value === "string" &&
+    CHAT_MODEL_FAILURE_KINDS.has(value as ChatModelFailureKind)
+    ? (value as ChatModelFailureKind)
+    : undefined
+}
+
 // T131 (#343) — cache key includes `purpose` so onboarding and
 // additional_program threads have independent React Query entries; mutations
 // invalidate only their own purpose.

--- a/src/hooks/useEmbeddedAgentThread.ts
+++ b/src/hooks/useEmbeddedAgentThread.ts
@@ -97,6 +97,19 @@ export interface CommitPreviewResponse {
   motivation: string | null
 }
 
+// #295 — mirrors `ChatModelFailureKind` in
+// `supabase/functions/embedded-agent/chatModel.ts`. Same copy-paste tax as
+// the route taxonomy above (TS imports across the Vite/Deno boundary aren't
+// worth the build complexity). Lets the chat surface branch the UX on a
+// transient `provider_unavailable` (Gemini busy → "try again") vs. a hard
+// failure, and lets Sentry tag the real cause.
+export type ChatModelFailureKind =
+  | "provider_unavailable"
+  | "provider_error"
+  | "client_error"
+  | "timeout"
+  | "empty_response"
+
 export type EmbeddedAgentError =
   // The chat surface needs to distinguish between hourly turn quota
   // (`useSendMessage`), the daily draft quota and the cross-source
@@ -104,7 +117,11 @@ export type EmbeddedAgentError =
   // the right copy without re-decoding the wire error.
   | { kind: "quota"; which?: "turn" | "draft" | "program"; limit?: number; used?: number }
   | { kind: "no_active_thread" }
-  | { kind: "model_failure" }
+  // #295 — `failure_kind` / `upstream_status` are best-effort: present when
+  // the server classified the upstream failure, absent on legacy 502s or a
+  // generic `model_failure` from /draft|/commit. UI + Sentry treat them as
+  // optional refinements, never as required.
+  | { kind: "model_failure"; failure_kind?: ChatModelFailureKind; upstream_status?: number }
   | { kind: "commit_failed"; mcp_kind?: string }
   | { kind: "unknown"; message: string }
 
@@ -183,7 +200,14 @@ async function toEmbeddedAgentError(error: InvokeError): Promise<EmbeddedAgentEr
     code === "draft_failed" ||
     code === "mcp_failed"
   ) {
-    return { kind: "model_failure" }
+    const failureKind = parseFailureKind(body?.failure_kind)
+    const upstreamStatus =
+      typeof body?.upstream_status === "number" ? body.upstream_status : undefined
+    return {
+      kind: "model_failure",
+      ...(failureKind ? { failure_kind: failureKind } : {}),
+      ...(upstreamStatus !== undefined ? { upstream_status: upstreamStatus } : {}),
+    }
   }
   return { kind: "unknown", message: error.message ?? code ?? "Unknown error" }
 }

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -72,7 +72,9 @@ export function captureEmbeddedAgentError(
       route,
       error_kind: error.kind,
       ...(failureKind ? { failure_kind: failureKind } : {}),
-      ...(upstreamStatus !== undefined ? { upstream_status: upstreamStatus } : {}),
+      // Sentry tags are conventionally string-valued; stringify so the tag
+      // is reliable for search/grouping regardless of SDK coercion.
+      ...(upstreamStatus !== undefined ? { upstream_status: String(upstreamStatus) } : {}),
     },
   })
 }

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -55,12 +55,24 @@ export function captureEmbeddedAgentError(
   error: EmbeddedAgentError,
 ): void {
   if (FRIENDLY_KINDS.has(error.kind)) return
-  const message = error.kind === "unknown" ? error.message : `embedded-agent ${route} ${error.kind}`
+  // #295 — for model failures, fold the server-classified `failure_kind`
+  // (provider_unavailable / timeout / …) into BOTH the tags AND the
+  // exception message. Appending it to the message means Sentry groups a
+  // transient Gemini 503 into its own issue, separate from a hard
+  // client_error — so a capacity blip can be muted without burying real
+  // bugs. Falls back to the old generic message when the server didn't
+  // classify (legacy 502 / non-chat model_failure).
+  const failureKind = error.kind === "model_failure" ? error.failure_kind : undefined
+  const upstreamStatus = error.kind === "model_failure" ? error.upstream_status : undefined
+  const base = error.kind === "unknown" ? error.message : `embedded-agent ${route} ${error.kind}`
+  const message = failureKind ? `${base} ${failureKind}` : base
   Sentry.captureException(new Error(message), {
     tags: {
       feature: "embedded-agent",
       route,
       error_kind: error.kind,
+      ...(failureKind ? { failure_kind: failureKind } : {}),
+      ...(upstreamStatus !== undefined ? { upstream_status: upstreamStatus } : {}),
     },
   })
 }

--- a/src/locales/en/create-program.json
+++ b/src/locales/en/create-program.json
@@ -78,6 +78,8 @@
     "quotaBody": "You've hit the conversation limit for this hour. Take a short break and come back to keep iterating.",
     "errorTitle": "Something went wrong",
     "errorBody": "We couldn't reach the assistant. Try again in a moment.",
+    "busyTitle": "The assistant is in high demand",
+    "busyBody": "Our AI is briefly overloaded — this usually clears in a few seconds. Try sending your message again.",
     "retryCta": "Try again",
     "threadErrorTitle": "We couldn't load your conversation",
     "threadErrorBody": "Something failed on our side. Try again — your draft is safe.",

--- a/src/locales/en/onboarding.json
+++ b/src/locales/en/onboarding.json
@@ -85,6 +85,8 @@
     "quotaBody": "You've reached the conversation limit for this hour. Take a short break and come back to keep building.",
     "errorTitle": "Something went wrong",
     "errorBody": "We couldn't reach the assistant. Try again in a moment.",
+    "busyTitle": "The assistant is in high demand",
+    "busyBody": "Our AI is briefly overloaded — this usually clears in a few seconds. Try sending your message again.",
     "retryCta": "Try again",
     "threadErrorTitle": "We couldn't load your conversation",
     "threadErrorBody": "Something failed on our side. Try again — your draft is safe.",

--- a/src/locales/fr/create-program.json
+++ b/src/locales/fr/create-program.json
@@ -78,6 +78,8 @@
     "quotaBody": "Vous avez atteint la limite de conversation pour cette heure. Faites une courte pause et revenez pour continuer.",
     "errorTitle": "Une erreur est survenue",
     "errorBody": "Impossible de joindre l'assistant. Réessayez dans un instant.",
+    "busyTitle": "L'assistant est très sollicité",
+    "busyBody": "Notre IA est momentanément surchargée — ça se résout en général en quelques secondes. Renvoyez votre message.",
     "retryCta": "Réessayer",
     "threadErrorTitle": "Impossible de charger votre conversation",
     "threadErrorBody": "Quelque chose a échoué de notre côté. Réessayez — votre draft est en sécurité.",

--- a/src/locales/fr/onboarding.json
+++ b/src/locales/fr/onboarding.json
@@ -85,6 +85,8 @@
     "quotaBody": "Vous avez atteint la limite de conversation pour cette heure. Prenez une courte pause et revenez pour continuer.",
     "errorTitle": "Une erreur est survenue",
     "errorBody": "Impossible de joindre l'assistant. Réessayez dans un instant.",
+    "busyTitle": "L'assistant est très sollicité",
+    "busyBody": "Notre IA est momentanément surchargée — ça se résout en général en quelques secondes. Renvoyez votre message.",
     "retryCta": "Réessayer",
     "threadErrorTitle": "Impossible de charger votre conversation",
     "threadErrorBody": "Quelque chose a échoué de notre côté. Réessayez — votre brouillon est sauvegardé.",

--- a/supabase/functions/embedded-agent/chatModel.ts
+++ b/supabase/functions/embedded-agent/chatModel.ts
@@ -49,11 +49,12 @@ export class ChatModelError extends Error {
 }
 
 // Map a non-2xx Gemini status onto a failure kind. 503 is the observed
-// prod case (UNAVAILABLE / high demand); the other retryable 5xx share the
-// "provider_error" bucket; everything else (4xx, incl. 429) is on us.
+// prod case (UNAVAILABLE / high demand); every OTHER 5xx is an upstream
+// problem too — retryable or not (501/505/…) — so it stays `provider_error`,
+// never `client_error`. Only sub-500 (4xx, incl. 429) is on us.
 function httpStatusToFailureKind(status: number): ChatModelFailureKind {
   if (status === 503) return "provider_unavailable"
-  if (RETRYABLE_CHAT_MODEL_STATUSES.has(status)) return "provider_error"
+  if (status >= 500) return "provider_error"
   return "client_error"
 }
 

--- a/supabase/functions/embedded-agent/chatModel.ts
+++ b/supabase/functions/embedded-agent/chatModel.ts
@@ -12,6 +12,51 @@
 
 import type { ChatModelInput, ChatModelOutput } from "./handler.ts"
 
+// Failure taxonomy for a chat turn. The Sentry issue for #295 only ever
+// said "model_failure" — a blind umbrella that forced an 8-query BigQuery
+// safari to find out the underlying cause was a Gemini 503. These kinds
+// give the handler something specific to log AND to push into the wire
+// error so the web client can tag Sentry with the real cause:
+//   - provider_unavailable: Gemini 503 UNAVAILABLE ("high demand") — their
+//     capacity, transient, retried, and the user should just try again.
+//   - provider_error:       other upstream 5xx (500/502/504) — also retried.
+//   - client_error:         non-retryable 4xx (bad key / payload) — OUR bug.
+//   - timeout:              the shared 15s AbortController budget ran out.
+//   - empty_response:       2xx but no usable text (thinking-only / empty).
+export type ChatModelFailureKind =
+  | "provider_unavailable"
+  | "provider_error"
+  | "client_error"
+  | "timeout"
+  | "empty_response"
+
+/**
+ * Typed chat-model failure. Carries the discriminating `kind` and, when the
+ * failure was an upstream HTTP response, the raw `upstreamStatus`. The
+ * `message` stays human-readable (and identical to the pre-#295 strings) so
+ * existing log-grep and test assertions keep working.
+ */
+export class ChatModelError extends Error {
+  readonly kind: ChatModelFailureKind
+  readonly upstreamStatus?: number
+
+  constructor(kind: ChatModelFailureKind, message: string, upstreamStatus?: number) {
+    super(message)
+    this.name = "ChatModelError"
+    this.kind = kind
+    this.upstreamStatus = upstreamStatus
+  }
+}
+
+// Map a non-2xx Gemini status onto a failure kind. 503 is the observed
+// prod case (UNAVAILABLE / high demand); the other retryable 5xx share the
+// "provider_error" bucket; everything else (4xx, incl. 429) is on us.
+function httpStatusToFailureKind(status: number): ChatModelFailureKind {
+  if (status === 503) return "provider_unavailable"
+  if (RETRYABLE_CHAT_MODEL_STATUSES.has(status)) return "provider_error"
+  return "client_error"
+}
+
 const GEMINI_URL =
   "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
 const TIMEOUT_MS = 15_000
@@ -100,13 +145,30 @@ export async function callChatGemini(
         body,
       })
 
-      if (res.ok) return parseSuccess(await res.json())
+      if (res.ok) {
+        try {
+          return parseSuccess(await res.json())
+        } catch (parseErr) {
+          // 2xx but unusable (empty / thinking-only / Gemini-embedded
+          // error). Distinct kind so triage doesn't confuse "Gemini was
+          // down" with "Gemini answered garbage".
+          throw new ChatModelError(
+            "empty_response",
+            parseErr instanceof Error ? parseErr.message : String(parseErr),
+            res.status,
+          )
+        }
+      }
 
       const errorBody = await res.text()
       const isRetryable = RETRYABLE_CHAT_MODEL_STATUSES.has(res.status)
       const isLastAttempt = attempt === MAX_CHAT_MODEL_ATTEMPTS
       if (!isRetryable || isLastAttempt) {
-        throw new Error(`Gemini API error ${res.status}: ${errorBody}`)
+        throw new ChatModelError(
+          httpStatusToFailureKind(res.status),
+          `Gemini API error ${res.status}: ${errorBody}`,
+          res.status,
+        )
       }
 
       input.onRetry?.({ attempt, upstreamStatus: res.status })
@@ -122,7 +184,7 @@ export async function callChatGemini(
     // Unreachable: the loop either returns on a 2xx or throws on an
     // exhausted/non-retryable failure. Kept as a defensive net so the
     // function always has a terminal statement.
-    throw new Error("Gemini retry loop exited without resolving")
+    throw new ChatModelError("provider_error", "Gemini retry loop exited without resolving")
   } finally {
     clearTimeout(timeout)
   }

--- a/supabase/functions/embedded-agent/chatModel_test.ts
+++ b/supabase/functions/embedded-agent/chatModel_test.ts
@@ -1,6 +1,13 @@
-import { assertEquals, assertRejects } from "https://deno.land/std@0.224.0/assert/mod.ts"
+import {
+  assert,
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts"
 import {
   callChatGemini,
+  ChatModelError,
   MAX_CHAT_MODEL_ATTEMPTS,
   RETRYABLE_CHAT_MODEL_STATUSES,
 } from "./chatModel.ts"
@@ -194,6 +201,57 @@ Deno.test("callChatGemini — abort during backoff sleep terminates the retry lo
   )
 
   assertEquals(recorder.calls, 1)
+})
+
+// #295 — the thrown error must carry a typed `kind` + `upstreamStatus` so
+// the handler can name the real cause downstream. These pin the mapping
+// (503 → provider_unavailable, 4xx → client_error, empty body →
+// empty_response) without re-testing the retry mechanics above.
+Deno.test("callChatGemini — exhausted 503 throws ChatModelError(provider_unavailable, 503)", async () => {
+  const { fetchImpl } = makeFetch([
+    makeGeminiErrorResponse(503),
+    makeGeminiErrorResponse(503),
+    makeGeminiErrorResponse(503),
+  ])
+
+  const err = await assertRejects(
+    () => callChatGemini(makeInput(), { fetchImpl, sleepImpl: noopSleep }),
+  )
+
+  assertInstanceOf(err, ChatModelError)
+  assertEquals(err.kind, "provider_unavailable")
+  assertEquals(err.upstreamStatus, 503)
+  assertStringIncludes(err.message, "Gemini API error 503")
+})
+
+Deno.test("callChatGemini — 400 throws ChatModelError(client_error, 400)", async () => {
+  const { fetchImpl } = makeFetch([makeGeminiErrorResponse(400, "bad request")])
+
+  const err = await assertRejects(
+    () => callChatGemini(makeInput(), { fetchImpl, sleepImpl: noopSleep }),
+  )
+
+  assertInstanceOf(err, ChatModelError)
+  assertEquals(err.kind, "client_error")
+  assertEquals(err.upstreamStatus, 400)
+})
+
+Deno.test("callChatGemini — 2xx with no usable text throws ChatModelError(empty_response)", async () => {
+  // 200 OK but `candidates` is empty → parseSuccess throws → we classify it
+  // as empty_response (Gemini answered garbage, distinct from being down).
+  const emptyOk = new Response(JSON.stringify({ candidates: [] }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+  const { fetchImpl } = makeFetch([emptyOk])
+
+  const err = await assertRejects(
+    () => callChatGemini(makeInput(), { fetchImpl, sleepImpl: noopSleep }),
+  )
+
+  assertInstanceOf(err, ChatModelError)
+  assertEquals(err.kind, "empty_response")
+  assert(err.upstreamStatus === 200)
 })
 
 Deno.test("callChatGemini — 429 is NOT retried (quota class, not capacity)", async () => {

--- a/supabase/functions/embedded-agent/chatModel_test.ts
+++ b/supabase/functions/embedded-agent/chatModel_test.ts
@@ -236,6 +236,21 @@ Deno.test("callChatGemini — 400 throws ChatModelError(client_error, 400)", asy
   assertEquals(err.upstreamStatus, 400)
 })
 
+// #318 PR review (Copilot) — a NON-retryable 5xx (501/505/…) is still an
+// upstream problem, so it must classify as provider_error, never the
+// client_error bucket reserved for 4xx. Guards `httpStatusToFailureKind`.
+Deno.test("callChatGemini — non-retryable 5xx (501) throws ChatModelError(provider_error, 501)", async () => {
+  const { fetchImpl } = makeFetch([makeGeminiErrorResponse(501, "not implemented")])
+
+  const err = await assertRejects(
+    () => callChatGemini(makeInput(), { fetchImpl, sleepImpl: noopSleep }),
+  )
+
+  assertInstanceOf(err, ChatModelError)
+  assertEquals(err.kind, "provider_error")
+  assertEquals(err.upstreamStatus, 501)
+})
+
 Deno.test("callChatGemini — 2xx with no usable text throws ChatModelError(empty_response)", async () => {
   // 200 OK but `candidates` is empty → parseSuccess throws → we classify it
   // as empty_response (Gemini answered garbage, distinct from being down).

--- a/supabase/functions/embedded-agent/handler.ts
+++ b/supabase/functions/embedded-agent/handler.ts
@@ -29,6 +29,7 @@ import {
 } from "./lib/bundle.ts"
 import type { CallMcpToolResult } from "../_shared/mcpClient.ts"
 import type { LogEvent } from "./log.ts"
+import { ChatModelError, type ChatModelFailureKind } from "./chatModel.ts"
 
 export type { LogEvent } from "./log.ts"
 
@@ -51,6 +52,27 @@ export interface ChatModelInput {
 
 export interface ChatModelOutput {
   content: string
+}
+
+/**
+ * Map whatever the chat model threw onto the canonical failure taxonomy
+ * (#295 observability). `ChatModelError` already carries the kind +
+ * upstream status; a bare `AbortError` means the shared 15s budget fired
+ * (timeout); anything else is an unclassified upstream error. This is the
+ * single place that decides the `error_kind` we log AND the `failure_kind`
+ * we hand back on the wire, so the two can never drift.
+ */
+export function classifyChatFailure(
+  err: unknown,
+): { kind: ChatModelFailureKind; upstreamStatus?: number } {
+  if (err instanceof ChatModelError) {
+    return { kind: err.kind, upstreamStatus: err.upstreamStatus }
+  }
+  // DOMException (sleep abort) and the AbortError shape (fetch abort) are not
+  // reliably `instanceof Error` across runtimes — match on the name instead.
+  const name = (err as { name?: unknown } | null)?.name
+  if (name === "AbortError") return { kind: "timeout" }
+  return { kind: "provider_error" }
 }
 
 export interface DraftStepInput {
@@ -670,18 +692,35 @@ async function handleSend(
     })
   } catch (err) {
     await deps.logBillableCall(userId, "embedded_chat")
+    // #295 — classify the failure so the log `error_kind` (and the wire
+    // `failure_kind` below) name the real cause (provider_unavailable /
+    // timeout / …) instead of the old blind `provider_failure` umbrella.
+    const failure = classifyChatFailure(err)
     deps.log({
       level: "error",
       feature: "embedded-agent",
       route: "/message",
       purpose,
-      error_kind: "provider_failure",
+      error_kind: failure.kind,
       request_id: requestId,
       user_id: userId,
       thread_id: active.id,
       message: err instanceof Error ? err.message : String(err),
     })
-    return Response.json({ error: "model_failure" }, { status: 502 })
+    // Wire contract: `error` stays `model_failure` (the web client's parser
+    // keys on it). `failure_kind` + `upstream_status` are additive so the
+    // PWA can tag Sentry with the real cause and branch the UX (transient
+    // "try again" vs. a hard error) without a follow-up log dig.
+    return Response.json(
+      {
+        error: "model_failure",
+        failure_kind: failure.kind,
+        ...(failure.upstreamStatus !== undefined
+          ? { upstream_status: failure.upstreamStatus }
+          : {}),
+      },
+      { status: 502 },
+    )
   }
 
   await deps.logBillableCall(userId, "embedded_chat")

--- a/supabase/functions/embedded-agent/handler_test.ts
+++ b/supabase/functions/embedded-agent/handler_test.ts
@@ -5,6 +5,7 @@ import {
   type ChatModelOutput,
   type LogEvent,
 } from "./handler.ts"
+import { ChatModelError } from "./chatModel.ts"
 import type { Thread, ThreadLocale, ThreadPurpose } from "./threadStore.ts"
 import type { UserContextProfile } from "./prompt/index.ts"
 import type { DraftArgs, DraftResult, LastPreview } from "./draft.ts"
@@ -814,12 +815,70 @@ Deno.test("POST /message logs the billable call AND returns 502 even when the mo
   assertEquals(calls.appendMessage[0].role, "user")
 
   assertEquals(calls.logEvents.length, 1)
-  // Canonical taxonomy (T122 inventory): the log uses `provider_failure`
-  // even though the wire contract still says `model_failure` — the web
-  // client's error parser depends on the wire string and isn't in scope
-  // for this ticket.
-  assertEquals(calls.logEvents[0].error_kind, "provider_failure")
+  // #295 — a plain (unclassified) throw lands in the `provider_error`
+  // bucket. The wire `error` stays `model_failure` for back-compat with the
+  // web client's parser; `failure_kind` is the additive refinement.
+  assertEquals(calls.logEvents[0].error_kind, "provider_error")
   assertEquals(calls.logEvents[0].route, "/message")
+  assertEquals(body.failure_kind, "provider_error")
+})
+
+// #295 — when the chat model throws a typed `ChatModelError` (the prod
+// path for a Gemini 503), the handler must surface the real cause both in
+// the structured log (`error_kind`) and on the wire (`failure_kind` +
+// `upstream_status`) so Sentry/triage never has to dig through Edge logs.
+Deno.test("POST /message classifies a Gemini 503 as provider_unavailable end to end", async () => {
+  const active = makeThread({ id: "t-1", status: "open" })
+  const { deps, calls } = makeDeps({
+    getActiveThread: async () => active,
+    chatModel: () => {
+      throw new ChatModelError(
+        "provider_unavailable",
+        "Gemini API error 503: high demand",
+        503,
+      )
+    },
+  })
+
+  const res = await handleEmbeddedAgent(
+    sendRequest({ content: "hi", locale: "en" }),
+    deps,
+  )
+
+  assertEquals(res.status, 502)
+  const body = await res.json() as Record<string, unknown>
+  assertEquals(body.error, "model_failure")
+  assertEquals(body.failure_kind, "provider_unavailable")
+  assertEquals(body.upstream_status, 503)
+
+  assertEquals(calls.logEvents.length, 1)
+  assertEquals(calls.logEvents[0].error_kind, "provider_unavailable")
+  assertEquals(calls.logEvents[0].route, "/message")
+})
+
+// #295 — an AbortError (the shared 15s budget firing) is the one non-
+// `ChatModelError` shape the classifier special-cases: it must read as a
+// `timeout`, never the catch-all `provider_error`.
+Deno.test("POST /message classifies an AbortError as timeout", async () => {
+  const active = makeThread({ id: "t-1", status: "open" })
+  const { deps, calls } = makeDeps({
+    getActiveThread: async () => active,
+    chatModel: () => {
+      throw Object.assign(new Error("aborted"), { name: "AbortError" })
+    },
+  })
+
+  const res = await handleEmbeddedAgent(
+    sendRequest({ content: "hi", locale: "en" }),
+    deps,
+  )
+
+  assertEquals(res.status, 502)
+  const body = await res.json() as Record<string, unknown>
+  assertEquals(body.failure_kind, "timeout")
+  // No upstream HTTP status on a client-side abort.
+  assertEquals(body.upstream_status, undefined)
+  assertEquals(calls.logEvents[0].error_kind, "timeout")
 })
 
 // #358 — When the chat model exposes its retry budget via `input.onRetry`,


### PR DESCRIPTION
## What

- **Server taxonomy** (`chatModel.ts`): a typed `ChatModelError` with a `kind` (`provider_unavailable` / `provider_error` / `client_error` / `timeout` / `empty_response`) and `upstreamStatus`.
- **Handler** (`handler.ts`): `classifyChatFailure()` logs the real `error_kind` (no more blind `provider_failure`) and adds `failure_kind` + `upstream_status` to the 502 body. The wire `error: "model_failure"` is unchanged for back-compat.
- **Client → Sentry** (`useEmbeddedAgentThread.ts`, `sentry.ts`): the `model_failure` error now carries `failure_kind`/`upstream_status`, tagged on the Sentry event and folded into the message so a Gemini 503 groups as its own issue.
- **UX** (`EmbeddedAgentChatStep.tsx` + i18n): transient failures (`provider_unavailable`/`timeout`) show a soft "assistant is busy, resend your message" banner with retry, instead of the generic dead-end error.

## Why

A real prod incident: a brand-new user hit a `502 model_failure` mid-onboarding, abandoned, and never came back. Root cause was a transient Gemini `503 UNAVAILABLE` ("high demand") — but Sentry only ever showed the blind `model_failure`, so confirming the cause took an 8-query BigQuery/Edge-log safari. This makes the cause visible at a glance and softens the user-facing failure so a transient blip no longer reads like a dead end.

## How

- All failure throw-sites in `callChatGemini` now raise the typed error; messages are byte-identical so existing log-grep and assertions still hold.
- `classifyChatFailure` is the single source of truth shared by the log and the wire body, so `error_kind` and `failure_kind` can never drift. Bare `AbortError` (the shared 15s budget) maps to `timeout`.
- Sentry grouping by `failure_kind` lets us mute Gemini-capacity noise without burying genuine `client_error` bugs.

## Notes / follow-ups

- Tests added: server classification (`chatModel_test.ts`, `handler_test.ts`) and client body parsing (`useEmbeddedAgentThread.test.ts`). **Gap**: no component test yet asserting the transient-vs-fatal banner choice in `EmbeddedAgentChatStep` — worth adding.
- Related but separate: the `#358` retry-on-5xx fix is merged but Edge functions deploy manually, so it may have been running an older version in prod. Verify `embedded-agent` is redeployed.

Closes #318

Made with [Cursor](https://cursor.com)