### PR TITLE
chore(test): dual-locale test harness

### DIFF
--- a/src/locales/locales.test.ts
+++ b/src/locales/locales.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest"
+
+// Namespace coverage is asserted by the test harness (src/test/utils.test.tsx).
+// This file asserts the stronger property the harness cannot see: that a key
+// resolves in every locale. Without it, a key missing from `fr` silently falls
+// back to English and the gap is invisible until a user reports it.
+const localeModules = import.meta.glob("./*/*.json", { eager: true }) as Record<
+  string,
+  { default: Record<string, unknown> }
+>
+
+const flatten = (
+  value: Record<string, unknown>,
+  prefix = "",
+): [string, unknown][] =>
+  Object.entries(value).flatMap(([key, child]) => {
+    const path = prefix ? `${prefix}.${key}` : key
+    return child !== null && typeof child === "object"
+      ? flatten(child as Record<string, unknown>, path)
+      : [[path, child] as [string, unknown]]
+  })
+
+const valuesByLocale = Object.entries(localeModules).reduce<
+  Record<string, Record<string, unknown>>
+>((acc, [path, module]) => {
+  const [, locale, namespace] = /^\.\/([^/]+)\/(.+)\.json$/.exec(path) ?? []
+  if (!locale || !namespace) return acc
+
+  const namespaced = Object.fromEntries(
+    flatten(module.default).map(([key, value]) => [
+      `${namespace}:${key}`,
+      value,
+    ]),
+  )
+
+  return { ...acc, [locale]: { ...(acc[locale] ?? {}), ...namespaced } }
+}, {})
+
+const locales = Object.keys(valuesByLocale).sort()
+
+const allKeys = [
+  ...new Set(locales.flatMap((locale) => Object.keys(valuesByLocale[locale]))),
+].sort()
+
+const sharedKeys = allKeys.filter((key) =>
+  locales.every((locale) => key in valuesByLocale[locale]),
+)
+
+// i18next reads `{{name}}`, `{{count}}` and formatted variants like
+// `{{value, number}}` — only the variable name matters for parity.
+const placeholders = (value: unknown): string =>
+  typeof value === "string"
+    ? [...value.matchAll(/\{\{\s*([^}\s,]+)/g)]
+        .map((match) => match[1])
+        .sort()
+        .join(",")
+    : ""
+
+describe("locale parity", () => {
+  it("discovers more than one locale, otherwise it proves nothing", () => {
+    expect(locales.length).toBeGreaterThan(1)
+    expect(allKeys.length).toBeGreaterThan(0)
+  })
+
+  it.each(locales)("%s defines every key found in another locale", (locale) => {
+    const missing = allKeys.filter((key) => !(key in valuesByLocale[locale]))
+
+    expect(missing).toEqual([])
+  })
+
+  it("uses the same interpolation variables for a key in every locale", () => {
+    const divergent = sharedKeys
+      .map((key) => ({
+        key,
+        byLocale: locales.map((locale) => ({
+          locale,
+          variables: placeholders(valuesByLocale[locale][key]),
+        })),
+      }))
+      .filter(
+        ({ byLocale }) =>
+          new Set(byLocale.map(({ variables }) => variables)).size > 1,
+      )
+      .map(
+        ({ key, byLocale }) =>
+          `${key} — ${byLocale
+            .map(({ locale, variables }) => `${locale}: [${variables}]`)
+            .join(" vs ")}`,
+      )
+
+    expect(divergent).toEqual([])
+  })
+
+  it("never leaves a key blank in one locale only", () => {
+    const blank = sharedKeys.filter((key) =>
+      locales.some(
+        (locale) =>
+          typeof valuesByLocale[locale][key] === "string" &&
+          (valuesByLocale[locale][key] as string).trim() === "",
+      ),
+    )
+
+    expect(blank).toEqual([])
+  })
+})

--- a/src/test/utils.test.tsx
+++ b/src/test/utils.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest"
+import { screen } from "@testing-library/react"
+import { useTranslation } from "react-i18next"
+
+import { createTestI18n, renderWithProviders } from "./utils"
+
+// The harness duplicates the namespace list that lives in src/lib/i18n.ts, so
+// derive the expectation from the locale files themselves rather than from a
+// third hand-maintained list.
+const localeFilePaths = Object.keys(
+  import.meta.glob("../locales/*/*.json", { eager: false }),
+)
+
+const namespacesOnDisk = localeFilePaths.reduce<Record<string, string[]>>(
+  (acc, path) => {
+    const [, locale, namespace] =
+      /\/locales\/([^/]+)\/(.+)\.json$/.exec(path) ?? []
+    return locale && namespace
+      ? { ...acc, [locale]: [...(acc[locale] ?? []), namespace] }
+      : acc
+  },
+  {},
+)
+
+function Label() {
+  const { t } = useTranslation("common")
+  return <span>{t("cancel")}</span>
+}
+
+describe("createTestI18n", () => {
+  it("defaults to English so existing tests are unaffected", () => {
+    const i18n = createTestI18n()
+
+    expect(i18n.language).toBe("en")
+    expect(i18n.t("cancel", { ns: "common" })).toBe("Cancel")
+  })
+
+  it("renders French when asked", () => {
+    const i18n = createTestI18n({ lng: "fr" })
+
+    expect(i18n.language).toBe("fr")
+    expect(i18n.t("cancel", { ns: "common" })).toBe("Annuler")
+  })
+
+  it("keeps the English fallback real, as in production", () => {
+    const i18n = createTestI18n({ lng: "fr" })
+
+    expect(i18n.options.fallbackLng).toContain("en")
+  })
+
+  it.each(Object.keys(namespacesOnDisk))(
+    "loads every %s namespace that exists on disk",
+    (locale) => {
+      const loaded = Object.keys(
+        createTestI18n().store.data[locale] ?? {},
+      ).sort()
+
+      expect(loaded).toEqual([...namespacesOnDisk[locale]].sort())
+    },
+  )
+
+  it("covers the same namespaces in both locales", () => {
+    expect([...namespacesOnDisk.fr].sort()).toEqual(
+      [...namespacesOnDisk.en].sort(),
+    )
+  })
+})
+
+describe("renderWithProviders locale option", () => {
+  it("renders English by default", () => {
+    renderWithProviders(<Label />)
+
+    expect(screen.getByText("Cancel")).toBeInTheDocument()
+  })
+
+  it("propagates the requested locale to the tree", () => {
+    renderWithProviders(<Label />, { locale: "fr" })
+
+    expect(screen.getByText("Annuler")).toBeInTheDocument()
+  })
+})

--- a/src/test/utils.test.tsx
+++ b/src/test/utils.test.tsx
@@ -48,6 +48,15 @@ describe("createTestI18n", () => {
     expect(i18n.options.fallbackLng).toContain("en")
   })
 
+  it("declares exactly the locales it ships resources for", () => {
+    // i18next appends its own "cimode" pseudo-locale to supportedLngs.
+    const declared = (createTestI18n().options.supportedLngs || [])
+      .filter((lng) => lng !== "cimode")
+      .sort()
+
+    expect(declared).toEqual(Object.keys(namespacesOnDisk).sort())
+  })
+
   it.each(Object.keys(namespacesOnDisk))(
     "loads every %s namespace that exists on disk",
     (locale) => {
@@ -58,12 +67,6 @@ describe("createTestI18n", () => {
       expect(loaded).toEqual([...namespacesOnDisk[locale]].sort())
     },
   )
-
-  it("covers the same namespaces in both locales", () => {
-    expect([...namespacesOnDisk.fr].sort()).toEqual(
-      [...namespacesOnDisk.en].sort(),
-    )
-  })
 })
 
 describe("renderWithProviders locale option", () => {

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -29,33 +29,82 @@ import type { UseQueryResult } from "@tanstack/react-query"
 import enAchievements from "@/locales/en/achievements.json"
 import enApiTokens from "@/locales/en/api-tokens.json"
 
-export function createTestI18n() {
+// Keep this list ordered identically to the `en` imports above: the two
+// drifting apart is this file's obvious failure mode.
+import frCommon from "@/locales/fr/common.json"
+import frAuth from "@/locales/fr/auth.json"
+import frWorkout from "@/locales/fr/workout.json"
+import frHistory from "@/locales/fr/history.json"
+import frBuilder from "@/locales/fr/builder.json"
+import frSettings from "@/locales/fr/settings.json"
+import frAbout from "@/locales/fr/about.json"
+import frExercise from "@/locales/fr/exercise.json"
+import frFeedback from "@/locales/fr/feedback.json"
+import frError from "@/locales/fr/error.json"
+import frOnboarding from "@/locales/fr/onboarding.json"
+import frLibrary from "@/locales/fr/library.json"
+import frGenerator from "@/locales/fr/generator.json"
+import frCreateProgram from "@/locales/fr/create-program.json"
+import frAccount from "@/locales/fr/account.json"
+import frPrivacy from "@/locales/fr/privacy.json"
+import frAdmin from "@/locales/fr/admin.json"
+import frAchievements from "@/locales/fr/achievements.json"
+import frApiTokens from "@/locales/fr/api-tokens.json"
+
+export type TestLocale = "en" | "fr"
+
+const testResources = {
+  en: {
+    common: enCommon,
+    auth: enAuth,
+    workout: enWorkout,
+    history: enHistory,
+    builder: enBuilder,
+    settings: enSettings,
+    about: enAbout,
+    exercise: enExercise,
+    feedback: enFeedback,
+    error: enError,
+    onboarding: enOnboarding,
+    library: enLibrary,
+    generator: enGenerator,
+    "create-program": enCreateProgram,
+    account: enAccount,
+    privacy: enPrivacy,
+    admin: enAdmin,
+    achievements: enAchievements,
+    "api-tokens": enApiTokens,
+  },
+  fr: {
+    common: frCommon,
+    auth: frAuth,
+    workout: frWorkout,
+    history: frHistory,
+    builder: frBuilder,
+    settings: frSettings,
+    about: frAbout,
+    exercise: frExercise,
+    feedback: frFeedback,
+    error: frError,
+    onboarding: frOnboarding,
+    library: frLibrary,
+    generator: frGenerator,
+    "create-program": frCreateProgram,
+    account: frAccount,
+    privacy: frPrivacy,
+    admin: frAdmin,
+    achievements: frAchievements,
+    "api-tokens": frApiTokens,
+  },
+}
+
+export function createTestI18n({ lng = "en" }: { lng?: TestLocale } = {}) {
   const instance = i18n.createInstance()
   instance.use(initReactI18next).init({
-    lng: "en",
-    resources: {
-      en: {
-        common: enCommon,
-        auth: enAuth,
-        workout: enWorkout,
-        history: enHistory,
-        builder: enBuilder,
-        settings: enSettings,
-        about: enAbout,
-        exercise: enExercise,
-        feedback: enFeedback,
-        error: enError,
-        onboarding: enOnboarding,
-        library: enLibrary,
-        generator: enGenerator,
-        "create-program": enCreateProgram,
-        account: enAccount,
-        privacy: enPrivacy,
-        admin: enAdmin,
-        achievements: enAchievements,
-        "api-tokens": enApiTokens,
-      },
-    },
+    lng,
+    resources: testResources,
+    fallbackLng: "en",
+    supportedLngs: ["en", "fr"],
     defaultNS: "common",
     interpolation: { escapeValue: false },
   })
@@ -64,13 +113,14 @@ export function createTestI18n() {
 
 interface ProviderOptions extends Omit<RenderOptions, "wrapper"> {
   initialEntries?: string[]
+  locale?: TestLocale
 }
 
 export function renderWithProviders(
   ui: ReactElement,
   options: ProviderOptions = {},
 ) {
-  const { initialEntries = ["/"], ...renderOptions } = options
+  const { initialEntries = ["/"], locale, ...renderOptions } = options
 
   const store = createStore()
   const queryClient = new QueryClient({
@@ -79,7 +129,7 @@ export function renderWithProviders(
       mutations: { retry: false },
     },
   })
-  const i18nInstance = createTestI18n()
+  const i18nInstance = createTestI18n({ lng: locale })
 
   function Wrapper({ children }: { children: ReactNode }) {
     return (
@@ -106,13 +156,14 @@ export function renderWithProviders(
 interface HookProviderOptions<TProps>
   extends Omit<RenderHookOptions<TProps>, "wrapper"> {
   initialEntries?: string[]
+  locale?: TestLocale
 }
 
 export function renderHookWithProviders<TResult, TProps = undefined>(
   hook: TProps extends undefined ? () => TResult : (props: TProps) => TResult,
   options: HookProviderOptions<TProps> = {} as HookProviderOptions<TProps>,
 ) {
-  const { initialEntries = ["/"], ...hookOptions } = options
+  const { initialEntries = ["/"], locale, ...hookOptions } = options
 
   const store = createStore()
   const queryClient = new QueryClient({
@@ -121,7 +172,7 @@ export function renderHookWithProviders<TResult, TProps = undefined>(
       mutations: { retry: false },
     },
   })
-  const i18nInstance = createTestI18n()
+  const i18nInstance = createTestI18n({ lng: locale })
 
   function Wrapper({ children }: { children: ReactNode }) {
     return (

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -51,8 +51,6 @@ import frAdmin from "@/locales/fr/admin.json"
 import frAchievements from "@/locales/fr/achievements.json"
 import frApiTokens from "@/locales/fr/api-tokens.json"
 
-export type TestLocale = "en" | "fr"
-
 const testResources = {
   en: {
     common: enCommon,
@@ -98,13 +96,15 @@ const testResources = {
   },
 }
 
+export type TestLocale = keyof typeof testResources
+
 export function createTestI18n({ lng = "en" }: { lng?: TestLocale } = {}) {
   const instance = i18n.createInstance()
   instance.use(initReactI18next).init({
     lng,
     resources: testResources,
     fallbackLng: "en",
-    supportedLngs: ["en", "fr"],
+    supportedLngs: Object.keys(testResources),
     defaultNS: "common",
     interpolation: { escapeValue: false },
   })


### PR DESCRIPTION
## What

- `createTestI18n({ lng })` now accepts a locale, defaulting to `"en"`, and loads the **French** namespaces alongside the English ones.
- `renderWithProviders` / `renderHookWithProviders` take a `locale` option that propagates through `I18nextProvider`.
- New `src/test/utils.test.tsx` guards the harness itself, including an exhaustiveness check over every locale file on disk.

## Why

The localized-exercise-catalog epic rests on one promise: **French users see no change**. That promise was structurally unverifiable — `createTestI18n()` was hardcoded to `lng: "en"` and only imported the 19 English namespaces, so no test in the suite could render a French label, let alone assert one. Every subsequent ticket on the display axis could only have tested half the behaviour it introduces, which is why T145 is a hard prerequisite for the rest.

## How

The two import lists are the obvious failure mode of this file — someone adds a namespace, wires up `en`, forgets `fr`, and the FR half of the suite silently tests the English fallback instead. So rather than assert against a hand-maintained list (which just moves the problem), the exhaustiveness test derives the expected namespaces from the locale JSON files via `import.meta.glob` and compares them to what the instance actually loaded. Deleting a single FR import makes it fail **by name**; verified locally.

Two smaller choices worth flagging:

- Added `fallbackLng: "en"` and `supportedLngs` to the test instance. They were absent, so the harness was running i18next's default `fallbackLng: "dev"` and never reproduced production fallback behaviour — which matters here, since the epic's whole resolution chain (`name_en → name → snapshot`) is fallback logic.
- Existing tests stay English by default and **no test file was modified**: 182 files / 1713 tests pass untouched. FR cases get added ticket by ticket.

Part of #422 (T145). Does not close the epic.

Made with [Cursor](https://cursor.com)