### PR TITLE
refactor(i18n): catalog namespace for muscle & equipment labels

### DIFF
--- a/src/components/builder/ExerciseFilterPanel.tsx
+++ b/src/components/builder/ExerciseFilterPanel.tsx
@@ -28,6 +28,7 @@ export function ExerciseFilterPanel({
   onDifficultyChange,
 }: ExerciseFilterPanelProps) {
   const { t } = useTranslation("builder")
+  const { t: tCatalog } = useTranslation("catalog")
 
   const sortedDifficultyLevels = useMemo(
     () =>
@@ -92,7 +93,7 @@ export function ExerciseFilterPanel({
                 : "border-border bg-background text-muted-foreground hover:bg-accent",
             )}
           >
-            {t(`equipment.${eq}`, eq)}
+            {tCatalog(`equipment.${eq}`)}
           </button>
         ))}
       </div>

--- a/src/components/history/balance/BalanceInsights.tsx
+++ b/src/components/history/balance/BalanceInsights.tsx
@@ -9,8 +9,8 @@ import {
 import type { VolumeByMuscleRow } from "@/lib/volumeByMuscleGroup"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
-function muscleLabel(t: TFunction<"history">, m: MuscleTaxonomy) {
-  return t(`balance.muscles.${m}`, { defaultValue: m })
+function muscleLabel(t: TFunction<"catalog">, m: MuscleTaxonomy) {
+  return t(`muscles.${m}`)
 }
 
 interface BalanceInsightsProps {
@@ -25,6 +25,7 @@ export function BalanceInsights({
   muscles,
 }: BalanceInsightsProps) {
   const { t } = useTranslation("history")
+  const { t: tCatalog } = useTranslation("catalog")
 
   const untrainedFocus = new Set(
     pairInsights
@@ -48,19 +49,19 @@ export function BalanceInsights({
           <p key={insight.pairName} className="border-l-2 border-primary/40 pl-3">
             {insight.kind === "untrained"
               ? t("balance.insightUntrained", {
-                  weak: muscleLabel(t, insight.focusMuscle),
-                  strong: muscleLabel(t, insight.otherMuscle),
+                  weak: muscleLabel(tCatalog, insight.focusMuscle),
+                  strong: muscleLabel(tCatalog, insight.otherMuscle),
                 })
               : t("balance.insightSkewed", {
-                  strong: muscleLabel(t, insight.focusMuscle),
-                  weak: muscleLabel(t, insight.otherMuscle),
+                  strong: muscleLabel(tCatalog, insight.focusMuscle),
+                  weak: muscleLabel(tCatalog, insight.otherMuscle),
                 })}
           </p>
         ))}
 
         {extraZeros.map((m) => (
           <p key={m} className="border-l-2 border-muted-foreground/30 pl-3">
-            {t("balance.zeroVolume", { muscle: muscleLabel(t, m) })}
+            {t("balance.zeroVolume", { muscle: muscleLabel(tCatalog, m) })}
           </p>
         ))}
       </CardContent>

--- a/src/components/history/balance/MuscleBreakdownTable.test.tsx
+++ b/src/components/history/balance/MuscleBreakdownTable.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { renderWithProviders } from "@/test/utils"
+import type { VolumeByMuscleRow } from "@/lib/volumeByMuscleGroup"
+import { MuscleBreakdownTable } from "./MuscleBreakdownTable"
+
+const MUSCLES: VolumeByMuscleRow[] = [
+  {
+    muscle_group: "Pectoraux",
+    total_sets: 12,
+    total_volume_kg: 4200,
+    exercise_count: 3,
+  },
+  {
+    muscle_group: "Ischios",
+    total_sets: 6,
+    total_volume_kg: 1800,
+    exercise_count: 2,
+  },
+]
+
+async function renderOpened(locale?: "en" | "fr") {
+  const user = userEvent.setup()
+  renderWithProviders(<MuscleBreakdownTable muscles={MUSCLES} />, { locale })
+  // The breakdown lives in a closed Collapsible; Radix mounts nothing until open.
+  await user.click(screen.getByRole("button"))
+}
+
+describe("MuscleBreakdownTable", () => {
+  it("translates the canonical muscle names in English", async () => {
+    await renderOpened("en")
+
+    expect(screen.getByText("Chest")).toBeInTheDocument()
+    expect(screen.getByText("Hamstrings")).toBeInTheDocument()
+  })
+
+  it("leaves the canonical French names untouched in French", async () => {
+    await renderOpened("fr")
+
+    expect(screen.getByText("Pectoraux")).toBeInTheDocument()
+    expect(screen.getByText("Ischios")).toBeInTheDocument()
+  })
+
+  it("never renders a raw i18n key", async () => {
+    await renderOpened("en")
+
+    // Unanchored on purpose: `t()` echoes back whatever key it was handed, so
+    // a mispointed lookup can surface as `muscles.X` or `balance.muscles.X`.
+    expect(screen.queryByText(/muscles\./)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/history/balance/MuscleBreakdownTable.tsx
+++ b/src/components/history/balance/MuscleBreakdownTable.tsx
@@ -20,8 +20,8 @@ import {
 } from "@/components/ui/table"
 import { cn } from "@/lib/utils"
 
-function muscleLabel(t: TFunction<"history">, key: string) {
-  return t(`balance.muscles.${key}`, { defaultValue: key })
+function muscleLabel(t: TFunction<"catalog">, key: string) {
+  return t(`muscles.${key}`)
 }
 
 interface MuscleBreakdownTableProps {
@@ -34,6 +34,7 @@ export function MuscleBreakdownTable({
   className,
 }: MuscleBreakdownTableProps) {
   const { t, i18n } = useTranslation("history")
+  const { t: tCatalog } = useTranslation("catalog")
   const [open, setOpen] = useState(false)
 
   const totalSets = useMemo(
@@ -104,7 +105,7 @@ export function MuscleBreakdownTable({
             {rows.map((m) => (
               <TableRow key={m.muscle_group}>
                 <TableCell className="font-medium">
-                  {muscleLabel(t, m.muscle_group)}
+                  {muscleLabel(tCatalog, m.muscle_group)}
                 </TableCell>
                 <TableCell className="text-right tabular-nums">
                   {fmtSets.format(m.total_sets)}

--- a/src/lib/catalogTaxonomy.ts
+++ b/src/lib/catalogTaxonomy.ts
@@ -1,0 +1,22 @@
+/**
+ * Canonical equipment slugs as stored in `exercises.equipment`.
+ *
+ * The column is plain `text` with no CHECK constraint, so nothing at the schema
+ * level keeps this list complete — `src/locales/catalogParity.test.ts` ties it
+ * to the `catalog` i18n tables instead. The muscle counterpart already lives in
+ * `MUSCLE_TAXONOMY` (src/lib/trainingBalance.ts) and is not duplicated here.
+ */
+export const EQUIPMENT_TAXONOMY = [
+  "barbell",
+  "dumbbell",
+  "machine",
+  "cable",
+  "bodyweight",
+  "kettlebell",
+  "bench",
+  "ez_bar",
+  "band",
+  "other",
+] as const
+
+export type EquipmentTaxonomy = (typeof EQUIPMENT_TAXONOMY)[number]

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -22,6 +22,7 @@ import enAccount from "@/locales/en/account.json"
 import enPrivacy from "@/locales/en/privacy.json"
 import enAchievements from "@/locales/en/achievements.json"
 import enApiTokens from "@/locales/en/api-tokens.json"
+import enCatalog from "@/locales/en/catalog.json"
 
 import frCommon from "@/locales/fr/common.json"
 import frAuth from "@/locales/fr/auth.json"
@@ -42,6 +43,7 @@ import frAccount from "@/locales/fr/account.json"
 import frPrivacy from "@/locales/fr/privacy.json"
 import frAchievements from "@/locales/fr/achievements.json"
 import frApiTokens from "@/locales/fr/api-tokens.json"
+import frCatalog from "@/locales/fr/catalog.json"
 
 i18n
   .use(LanguageDetector)
@@ -68,6 +70,7 @@ i18n
         privacy: enPrivacy,
         achievements: enAchievements,
         "api-tokens": enApiTokens,
+        catalog: enCatalog,
       },
       fr: {
         common: frCommon,
@@ -89,11 +92,12 @@ i18n
         privacy: frPrivacy,
         achievements: frAchievements,
         "api-tokens": frApiTokens,
+        catalog: frCatalog,
       },
     },
     fallbackLng: "en",
     supportedLngs: ["en", "fr"],
-    ns: ["common", "auth", "workout", "history", "builder", "settings", "about", "exercise", "admin", "feedback", "error", "onboarding", "library", "generator", "create-program", "account", "privacy", "achievements", "api-tokens"],
+    ns: ["common", "auth", "workout", "history", "builder", "settings", "about", "exercise", "admin", "feedback", "error", "onboarding", "library", "generator", "create-program", "account", "privacy", "achievements", "api-tokens", "catalog"],
     defaultNS: "common",
     interpolation: { escapeValue: false },
     detection: {

--- a/src/locales/catalogParity.test.ts
+++ b/src/locales/catalogParity.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest"
+
+import { EQUIPMENT_TAXONOMY } from "@/lib/catalogTaxonomy"
+import { MUSCLE_TAXONOMY } from "@/lib/trainingBalance"
+
+import enCatalog from "./en/catalog.json"
+import frCatalog from "./fr/catalog.json"
+
+type TableName = "muscles" | "equipment"
+
+// Imported, never restated: a copy here would drift from the values the app
+// actually stores, and the test would then certify itself.
+const canonical: Record<TableName, readonly string[]> = {
+  muscles: MUSCLE_TAXONOMY,
+  equipment: EQUIPMENT_TAXONOMY,
+}
+
+const catalogs: Record<string, Record<TableName, Record<string, string>>> = {
+  en: enCatalog,
+  fr: frCatalog,
+}
+
+const cases = Object.keys(catalogs).flatMap((locale) =>
+  (Object.keys(canonical) as TableName[]).map((table) => ({ locale, table })),
+)
+
+describe("catalog taxonomy coverage", () => {
+  it.each(cases)("$locale translates every $table value", ({ locale, table }) => {
+    const translated = catalogs[locale][table]
+    const missing = canonical[table].filter((value) => !(value in translated))
+
+    expect(missing).toEqual([])
+  })
+
+  it.each(cases)("$locale has no orphan $table key", ({ locale, table }) => {
+    const known = new Set(canonical[table])
+    const orphans = Object.keys(catalogs[locale][table]).filter(
+      (key) => !known.has(key),
+    )
+
+    expect(orphans).toEqual([])
+  })
+})

--- a/src/locales/en/builder.json
+++ b/src/locales/en/builder.json
@@ -42,18 +42,6 @@
     "intermediate": "Intermediate",
     "advanced": "Advanced"
   },
-  "equipment": {
-    "barbell": "Barbell",
-    "dumbbell": "Dumbbell",
-    "machine": "Machine",
-    "cable": "Cable",
-    "bodyweight": "Bodyweight",
-    "kettlebell": "Kettlebell",
-    "bench": "Bench",
-    "ez_bar": "EZ Bar",
-    "band": "Band",
-    "other": "Other"
-  },
 
   "activateProgram": "Activate",
   "renameProgram": "Rename",

--- a/src/locales/en/catalog.json
+++ b/src/locales/en/catalog.json
@@ -1,0 +1,29 @@
+{
+  "muscles": {
+    "Pectoraux": "Chest",
+    "Dos": "Back",
+    "Épaules": "Shoulders",
+    "Biceps": "Biceps",
+    "Triceps": "Triceps",
+    "Quadriceps": "Quads",
+    "Ischios": "Hamstrings",
+    "Fessiers": "Glutes",
+    "Adducteurs": "Adductors",
+    "Mollets": "Calves",
+    "Abdos": "Abs",
+    "Trapèzes": "Traps",
+    "Lombaires": "Lower back"
+  },
+  "equipment": {
+    "barbell": "Barbell",
+    "dumbbell": "Dumbbell",
+    "machine": "Machine",
+    "cable": "Cable",
+    "bodyweight": "Bodyweight",
+    "kettlebell": "Kettlebell",
+    "bench": "Bench",
+    "ez_bar": "EZ Bar",
+    "band": "Band",
+    "other": "Other"
+  }
+}

--- a/src/locales/en/history.json
+++ b/src/locales/en/history.json
@@ -93,21 +93,6 @@
     "colMuscle": "Muscle",
     "colSets": "Sets (weighted)",
     "colVolume": "Volume (kg)",
-    "colShare": "Share",
-    "muscles": {
-      "Pectoraux": "Chest",
-      "Dos": "Back",
-      "Épaules": "Shoulders",
-      "Biceps": "Biceps",
-      "Triceps": "Triceps",
-      "Quadriceps": "Quads",
-      "Ischios": "Hamstrings",
-      "Fessiers": "Glutes",
-      "Adducteurs": "Adductors",
-      "Mollets": "Calves",
-      "Abdos": "Abs",
-      "Trapèzes": "Traps",
-      "Lombaires": "Lower back"
-    }
+    "colShare": "Share"
   }
 }

--- a/src/locales/fr/builder.json
+++ b/src/locales/fr/builder.json
@@ -42,18 +42,6 @@
     "intermediate": "Intermédiaire",
     "advanced": "Avancé"
   },
-  "equipment": {
-    "barbell": "Barre",
-    "dumbbell": "Haltères",
-    "machine": "Machine",
-    "cable": "Poulie",
-    "bodyweight": "Poids du corps",
-    "kettlebell": "Kettlebell",
-    "bench": "Banc",
-    "ez_bar": "Barre EZ",
-    "band": "Élastique",
-    "other": "Autre"
-  },
 
   "activateProgram": "Activer",
   "renameProgram": "Renommer",

--- a/src/locales/fr/catalog.json
+++ b/src/locales/fr/catalog.json
@@ -1,0 +1,29 @@
+{
+  "muscles": {
+    "Pectoraux": "Pectoraux",
+    "Dos": "Dos",
+    "Épaules": "Épaules",
+    "Biceps": "Biceps",
+    "Triceps": "Triceps",
+    "Quadriceps": "Quadriceps",
+    "Ischios": "Ischios",
+    "Fessiers": "Fessiers",
+    "Adducteurs": "Adducteurs",
+    "Mollets": "Mollets",
+    "Abdos": "Abdos",
+    "Trapèzes": "Trapèzes",
+    "Lombaires": "Lombaires"
+  },
+  "equipment": {
+    "barbell": "Barre",
+    "dumbbell": "Haltères",
+    "machine": "Machine",
+    "cable": "Poulie",
+    "bodyweight": "Poids du corps",
+    "kettlebell": "Kettlebell",
+    "bench": "Banc",
+    "ez_bar": "Barre EZ",
+    "band": "Élastique",
+    "other": "Autre"
+  }
+}

--- a/src/locales/fr/history.json
+++ b/src/locales/fr/history.json
@@ -93,21 +93,6 @@
     "colMuscle": "Muscle",
     "colSets": "Séries (pondérées)",
     "colVolume": "Volume (kg)",
-    "colShare": "Part",
-    "muscles": {
-      "Pectoraux": "Pectoraux",
-      "Dos": "Dos",
-      "Épaules": "Épaules",
-      "Biceps": "Biceps",
-      "Triceps": "Triceps",
-      "Quadriceps": "Quadriceps",
-      "Ischios": "Ischios",
-      "Fessiers": "Fessiers",
-      "Adducteurs": "Adducteurs",
-      "Mollets": "Mollets",
-      "Abdos": "Abdos",
-      "Trapèzes": "Trapèzes",
-      "Lombaires": "Lombaires"
-    }
+    "colShare": "Part"
   }
 }

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -28,6 +28,7 @@ import enAdmin from "@/locales/en/admin.json"
 import type { UseQueryResult } from "@tanstack/react-query"
 import enAchievements from "@/locales/en/achievements.json"
 import enApiTokens from "@/locales/en/api-tokens.json"
+import enCatalog from "@/locales/en/catalog.json"
 
 // Keep this list ordered identically to the `en` imports above: the two
 // drifting apart is this file's obvious failure mode.
@@ -50,6 +51,7 @@ import frPrivacy from "@/locales/fr/privacy.json"
 import frAdmin from "@/locales/fr/admin.json"
 import frAchievements from "@/locales/fr/achievements.json"
 import frApiTokens from "@/locales/fr/api-tokens.json"
+import frCatalog from "@/locales/fr/catalog.json"
 
 const testResources = {
   en: {
@@ -72,6 +74,7 @@ const testResources = {
     admin: enAdmin,
     achievements: enAchievements,
     "api-tokens": enApiTokens,
+    catalog: enCatalog,
   },
   fr: {
     common: frCommon,
@@ -93,6 +96,7 @@ const testResources = {
     admin: frAdmin,
     achievements: frAchievements,
     "api-tokens": frApiTokens,
+    catalog: frCatalog,
   },
 }
 


### PR DESCRIPTION
## What

- New `catalog` i18n namespace (`src/locales/{en,fr}/catalog.json`) holding `muscles` (13) and `equipment` (10) — moved verbatim from `history:balance.muscles` and `builder:equipment`, which are deleted.
- `defaultValue: key` removed from the three consumers (`MuscleBreakdownTable`, `BalanceInsights`, `ExerciseFilterPanel`); an exhaustiveness test takes over.
- `EQUIPMENT_TAXONOMY` added in `src/lib/catalogTaxonomy.ts` — the 10 slugs existed nowhere in code.
- Two new test files: `catalogParity.test.ts` (taxonomy coverage) and `MuscleBreakdownTable.test.tsx` (renders in both locales).

## Why

Muscle labels were `history`-scoped **by accident**, while the same 13 labels are needed in the builder, the library and the session — T151 can't reach them where they were. `catalog` holds business taxonomy; `history` and `builder` hold UI chrome.

The `defaultValue: key` removal is the substantive part. Because the muscle keys *are* the canonical French strings, a missing English translation rendered the French string and looked perfectly fine — to a French-speaking reviewer. That silent fallback is the exact failure mode this epic exists to fix, so it can't be left in the mechanism meant to fix it.

## How

Both taxonomies were **verified against production before writing**, not inferred from the i18n tables: `select distinct` returns exactly 13 `muscle_group` and 10 `equipment` values, with no orphans and no gaps either way. Worth noting that neither column has a `CHECK` constraint, so nothing at the schema level keeps these lists complete — which is precisely why the test exists rather than the type system.

`MUSCLE_TAXONOMY` is imported, never restated; a copy would drift from what the app stores and the test would end up certifying itself.

`MuscleBreakdownTable` had **no test at all**, so dropping its fallback would have shipped unverified. It now renders in both locales — the first real use of the T145 harness, and what actually discharges the epic's "nothing changes for French users" guarantee.

Every guard was verified by mutation rather than observed green:

| Mutation | Caught by |
|---|---|
| remove `Ischios` from `fr/catalog.json` | taxonomy coverage **and** the generic en/fr parity test from T145 |
| add an orphan `smith_machine` key | orphan check **and** the parity test |
| repoint `muscleLabel` at the deleted key | all 3 component tests |

The double catch is a bonus from T145: any new namespace is policed for en/fr parity with no extra work.

**Not closing #422** — that's the epic, with nine tickets left. Part of #422, ticket T146. Existing `ExerciseFilterPanel` tests already asserted the English equipment labels and still pass, which independently proves that half of the move.

Made with [Cursor](https://cursor.com)