### PR TITLE
feat(data): catalog embeds on lagging queries

### DIFF
--- a/src/components/library/ProgramDetailSheet.tsx
+++ b/src/components/library/ProgramDetailSheet.tsx
@@ -10,11 +10,20 @@ import {
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/supabase"
+import { LABEL_EXERCISE_SELECT } from "@/lib/exerciseSelects"
 import { DayCard } from "@/components/library/DayCard"
 import type { Program } from "@/types/onboarding"
-import type { WorkoutDay, WorkoutExercise } from "@/types/database"
+import type {
+  ExerciseLabelFields,
+  WorkoutDay,
+  WorkoutExercise,
+} from "@/types/database"
 
-type DayWithExercises = WorkoutDay & { workout_exercises: WorkoutExercise[] }
+type DayWithExercises = WorkoutDay & {
+  workout_exercises: (WorkoutExercise & {
+    exercise: ExerciseLabelFields | null
+  })[]
+}
 
 interface ProgramDetailSheetProps {
   program: Program | null
@@ -32,7 +41,9 @@ export function ProgramDetailSheet({ program, open, onOpenChange, onEdit }: Prog
     queryFn: async () => {
       const { data, error } = await supabase
         .from("workout_days")
-        .select("*, workout_exercises(*)")
+        .select(
+          `*, workout_exercises(*, exercise:exercises(${LABEL_EXERCISE_SELECT}))`,
+        )
         .eq("program_id", program!.id)
         .order("sort_order")
 

--- a/src/hooks/useExerciseHistory.test.ts
+++ b/src/hooks/useExerciseHistory.test.ts
@@ -1,0 +1,134 @@
+import { vi, describe, it, expect, beforeEach } from "vitest"
+import { waitFor, act } from "@testing-library/react"
+import { renderHookWithProviders } from "@/test/utils"
+import { authAtom } from "@/store/atoms"
+import { useExerciseHistory } from "./useExerciseHistory"
+
+const selectFn = vi.fn()
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: vi.fn(() => ({ select: selectFn })) },
+}))
+
+const fetchExercisesByIds = vi.hoisted(() => vi.fn())
+vi.mock("@/lib/fetchExercisesByIds", () => ({ fetchExercisesByIds }))
+
+const catalogRow = (id: string, name: string, name_en: string) => ({
+  id,
+  name,
+  name_en,
+  muscle_group: "Pectoraux",
+  equipment: "barbell",
+  emoji: "💪",
+})
+
+function mockLogs(rows: { exercise_id: string; exercise_name_snapshot: string }[]) {
+  selectFn.mockResolvedValue({ data: rows, error: null })
+}
+
+function render() {
+  const rendered = renderHookWithProviders(() => useExerciseHistory())
+  act(() => {
+    rendered.store.set(authAtom, { id: "user-1" } as never)
+  })
+  return rendered
+}
+
+describe("useExerciseHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fetchExercisesByIds.mockResolvedValue([])
+  })
+
+  it("does not embed the catalog — it would be paid on every set_log row", async () => {
+    mockLogs([{ exercise_id: "a", exercise_name_snapshot: "Squat" }])
+
+    const { result } = render()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(selectFn).toHaveBeenCalledWith("exercise_id, exercise_name_snapshot")
+    expect(selectFn.mock.calls[0][0]).not.toContain("exercises(")
+  })
+
+  it("looks the catalog up once for the distinct ids only", async () => {
+    mockLogs([
+      { exercise_id: "a", exercise_name_snapshot: "Squat" },
+      { exercise_id: "a", exercise_name_snapshot: "Squat" },
+      { exercise_id: "b", exercise_name_snapshot: "Bench" },
+    ])
+
+    const { result } = render()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(fetchExercisesByIds).toHaveBeenCalledTimes(1)
+    expect(fetchExercisesByIds.mock.calls[0][0]).toEqual(["a", "b"])
+    expect(fetchExercisesByIds.mock.calls[0][1]).not.toContain("*")
+  })
+
+  it("attaches the catalog row so T150 can localize the label", async () => {
+    mockLogs([{ exercise_id: "a", exercise_name_snapshot: "Développé couché" }])
+    fetchExercisesByIds.mockResolvedValue([
+      catalogRow("a", "Développé couché", "Bench Press"),
+    ])
+
+    const { result } = render()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual([
+      {
+        id: "a",
+        name: "Développé couché",
+        exercise: catalogRow("a", "Développé couché", "Bench Press"),
+      },
+    ])
+  })
+
+  it("keeps the option with a null embed when the catalog omits the id", async () => {
+    mockLogs([{ exercise_id: "gone", exercise_name_snapshot: "Vieux mouvement" }])
+
+    const { result } = render()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual([
+      { id: "gone", name: "Vieux mouvement", exercise: null },
+    ])
+  })
+
+  it("keeps the first snapshot seen for a renamed exercise", async () => {
+    mockLogs([
+      { exercise_id: "a", exercise_name_snapshot: "Nouveau nom" },
+      { exercise_id: "a", exercise_name_snapshot: "Ancien nom" },
+    ])
+
+    const { result } = render()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual([
+      { id: "a", name: "Nouveau nom", exercise: null },
+    ])
+  })
+
+  it("sorts options by name", async () => {
+    mockLogs([
+      { exercise_id: "c", exercise_name_snapshot: "Squat" },
+      { exercise_id: "a", exercise_name_snapshot: "Abdos" },
+      { exercise_id: "b", exercise_name_snapshot: "Développé" },
+    ])
+
+    const { result } = render()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.map((o) => o.name)).toEqual([
+      "Abdos",
+      "Développé",
+      "Squat",
+    ])
+  })
+
+  it("stays idle without auth", () => {
+    const { result } = renderHookWithProviders(() => useExerciseHistory())
+
+    expect(result.current.fetchStatus).toBe("idle")
+    expect(selectFn).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useExerciseHistory.ts
+++ b/src/hooks/useExerciseHistory.ts
@@ -2,12 +2,31 @@ import { useQuery } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
 import { supabase } from "@/lib/supabase"
 import { authAtom } from "@/store/atoms"
+import { LABEL_EXERCISE_SELECT } from "@/lib/exerciseSelects"
+import { fetchExercisesByIds } from "@/lib/fetchExercisesByIds"
+import type { ExerciseLabelFields } from "@/types/database"
 
 export interface ExerciseOption {
   id: string
+  /**
+   * Snapshot name, kept as the display value here. T150 resolves the localized
+   * label from `exercise` and sorts on it.
+   */
   name: string
+  /** Catalog row for the localized label; null when it isn't readable. */
+  exercise: ExerciseLabelFields | null
 }
 
+/**
+ * Options for the history exercise picker.
+ *
+ * Resolved in two steps rather than with an `exercise:exercises(...)` embed:
+ * this query scans every `set_log` the user owns, so an embed would pay the
+ * catalog columns thousands of times over to describe a list bounded by the
+ * catalog itself (~140 distinct exercises for 3.3k logs today). The second
+ * request is off the session path, and the snapshot stays as the fallback for
+ * ids the catalog lookup doesn't return.
+ */
 export function useExerciseHistory() {
   const user = useAtomValue(authAtom)
 
@@ -19,18 +38,31 @@ export function useExerciseHistory() {
         .select("exercise_id, exercise_name_snapshot")
 
       if (error) throw error
-      if (!data) return []
 
-      const seen = new Map<string, string>()
-      for (const row of data) {
-        if (!seen.has(row.exercise_id)) {
-          seen.set(row.exercise_id, row.exercise_name_snapshot)
-        }
-      }
+      const rows = data ?? []
+      const ids = [...new Set(rows.map((row) => row.exercise_id))]
 
-      return Array.from(seen, ([id, name]) => ({ id, name })).sort((a, b) =>
-        a.name.localeCompare(b.name),
+      // `new Map` keeps the last entry for a duplicate key; reverse so the
+      // first snapshot encountered wins, as it did before.
+      const snapshotById = new Map(
+        rows
+          .map((row) => [row.exercise_id, row.exercise_name_snapshot] as const)
+          .reverse(),
       )
+
+      const catalog = await fetchExercisesByIds<ExerciseLabelFields>(
+        ids,
+        LABEL_EXERCISE_SELECT,
+      )
+      const catalogById = new Map(catalog.map((row) => [row.id, row] as const))
+
+      return ids
+        .map((id) => ({
+          id,
+          name: snapshotById.get(id) ?? "",
+          exercise: catalogById.get(id) ?? null,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name))
     },
     enabled: !!user,
   })

--- a/src/hooks/useSavedWorkouts.ts
+++ b/src/hooks/useSavedWorkouts.ts
@@ -2,13 +2,18 @@ import { useQuery } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
 import { supabase } from "@/lib/supabase"
 import { authAtom } from "@/store/atoms"
-import type { WorkoutDay, WorkoutExercise } from "@/types/database"
+import { LABEL_EXERCISE_SELECT } from "@/lib/exerciseSelects"
+import type {
+  ExerciseLabelFields,
+  WorkoutDay,
+  WorkoutExercise,
+} from "@/types/database"
 
 export interface SavedWorkout extends WorkoutDay {
-  workout_exercises: Pick<
+  workout_exercises: (Pick<
     WorkoutExercise,
     "id" | "name_snapshot" | "emoji_snapshot" | "sets" | "reps" | "muscle_snapshot"
-  >[]
+  > & { exercise: ExerciseLabelFields | null })[]
 }
 
 export function useSavedWorkouts() {
@@ -20,7 +25,7 @@ export function useSavedWorkouts() {
       const { data, error } = await supabase
         .from("workout_days")
         .select(
-          "*, workout_exercises(id, name_snapshot, emoji_snapshot, sets, reps, muscle_snapshot)",
+          `*, workout_exercises(id, name_snapshot, emoji_snapshot, sets, reps, muscle_snapshot, exercise:exercises(${LABEL_EXERCISE_SELECT}))`,
         )
         .not("saved_at", "is", null)
         .is("program_id", null)

--- a/src/hooks/useSessionSetLogs.ts
+++ b/src/hooks/useSessionSetLogs.ts
@@ -1,20 +1,21 @@
 import { useQuery } from "@tanstack/react-query"
 import { supabase } from "@/lib/supabase"
-import type { SetLog } from "@/types/database"
+import { LABEL_EXERCISE_SELECT } from "@/lib/exerciseSelects"
+import type { SetLogWithExercise } from "@/types/database"
 
 export function useSessionSetLogs(sessionId: string | null) {
-  return useQuery<SetLog[]>({
+  return useQuery<SetLogWithExercise[]>({
     queryKey: ["session-set-logs", sessionId],
     queryFn: async () => {
       const { data, error } = await supabase
         .from("set_logs")
-        .select("*")
+        .select(`*, exercise:exercises(${LABEL_EXERCISE_SELECT})`)
         .eq("session_id", sessionId!)
         .order("exercise_name_snapshot")
         .order("set_number")
 
       if (error) throw error
-      return (data as SetLog[]) ?? []
+      return (data as SetLogWithExercise[]) ?? []
     },
     enabled: !!sessionId,
   })

--- a/src/lib/exerciseSelects.test.ts
+++ b/src/lib/exerciseSelects.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  FULL_EXERCISE_SELECT,
+  LABEL_EXERCISE_SELECT,
+  SLIM_EXERCISE_SELECT,
+} from "./exerciseSelects"
+
+const columns = (select: string) => select.split(",").map((c) => c.trim())
+
+const SELECTS = {
+  SLIM_EXERCISE_SELECT,
+  FULL_EXERCISE_SELECT,
+  LABEL_EXERCISE_SELECT,
+}
+
+describe("exercise selects", () => {
+  it.each(Object.entries(SELECTS))(
+    "%s enumerates its columns instead of using *",
+    (_name, select) => {
+      expect(columns(select)).not.toContain("*")
+    },
+  )
+
+  it.each(Object.entries(SELECTS))(
+    "%s carries both name columns, so a label can be localized",
+    (_name, select) => {
+      expect(columns(select)).toEqual(
+        expect.arrayContaining(["name", "name_en"]),
+      )
+    },
+  )
+
+  it("keeps the label projection a strict subset of the full one", () => {
+    const full = new Set(columns(FULL_EXERCISE_SELECT))
+    const extra = columns(LABEL_EXERCISE_SELECT).filter((c) => !full.has(c))
+
+    expect(extra).toEqual([])
+  })
+
+  it("keeps the label projection minimal — labels only, no media or metadata", () => {
+    expect(columns(LABEL_EXERCISE_SELECT).sort()).toEqual([
+      "emoji",
+      "equipment",
+      "id",
+      "muscle_group",
+      "name",
+      "name_en",
+    ])
+  })
+
+  it("carries the taxonomy columns useCatalogLabels translates", () => {
+    expect(columns(LABEL_EXERCISE_SELECT)).toEqual(
+      expect.arrayContaining(["muscle_group", "equipment"]),
+    )
+  })
+})

--- a/src/lib/exerciseSelects.ts
+++ b/src/lib/exerciseSelects.ts
@@ -35,3 +35,15 @@ export const SLIM_EXERCISE_SELECT =
  */
 export const FULL_EXERCISE_SELECT =
   "id, name, name_en, emoji, muscle_group, equipment, image_url, difficulty_level, is_system, measurement_type, default_duration_seconds, secondary_muscles, instructions, youtube_url, source, reviewed_at, reviewed_by, created_at"
+
+/**
+ * Smallest projection that can render a localized label (ADR 0010): the name
+ * pair plus the two taxonomy values `useCatalogLabels` translates.
+ *
+ * For embeds on rows that only need a *label*, not the exercise itself — set
+ * logs, saved-workout lists, program detail. These are long lists, so the cost
+ * of every extra column is paid per row; prefer this over FULL unless the
+ * consumer genuinely reads instructions, media or admin metadata.
+ */
+export const LABEL_EXERCISE_SELECT =
+  "id, name, name_en, muscle_group, equipment, emoji"

--- a/src/lib/fetchExercisesByIds.ts
+++ b/src/lib/fetchExercisesByIds.ts
@@ -4,7 +4,14 @@ import type { Exercise } from "@/types/database"
 /** PostgREST URL limits — keep chunks conservative. */
 export const FETCH_EXERCISES_BY_IDS_CHUNK_SIZE = 100
 
-export async function fetchExercisesByIds(ids: string[]): Promise<Exercise[]> {
+/**
+ * Chunked catalog lookup by id. `select` narrows the projection for callers that
+ * only need a label rather than the whole row — see `LABEL_EXERCISE_SELECT`.
+ */
+export async function fetchExercisesByIds<T = Exercise>(
+  ids: string[],
+  select: string = "*",
+): Promise<T[]> {
   const unique = [...new Set(ids.filter(Boolean))]
   if (unique.length === 0) return []
 
@@ -22,12 +29,12 @@ export async function fetchExercisesByIds(ids: string[]): Promise<Exercise[]> {
     chunks.map(async (chunk) => {
       const { data, error } = await supabase
         .from("exercises")
-        .select("*")
+        .select(select)
         .in("id", chunk)
       if (error) throw error
       return data ?? []
     }),
   )
 
-  return rows.flat() as Exercise[]
+  return rows.flat() as T[]
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -28,6 +28,16 @@ export interface Exercise {
   default_duration_seconds?: number | null
 }
 
+/**
+ * Shape returned by `LABEL_EXERCISE_SELECT` — the columns needed to render a
+ * localized label, nothing more. Embeds are nullable: the catalog row can be
+ * filtered by RLS or simply absent from the payload.
+ */
+export type ExerciseLabelFields = Pick<
+  Exercise,
+  "id" | "name" | "name_en" | "muscle_group" | "equipment" | "emoji"
+>
+
 export interface WorkoutDay {
   id: string
   user_id: string
@@ -179,6 +189,11 @@ export interface Cycle {
   user_id: string
   started_at: string
   finished_at: string | null
+}
+
+/** `set_logs` row carrying the joined catalog label fields (T148). */
+export interface SetLogWithExercise extends SetLog {
+  exercise: ExerciseLabelFields | null
 }
 
 export interface SetLog {


### PR DESCRIPTION
## What

Four queries carried `exercise_id` but not the `exercises` row, so they had nothing to localize from. Three now embed it; the fourth resolves by id instead, for reasons below.

- New `LABEL_EXERCISE_SELECT` in `exerciseSelects.ts` — `id, name, name_en, muscle_group, equipment, emoji`.
- Embeds on `useSessionSetLogs`, `useSavedWorkouts` (nested), `ProgramDetailSheet`.
- `useExerciseHistory` resolves the catalog by id via `fetchExercisesByIds`.
- Types carry the embed's nullability (`ExerciseLabelFields`, `SetLogWithExercise`).

**No rendered label changes in this PR.** Infrastructure only, isolated so a payload/cache/type regression is diagnosable on its own. T149/T150/T151 consume it.

## Why

The projection is the name pair plus the two taxonomy values `useCatalogLabels` translates — nothing else. These are long lists, and every embedded column is paid *per row*; that's the reason `exerciseSelects.ts` already refuses `*`. Shared rather than copied into three call sites.

The embed is nullable in the types because the catalog row can be RLS-filtered or simply absent from the payload — precisely what the Catalog Snapshot fallback in `resolveExerciseName` (#427) exists for.

## How — and where this departs from the ticket

T148 prescribed an embed on all four queries. I followed it on three and not on `useExerciseHistory`, because the ticket's own reasoning stops applying there.

The other three are bounded by a session or a program. That one is not — it scans **every** `set_log` the user owns to build a list bounded by the catalog:

```sql
select count(*), count(distinct exercise_id) from set_logs;
-- 3275 rows  →  140 distinct exercises
```

It already reads 23x more rows than it produces options, and it grows with training history while the useful output stays capped by the catalog. Six embedded columns there would quadruple that payload to describe 140 entities.

So the first query is **left untouched** and the distinct ids go through `fetchExercisesByIds`, which already chunks and is already tested. Trade-off: one extra request, off the session path, so Epic Brief story 9 ("zéro requête supplémentaire en séance") isn't in play. Leaving the first query intact also preserves `exercise_name_snapshot` as the fallback for ids the lookup doesn't return — an embed-free rewrite would have dropped those options from the picker instead of degrading gracefully.

`fetchExercisesByIds` gained an optional projection, defaulting to today's `*`, so its two existing callers are untouched.

`ExerciseOption` gains the catalog row but still *displays* the snapshot name. T150 flips the resolution and the sort.

## Guards

| Guard | Verified by mutation |
|---|---|
| label projection ⊂ full projection | — invariant test, catches drift PostgREST would only find at runtime |
| picker sends no embed, asks only for distinct ids | assertion on the select string |
| first snapshot wins for a renamed exercise | dropping `.reverse()` fails the test |

1789 tests pass, `tsc` clean, no new lint. **Not closing #422** — part of it, ticket T148.

Made with [Cursor](https://cursor.com)