### PR TITLE
Prefer English catalog name for program exercise snapshots

### DIFF
--- a/src/lib/programPersistence.ts
+++ b/src/lib/programPersistence.ts
@@ -93,10 +93,14 @@ function buildWorkoutExerciseInsertRow(
     isDuration && ge.targetDurationSeconds !== undefined && ge.targetDurationSeconds !== null
   const effectiveDurationSec = useExplicitDuration ? ge.targetDurationSeconds! : defaultSec
 
+  // Prefer English catalog name when present (parity with MCP; see upstream #415).
+  const nameEn = ge.exercise.name_en?.trim()
+  const nameSnapshot = nameEn && nameEn.length > 0 ? nameEn : ge.exercise.name
+
   return {
     workout_day_id: workoutDayId,
     exercise_id: ge.exercise.id,
-    name_snapshot: ge.exercise.name,
+    name_snapshot: nameSnapshot,
     muscle_snapshot: ge.exercise.muscle_group,
     emoji_snapshot: ge.exercise.emoji ?? "🏋️",
     sets: ge.sets,

--- a/supabase/functions/mcp/lib/catalogLookup.ts
+++ b/supabase/functions/mcp/lib/catalogLookup.ts
@@ -10,7 +10,7 @@ import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.103.
 import type { CatalogExerciseForProgram } from "./programPersistence.ts"
 
 const CATALOG_COLUMNS =
-  "id, name, muscle_group, emoji, equipment, measurement_type, default_duration_seconds"
+  "id, name, name_en, muscle_group, emoji, equipment, measurement_type, default_duration_seconds"
 
 function catalogRowToExercise(row: Record<string, unknown>): CatalogExerciseForProgram {
   const mt = row.measurement_type
@@ -21,9 +21,15 @@ function catalogRowToExercise(row: Record<string, unknown>): CatalogExerciseForP
     const n = Number(rawDur)
     default_duration_seconds = Number.isFinite(n) ? n : null
   }
+  const nameEnRaw = row.name_en
+  const name_en =
+    nameEnRaw != null && String(nameEnRaw).trim() !== ""
+      ? String(nameEnRaw).trim()
+      : null
   return {
     id: String(row.id),
     name: String(row.name),
+    name_en,
     muscle_group: String(row.muscle_group),
     emoji: row.emoji != null ? String(row.emoji) : null,
     equipment: String(row.equipment),

--- a/supabase/functions/mcp/lib/programPersistence.ts
+++ b/supabase/functions/mcp/lib/programPersistence.ts
@@ -49,11 +49,22 @@ export function parseRepsBounds(reps: string): { min: number; max: number } {
 export interface CatalogExerciseForProgram {
   id: string
   name: string
+  /** English catalog name when present — preferred for name_snapshot (see #415). */
+  name_en?: string | null
   muscle_group: string
   emoji: string | null
   equipment: string
   measurement_type?: "reps" | "duration" | null
   default_duration_seconds?: number | null
+}
+
+/** Prefer English catalog name for program/session UI when available. */
+export function snapshotExerciseName(exercise: {
+  name: string
+  name_en?: string | null
+}): string {
+  const en = exercise.name_en?.trim()
+  return en && en.length > 0 ? en : exercise.name
 }
 
 export interface GeneratedExerciseForProgram {
@@ -157,7 +168,7 @@ function buildWorkoutExerciseInsertRow(
   return {
     workout_day_id: workoutDayId,
     exercise_id: ge.exercise.id,
-    name_snapshot: ge.exercise.name,
+    name_snapshot: snapshotExerciseName(ge.exercise),
     muscle_snapshot: ge.exercise.muscle_group,
     emoji_snapshot: ge.exercise.emoji ?? "🏋️",
     sets: ge.sets,


### PR DESCRIPTION
## Summary

Fixes [#415](https://github.com/PierreTsia/workout-app/issues/415): when programs are created or updated via MCP (and the web AI persistence path), exercise `name_snapshot` now prefers `exercises.name_en` when present, so the session UI shows **Bench Press** instead of **Développé couché**.

Catalog already stores bilingual names; writes previously always snapshotted the French primary `name` column.

## Changes

- `supabase/functions/mcp/lib/catalogLookup.ts` — select/map `name_en`
- `supabase/functions/mcp/lib/programPersistence.ts` — `snapshotExerciseName()` → EN when available
- `src/lib/programPersistence.ts` — same preference for the web AI program path (keep Edge/web parity)

## Out of scope

- Exercise **instructions** remain a single French-oriented `instructions` JSONB field (no `instructions_en` yet)
- Existing program rows keep old FR snapshots until re-saved / updated
- Full locale-aware UI for muscles, coach strings, etc.

## Test plan

- [x] Local Supabase + MCP `create_program` / `update_program` → `workout_exercises.name_snapshot` is English (e.g. `Bench Press`)
- [x] Dry-run / apply paths exercise IDs resolve correctly with `name_en` loaded
- [ ] CI / existing `programPersistence` tests pass on this branch

Closes #415