### PR TITLE
feat(i18n): catalogLabels lib + useCatalogLabels hook

### DIFF
--- a/src/hooks/useCatalogLabels.test.tsx
+++ b/src/hooks/useCatalogLabels.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+
+import { renderHookWithProviders } from "@/test/utils"
+import { useCatalogLabels } from "./useCatalogLabels"
+
+const BENCH = {
+  exercise: { name: "Développé couché", name_en: "Bench Press" },
+  name_snapshot: "Développé couché",
+}
+
+function labels(locale: "en" | "fr") {
+  return renderHookWithProviders(() => useCatalogLabels(), { locale }).result
+    .current
+}
+
+describe("useCatalogLabels", () => {
+  it("resolves the same row to two different names across locales", () => {
+    expect(labels("en").exerciseName(BENCH)).toBe("Bench Press")
+    expect(labels("fr").exerciseName(BENCH)).toBe("Développé couché")
+  })
+
+  it("translates a canonical muscle name for an English reader", () => {
+    expect(labels("en").muscleLabel("Ischios")).toBe("Hamstrings")
+  })
+
+  it("leaves a canonical muscle name untouched for a French reader", () => {
+    expect(labels("fr").muscleLabel("Ischios")).toBe("Ischios")
+  })
+
+  it("renders an out-of-taxonomy snapshot value raw rather than as a key", () => {
+    const muscleLabel = labels("en").muscleLabel
+
+    expect(muscleLabel("Deltoïdes post.")).toBe("Deltoïdes post.")
+    expect(muscleLabel("Ischios / Bas du dos")).toBe("Ischios / Bas du dos")
+  })
+
+  it("translates equipment slugs and passes unknown ones through", () => {
+    expect(labels("en").equipmentLabel("ez_bar")).toBe("EZ Bar")
+    expect(labels("fr").equipmentLabel("ez_bar")).toBe("Barre EZ")
+    expect(labels("en").equipmentLabel("smith_machine")).toBe("smith_machine")
+  })
+
+  it("never returns null for a missing value", () => {
+    const { muscleLabel, equipmentLabel } = labels("en")
+
+    expect(muscleLabel(null)).toBe("")
+    expect(equipmentLabel(undefined)).toBe("")
+  })
+})

--- a/src/hooks/useCatalogLabels.ts
+++ b/src/hooks/useCatalogLabels.ts
@@ -1,0 +1,37 @@
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+
+import {
+  equipmentLabelKey,
+  muscleLabelKey,
+  resolveExerciseName,
+  type CatalogNameSource,
+} from "@/lib/catalogLabels"
+
+/**
+ * Binds the pure resolution rule (ADR 0010) to the reader's current locale.
+ * Reads only what is already in the render tree — no query, no network.
+ */
+export function useCatalogLabels() {
+  const { t, i18n } = useTranslation("catalog")
+  const { language } = i18n
+
+  return useMemo(
+    () => ({
+      exerciseName: (source: CatalogNameSource) =>
+        resolveExerciseName(source, language),
+
+      /** Falls back to the raw value: snapshots hold pre-taxonomy muscle names. */
+      muscleLabel: (value: string | null | undefined) => {
+        const key = muscleLabelKey(value)
+        return key ? t(key) : (value ?? "")
+      },
+
+      equipmentLabel: (slug: string | null | undefined) => {
+        const key = equipmentLabelKey(slug)
+        return key ? t(key) : (slug ?? "")
+      },
+    }),
+    [t, language],
+  )
+}

--- a/src/lib/catalogLabels.test.ts
+++ b/src/lib/catalogLabels.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest"
+
+import source from "./catalogLabels.ts?raw"
+import {
+  equipmentLabelKey,
+  isEnglish,
+  muscleLabelKey,
+  resolveExerciseName,
+  type CatalogNameSource,
+} from "./catalogLabels"
+
+const row = (overrides: Partial<CatalogNameSource> = {}): CatalogNameSource => ({
+  exercise: { name: "Développé couché", name_en: "Bench Press" },
+  name_snapshot: "Développé couché (snapshot)",
+  ...overrides,
+})
+
+describe("purity", () => {
+  // The whole point of splitting the rule out of the hook is that it resolves
+  // labels without a render. An import of react or i18next here would undo that
+  // silently, so assert on the source rather than trust the convention.
+  it.each(["react", "i18next", "@/lib/supabase"])(
+    "does not import %s",
+    (module) => {
+      expect(source).not.toMatch(
+        new RegExp(`from\\s+["']${module.replace("/", "\\/")}`),
+      )
+    },
+  )
+})
+
+describe("resolveExerciseName", () => {
+  it("prefers name_en for an English reader", () => {
+    expect(resolveExerciseName(row(), "en")).toBe("Bench Press")
+  })
+
+  it("never returns name_en to a French reader", () => {
+    expect(resolveExerciseName(row(), "fr")).toBe("Développé couché")
+  })
+
+  it.each(["", "   ", null, undefined])(
+    "falls back to name when name_en is %o",
+    (name_en) => {
+      const source = row({ exercise: { name: "Développé couché", name_en } })
+
+      expect(resolveExerciseName(source, "en")).toBe("Développé couché")
+    },
+  )
+
+  it("falls back to the snapshot when the catalog row is absent", () => {
+    const source = row({ exercise: null })
+
+    expect(resolveExerciseName(source, "en")).toBe("Développé couché (snapshot)")
+  })
+
+  it("falls back to the snapshot when the catalog row carries no name", () => {
+    const source = row({ exercise: { name: "  ", name_en: null } })
+
+    expect(resolveExerciseName(source, "en")).toBe("Développé couché (snapshot)")
+  })
+
+  it("reads the set_log snapshot column too", () => {
+    const source: CatalogNameSource = {
+      exercise: null,
+      exercise_name_snapshot: "Squat (log)",
+    }
+
+    expect(resolveExerciseName(source, "fr")).toBe("Squat (log)")
+  })
+
+  it("returns an empty string rather than throwing when nothing resolves", () => {
+    expect(resolveExerciseName({}, "en")).toBe("")
+  })
+
+  it("trims the value it returns", () => {
+    const source = row({ exercise: { name: null, name_en: "  Bench Press  " } })
+
+    expect(resolveExerciseName(source, "en")).toBe("Bench Press")
+  })
+
+  it("treats a region-tagged English locale as English", () => {
+    expect(resolveExerciseName(row(), "en-US")).toBe("Bench Press")
+  })
+})
+
+describe("isEnglish", () => {
+  it.each([
+    ["en", true],
+    ["en-US", true],
+    ["EN", true],
+    ["fr", false],
+    ["fr-FR", false],
+    [null, false],
+    [undefined, false],
+  ])("%o → %s", (locale, expected) => {
+    expect(isEnglish(locale)).toBe(expected)
+  })
+})
+
+describe("muscleLabelKey", () => {
+  it("keys a canonical muscle name", () => {
+    expect(muscleLabelKey("Pectoraux")).toBe("muscles.Pectoraux")
+  })
+
+  it.each(["Deltoïdes post.", "Ischios / Bas du dos", "", null, undefined])(
+    "returns null for %o so the caller can render it raw",
+    (value) => {
+      expect(muscleLabelKey(value)).toBeNull()
+    },
+  )
+})
+
+describe("equipmentLabelKey", () => {
+  it("keys a known slug", () => {
+    expect(equipmentLabelKey("ez_bar")).toBe("equipment.ez_bar")
+  })
+
+  it.each(["smith_machine", "", null, undefined])(
+    "returns null for %o",
+    (slug) => {
+      expect(equipmentLabelKey(slug)).toBeNull()
+    },
+  )
+})

--- a/src/lib/catalogLabels.ts
+++ b/src/lib/catalogLabels.ts
@@ -1,0 +1,69 @@
+/**
+ * Display-time resolution of catalog labels (ADR 0010).
+ *
+ * The rule lives here once, as pure functions taking the locale as a parameter:
+ * no React, no i18next, so it can be tested in both locales without rendering.
+ * `useCatalogLabels` binds it to the current language.
+ */
+import { EQUIPMENT_TAXONOMY } from "@/lib/catalogTaxonomy"
+import { MUSCLE_TAXONOMY } from "@/lib/trainingBalance"
+
+/**
+ * Loose on purpose: serves an embedded `workout_exercises` row (`name_snapshot`)
+ * and an enriched `set_log` (`exercise_name_snapshot`) without a wrapper.
+ */
+export interface CatalogNameSource {
+  exercise?: { name?: string | null; name_en?: string | null } | null
+  name_snapshot?: string | null
+  exercise_name_snapshot?: string | null
+}
+
+const clean = (value: string | null | undefined): string | null => {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+/**
+ * `i18n.language` can carry a region ("en-US") when it comes from the browser
+ * detector, so match on the base subtag rather than on equality.
+ */
+export const isEnglish = (locale: string | null | undefined): boolean =>
+  Boolean(locale?.toLowerCase().startsWith("en"))
+
+/**
+ * `name_en` (English readers only) → `name` → **Catalog Snapshot**.
+ *
+ * The snapshot is a last resort for when the catalog row is missing from the
+ * query payload — never a display source, and never localized.
+ */
+export function resolveExerciseName(
+  source: CatalogNameSource,
+  locale: string,
+): string {
+  const english = isEnglish(locale) ? clean(source.exercise?.name_en) : null
+
+  return (
+    english ??
+    clean(source.exercise?.name) ??
+    clean(source.name_snapshot) ??
+    clean(source.exercise_name_snapshot) ??
+    ""
+  )
+}
+
+const MUSCLES: ReadonlySet<string> = new Set(MUSCLE_TAXONOMY)
+const EQUIPMENT: ReadonlySet<string> = new Set(EQUIPMENT_TAXONOMY)
+
+/**
+ * i18n key for a canonical muscle name, or `null` when the value sits outside
+ * the taxonomy — which happens: `workout_exercises.muscle_snapshot` froze
+ * pre-taxonomy values such as "Deltoïdes post." that no key will ever match.
+ * Callers render those raw.
+ */
+export const muscleLabelKey = (value: string | null | undefined): string | null =>
+  value && MUSCLES.has(value) ? `muscles.${value}` : null
+
+/** i18n key for an equipment slug, or `null` when the slug is unknown. */
+export const equipmentLabelKey = (
+  slug: string | null | undefined,
+): string | null => (slug && EQUIPMENT.has(slug) ? `equipment.${slug}` : null)


### PR DESCRIPTION
## What

- `src/lib/catalogLabels.ts` — pure: `resolveExerciseName(source, locale)`, `muscleLabelKey`, `equipmentLabelKey`, `isEnglish`.
- `src/hooks/useCatalogLabels.ts` — binds the rule to `i18n.language`, returns `{ exerciseName, muscleLabel, equipmentLabel }`.
- 39 tests across both files, run in **both locales**.

No surface is wired in this PR. T147 ships the tool and its proof; T149/T150/T151 consume it.

## Why

The resolution rule from ADR 0010 needs to exist exactly once. PR #416 was rejected partly because it patched two of six write paths — the same rule restated per call site is the mechanism that produces mixed-language output. Splitting the rule from the render also makes it testable in both locales without mounting anything.

## How

`resolveExerciseName` applies `name_en` → `name` → **Catalog Snapshot**, and `name_en` is only ever considered for an English reader. A French reader can never be served `name_en` — that is precisely the regression #416 would have shipped.

Two decisions worth a reviewer's attention:

**Locale matching is on the base subtag, not equality.** `i18n.language` carries a region (`"en-US"`) when it comes from the browser detector rather than from `localStorage`. An `locale === "en"` check would have quietly served French names to English readers — this epic's own bug, reintroduced one layer down. There is a test for `"en-US"`.

**`muscleLabelKey` returns `null` outside the taxonomy** so callers render the raw value. This isn't defensive padding — the ticket claimed such values exist and I checked where:

```sql
select 'workout_exercises.muscle_snapshot', muscle_snapshot, count(*) ...
-- "Deltoïdes post."      → 2 rows
-- "Ischios / Bas du dos" → 1 row
```

They live in **frozen snapshots**, not in `exercises.muscle_group` (which is exactly 13 clean values) and not in `secondary_muscles`. That's the sensible place for them: a snapshot is where a value survives a taxonomy being tightened. Note also that `"Deltoïdes post."` contains a dot — i18next's key separator — so it could never have resolved to a key even if one existed. This also confirms retroactively that T146's removal of `defaultValue` was safe: its consumers read the catalog aggregate, never snapshots.

**Purity is asserted, not assumed.** The acceptance criterion "imports neither React nor i18next" is checked against the file's own source via `?raw`, because violating it would silently undo the split that makes the rule testable without a render.

Every guard verified by mutation rather than observed green:

| Mutation | Caught by |
|---|---|
| `import { useMemo } from "react"` into the lib | purity guard |
| drop the `isEnglish` check | the lib test **and** the hook test |

**Not closing #422** — that's the epic, eight tickets left. Part of #422, ticket T147.

Made with [Cursor](https://cursor.com)