### PR TITLE
feat(i18n): localized exercise names on session, builder & block surfaces

### DIFF
--- a/.cursor/rules/build-sandbox-caveat.mdc
+++ b/.cursor/rules/build-sandbox-caveat.mdc
@@ -19,4 +19,20 @@ This is **not a project bug**. workbox-build uses `worker_threads` via terser, a
 
 - Always run `npm run build` with `required_permissions: ["all"]`.
 - **Do NOT** check out `main` to verify — the error is identical on every branch.
-- For lightweight type-checking, prefer `npx tsc --noEmit` (works in the sandbox).
+- For type-checking without the bundler, run `npx tsc -b` (what CI's `type-check`
+  job runs) or `npx tsc -p tsconfig.app.json --noEmit`. Both work in the sandbox.
+
+## Never use `npx tsc --noEmit`
+
+It **always passes and verifies nothing.** The root `tsconfig.json` is a
+solution file — `"files": []` plus project references — so the command loads zero
+files and exits 0 on a codebase that cannot compile. It is worse than no check,
+because it reads like a green one.
+
+```bash
+# ❌ silently vacuous — reports success with a type error in src/
+npx tsc --noEmit
+
+# ✅ actually loads src/ and the test files
+npx tsc -p tsconfig.app.json --noEmit
+```

--- a/e2e/builder-crud.spec.ts
+++ b/e2e/builder-crud.spec.ts
@@ -31,7 +31,29 @@ async function getActiveProgramId(): Promise<string> {
   return data!.id
 }
 
+/** Days seeded by global-setup. Anything else on the program is test debris. */
+const SEEDED_DAY_LABELS = ["Lundi", "Mercredi", "Vendredi"]
+
 test.describe("Builder — CRUD", () => {
+  // These tests delete the days they create, but only on the happy path. A
+  // failure in between leaks a fourth day onto the shared program, which then
+  // breaks cycle-abandon's "1/3 workouts done" count — one broken assertion
+  // reported as two unrelated failures. Sweep the debris instead.
+  // Best-effort: a session pinned to a leaked day would block the delete, and a
+  // cleanup hook must never be the thing that turns a green run red.
+  test.afterAll(async () => {
+    try {
+      const labelList = SEEDED_DAY_LABELS.map((l) => `"${l}"`).join(",")
+      await admin
+        .from("workout_days")
+        .delete()
+        .eq("program_id", await getActiveProgramId())
+        .not("label", "in", `(${labelList})`)
+    } catch {
+      /* leave it to the next run's setup */
+    }
+  })
+
   test("create day, add exercise, edit sets/reps, delete exercise, delete day", async ({
     page,
   }) => {
@@ -106,17 +128,20 @@ test.describe("Builder — CRUD", () => {
     const libraryItemCount = await allItems.count()
 
     // --- Verify search filters the list ---
+    // The suite runs in English, so search with an English term: the query must
+    // hit `name_en` server-side and the row must render the same English label.
     const searchInput = pickerDialog.getByRole("searchbox")
-    await searchInput.fill("Développé")
+    await searchInput.fill("Bench")
     const filteredItems = pickerDialog.locator("[cmdk-item]")
     await expect(async () => {
       const count = await filteredItems.count()
       expect(count).toBeGreaterThan(0)
       expect(count).toBeLessThan(libraryItemCount)
     }).toPass({ timeout: 10_000 })
-    await expect(
-      filteredItems.first().locator("span.truncate"),
-    ).toContainText("Développé", { timeout: 3_000 })
+    await expect(filteredItems.first().locator("span.truncate")).toContainText(
+      /bench/i,
+      { timeout: 3_000 },
+    )
     await searchInput.fill("")
     await expect(allItems).toHaveCount(libraryItemCount, { timeout: 10_000 })
 

--- a/src/components/builder/BlockCard.tsx
+++ b/src/components/builder/BlockCard.tsx
@@ -3,6 +3,7 @@ import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import { GripVertical, Layers, Pencil, Timer, Trash2 } from "lucide-react"
 import type { ExerciseBlockWithExercises } from "@/types/database"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 
@@ -14,6 +15,7 @@ interface BlockCardProps {
 
 export function BlockCard({ block, onEdit, onDelete }: BlockCardProps) {
   const { t } = useTranslation("builder")
+  const { exerciseName } = useCatalogLabels()
   const {
     attributes,
     listeners,
@@ -82,7 +84,7 @@ export function BlockCard({ block, onEdit, onDelete }: BlockCardProps) {
                 className="flex items-center gap-2 text-sm text-muted-foreground"
               >
                 <span>{be.emoji_snapshot}</span>
-                <span>{be.name_snapshot}</span>
+                <span>{exerciseName(be)}</span>
               </li>
             ))}
           </ul>

--- a/src/components/builder/DayEditor.tsx
+++ b/src/components/builder/DayEditor.tsx
@@ -15,6 +15,7 @@ import {
 import { Layers, Loader2, Plus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useWorkoutDays } from "@/hooks/useWorkoutDays"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { useDayItems } from "@/hooks/useDayItems"
 import {
   useCreateBlock,
@@ -27,7 +28,7 @@ import {
   useReorderExercises,
 } from "@/hooks/useBuilderMutations"
 import { dayItemId, reorderDayItems } from "@/lib/dayItems"
-import type { Exercise, WorkoutExercise } from "@/types/database"
+import type { Exercise, WorkoutExerciseWithExercise } from "@/types/database"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import {
@@ -57,6 +58,7 @@ export function DayEditor({
   onMutationStateChange,
 }: DayEditorProps) {
   const { t } = useTranslation("builder")
+  const { exerciseName } = useCatalogLabels()
   const { data: days } = useWorkoutDays(programId)
   const { items: dayItems, isLoading } = useDayItems(dayId)
   const updateDay = useUpdateDay(programId)
@@ -74,7 +76,8 @@ export function DayEditor({
   const [blockPickerOpen, setBlockPickerOpen] = useState(false)
   const [editBlockId, setEditBlockId] = useState<string | null>(null)
   const [deleteBlockId, setDeleteBlockId] = useState<string | null>(null)
-  const [deleteTarget, setDeleteTarget] = useState<WorkoutExercise | null>(null)
+  const [deleteTarget, setDeleteTarget] =
+    useState<WorkoutExerciseWithExercise | null>(null)
 
   if (dayId !== trackedDayId) {
     setTrackedDayId(dayId)
@@ -341,7 +344,7 @@ export function DayEditor({
             <DialogTitle>{t("removeExerciseTitle")}</DialogTitle>
             <DialogDescription>
               {t("removeExerciseDescription", {
-                name: deleteTarget?.name_snapshot,
+                name: deleteTarget ? exerciseName(deleteTarget) : "",
               })}
             </DialogDescription>
           </DialogHeader>

--- a/src/components/builder/ExerciseDetailForm.test.tsx
+++ b/src/components/builder/ExerciseDetailForm.test.tsx
@@ -2,7 +2,7 @@ import { vi, describe, it, expect, beforeEach } from "vitest"
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { renderWithProviders } from "@/test/utils"
-import type { WorkoutExercise } from "@/types/database"
+import type { WorkoutExerciseWithExercise } from "@/types/database"
 
 vi.mock("@/lib/supabase", () => ({
   supabase: { from: vi.fn() },
@@ -15,8 +15,11 @@ vi.mock("@/hooks/useBuilderMutations", () => ({
 
 import { ExerciseDetailForm } from "./ExerciseDetailForm"
 
-function makeExercise(overrides: Partial<WorkoutExercise> = {}): WorkoutExercise {
+function makeExercise(
+  overrides: Partial<WorkoutExerciseWithExercise> = {},
+): WorkoutExerciseWithExercise {
   return {
+    exercise: null,
     id: "ex-1",
     workout_day_id: "day-1",
     exercise_id: "lib-1",

--- a/src/components/builder/ExerciseDetailForm.tsx
+++ b/src/components/builder/ExerciseDetailForm.tsx
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ChevronDown } from "lucide-react"
-import type { WorkoutExercise } from "@/types/database"
+import type {
+  WorkoutExercise,
+  WorkoutExerciseWithExercise,
+} from "@/types/database"
 import { useUpdateExercise } from "@/hooks/useBuilderMutations"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 import type { useExerciseFromLibrary } from "@/hooks/useExerciseFromLibrary"
 import { Input } from "@/components/ui/input"
@@ -16,7 +20,7 @@ import { DEFAULT_DURATION_FALLBACK_SEC } from "@/lib/sessionSetRow"
 type LibraryExercise = ReturnType<typeof useExerciseFromLibrary>["data"]
 
 interface ExerciseDetailFormProps {
-  exercise: WorkoutExercise
+  exercise: WorkoutExerciseWithExercise
   libExercise: LibraryExercise
   onMutationStateChange: (state: "saving" | "saved" | "error") => void
 }
@@ -79,6 +83,7 @@ export function ExerciseDetailForm({
 }: ExerciseDetailFormProps) {
   const { t } = useTranslation("builder")
   const { unit, toDisplay, toKg } = useWeightUnit()
+  const { exerciseName } = useCatalogLabels()
   const updateExercise = useUpdateExercise()
 
   const [form, setForm] = useState<FormState>(() =>
@@ -155,7 +160,9 @@ export function ExerciseDetailForm({
         <div className="flex items-center gap-3 min-w-0">
           <ExerciseThumbnail imageUrl={libExercise?.image_url} emoji={exercise.emoji_snapshot} className="h-12 w-12 shrink-0" />
           <div className="min-w-0">
-            <h2 className="text-lg font-bold truncate">{exercise.name_snapshot}</h2>
+            <h2 className="text-lg font-bold truncate">
+              {exerciseName(exercise)}
+            </h2>
             <p className="text-sm text-muted-foreground">
               {exercise.muscle_snapshot}
             </p>

--- a/src/components/builder/ExerciseLibraryPicker.test.tsx
+++ b/src/components/builder/ExerciseLibraryPicker.test.tsx
@@ -166,7 +166,11 @@ vi.mock("@/components/exercise/ExerciseThumbnail", () => ({
   ExerciseThumbnail: () => <div data-testid="thumbnail" />,
 }))
 
-function renderPicker(overrides = {}) {
+/**
+ * Renders in English like the rest of this file's assertions, so the expected
+ * exercise labels are the `name_en` values — the picker localizes them (T149).
+ */
+function renderPicker(overrides = {}, locale: "en" | "fr" = "en") {
   return renderWithProviders(
     <ExerciseLibraryPicker
       open={true}
@@ -176,6 +180,7 @@ function renderPicker(overrides = {}) {
       onMutationStateChange={vi.fn()}
       {...overrides}
     />,
+    { locale },
   )
 }
 
@@ -191,12 +196,30 @@ describe("ExerciseLibraryPicker", () => {
     )
   })
 
+  // The picker feeds the rows the day and session localize. If it stayed on the
+  // canonical `name`, an English reader would pick "Développé couché" and watch
+  // "Bench Press" appear in its place — one screen, two languages.
+  it("lists the English catalog names for an English reader", () => {
+    renderPicker({}, "en")
+
+    expect(screen.getByText("Bench Press")).toBeInTheDocument()
+    expect(screen.getByText("Lateral Raises")).toBeInTheDocument()
+    expect(screen.queryByText("Développé couché")).not.toBeInTheDocument()
+  })
+
+  it("lists the canonical names for a French reader", () => {
+    renderPicker({}, "fr")
+
+    expect(screen.getByText("Développé couché")).toBeInTheDocument()
+    expect(screen.queryByText("Bench Press")).not.toBeInTheDocument()
+  })
+
   it("renders all exercises grouped by muscle", () => {
     renderPicker()
-    expect(screen.getByText("Développé couché")).toBeInTheDocument()
-    expect(screen.getByText("Élévations latérales")).toBeInTheDocument()
-    expect(screen.getByText("Presse à cuisse")).toBeInTheDocument()
-    expect(screen.getByText("Curls biceps inclinés")).toBeInTheDocument()
+    expect(screen.getByText("Bench Press")).toBeInTheDocument()
+    expect(screen.getByText("Lateral Raises")).toBeInTheDocument()
+    expect(screen.getByText("Leg Press")).toBeInTheDocument()
+    expect(screen.getByText("Dumbbell Incline Curl")).toBeInTheDocument()
   })
 
   it("shows filter icon", () => {
@@ -220,9 +243,9 @@ describe("ExerciseLibraryPicker", () => {
     await user.click(screen.getByLabelText("Filters"))
     await user.click(screen.getByRole("button", { name: "Machine" }))
 
-    expect(screen.getByText("Presse à cuisse")).toBeInTheDocument()
-    expect(screen.queryByText("Développé couché")).not.toBeInTheDocument()
-    expect(screen.queryByText("Élévations latérales")).not.toBeInTheDocument()
+    expect(screen.getByText("Leg Press")).toBeInTheDocument()
+    expect(screen.queryByText("Bench Press")).not.toBeInTheDocument()
+    expect(screen.queryByText("Lateral Raises")).not.toBeInTheDocument()
   })
 
   it("filters by muscle group when a pill is selected", async () => {
@@ -232,9 +255,9 @@ describe("ExerciseLibraryPicker", () => {
     await user.click(screen.getByLabelText("Filters"))
     await user.click(screen.getByRole("button", { name: "Pectoraux" }))
 
-    expect(screen.getByText("Développé couché")).toBeInTheDocument()
-    expect(screen.queryByText("Élévations latérales")).not.toBeInTheDocument()
-    expect(screen.queryByText("Presse à cuisse")).not.toBeInTheDocument()
+    expect(screen.getByText("Bench Press")).toBeInTheDocument()
+    expect(screen.queryByText("Lateral Raises")).not.toBeInTheDocument()
+    expect(screen.queryByText("Leg Press")).not.toBeInTheDocument()
   })
 
   it("filters by difficulty when a pill is selected", async () => {
@@ -244,10 +267,10 @@ describe("ExerciseLibraryPicker", () => {
     await user.click(screen.getByLabelText("Filters"))
     await user.click(screen.getByRole("button", { name: "Beginner" }))
 
-    expect(screen.getByText("Développé couché")).toBeInTheDocument()
-    expect(screen.queryByText("Élévations latérales")).not.toBeInTheDocument()
-    expect(screen.queryByText("Presse à cuisse")).not.toBeInTheDocument()
-    expect(screen.queryByText("Curls biceps inclinés")).not.toBeInTheDocument()
+    expect(screen.getByText("Bench Press")).toBeInTheDocument()
+    expect(screen.queryByText("Lateral Raises")).not.toBeInTheDocument()
+    expect(screen.queryByText("Leg Press")).not.toBeInTheDocument()
+    expect(screen.queryByText("Dumbbell Incline Curl")).not.toBeInTheDocument()
   })
 
   it("includes difficulty in active filter count", async () => {
@@ -297,8 +320,8 @@ describe("ExerciseLibraryPicker", () => {
     await user.click(screen.getByRole("button", { name: "Pectoraux" }))
     await user.click(screen.getByRole("button", { name: "Dumbbell" }))
 
-    expect(screen.getByText("Écarté haltères")).toBeInTheDocument()
-    expect(screen.queryByText("Développé couché")).not.toBeInTheDocument()
+    expect(screen.getByText("Dumbbell Fly")).toBeInTheDocument()
+    expect(screen.queryByText("Bench Press")).not.toBeInTheDocument()
   })
 
   it("shows loading state", () => {
@@ -355,7 +378,7 @@ describe("ExerciseLibraryPicker", () => {
   it("does not add exercise when row text is clicked", async () => {
     renderPicker()
     const user = userEvent.setup()
-    await user.click(screen.getByText("Développé couché"))
+    await user.click(screen.getByText("Bench Press"))
     expect(mockAddExercisesMutateAsync).not.toHaveBeenCalled()
   })
 
@@ -413,7 +436,7 @@ describe("ExerciseLibraryPicker", () => {
     await user.click(screen.getByLabelText("Filters"))
     await user.click(screen.getByRole("button", { name: "Pectoraux" }))
 
-    expect(screen.queryByText("Élévations latérales")).not.toBeInTheDocument()
+    expect(screen.queryByText("Lateral Raises")).not.toBeInTheDocument()
     expect(
       screen.getByRole("button", { name: "Apply changes" }),
     ).toBeInTheDocument()
@@ -484,7 +507,7 @@ describe("ExerciseLibraryPicker", () => {
     await user.click(screen.getByLabelText("Filters"))
     await user.click(screen.getByRole("button", { name: "Pectoraux" }))
 
-    expect(screen.queryByText("Élévations latérales")).not.toBeInTheDocument()
+    expect(screen.queryByText("Lateral Raises")).not.toBeInTheDocument()
     expect(
       screen.getByRole("button", { name: /create circuit \(2 exercises\)/i }),
     ).toBeInTheDocument()

--- a/src/components/builder/ExerciseRow.test.tsx
+++ b/src/components/builder/ExerciseRow.test.tsx
@@ -1,15 +1,29 @@
 import { vi, describe, it, expect } from "vitest"
 import { screen } from "@testing-library/react"
 import { renderWithProviders } from "@/test/utils"
-import type { WorkoutExercise } from "@/types/database"
+import type { Exercise, WorkoutExerciseWithExercise } from "@/types/database"
 import { ExerciseRow } from "./ExerciseRow"
 
 vi.mock("@/lib/supabase", () => ({
   supabase: { from: vi.fn() },
 }))
 
-function makeExercise(overrides: Partial<WorkoutExercise> = {}): WorkoutExercise {
+const catalogRow = (overrides: Partial<Exercise> = {}) =>
+  ({
+    id: "lib-1",
+    name: "Développé couché",
+    name_en: "Bench Press",
+    muscle_group: "Pectoraux",
+    equipment: "barbell",
+    emoji: "💪",
+    ...overrides,
+  }) as Exercise
+
+function makeExercise(
+  overrides: Partial<WorkoutExerciseWithExercise> = {},
+): WorkoutExerciseWithExercise {
   return {
+    exercise: null,
     id: "ex-1",
     workout_day_id: "day-1",
     exercise_id: "lib-1",
@@ -27,16 +41,55 @@ function makeExercise(overrides: Partial<WorkoutExercise> = {}): WorkoutExercise
   }
 }
 
+function render(
+  exercise: WorkoutExerciseWithExercise,
+  locale?: "en" | "fr",
+) {
+  renderWithProviders(
+    <ExerciseRow exercise={exercise} onTap={vi.fn()} onDelete={vi.fn()} />,
+    { locale },
+  )
+}
+
 describe("ExerciseRow", () => {
   it("displays the rest time", () => {
-    renderWithProviders(
-      <ExerciseRow
-        exercise={makeExercise({ rest_seconds: 90 })}
-        onTap={vi.fn()}
-        onDelete={vi.fn()}
-      />,
-    )
+    render(makeExercise({ rest_seconds: 90 }))
 
     expect(screen.getByText(/90s/)).toBeInTheDocument()
+  })
+
+  it("shows the English catalog name to an English reader", () => {
+    render(
+      makeExercise({ name_snapshot: "Développé couché", exercise: catalogRow() }),
+      "en",
+    )
+
+    expect(screen.getByText("Bench Press")).toBeInTheDocument()
+  })
+
+  it("shows the French catalog name to a French reader", () => {
+    render(
+      makeExercise({ name_snapshot: "Développé couché", exercise: catalogRow() }),
+      "fr",
+    )
+
+    expect(screen.getByText("Développé couché")).toBeInTheDocument()
+    expect(screen.queryByText("Bench Press")).not.toBeInTheDocument()
+  })
+
+  it("falls back to the catalog name in both locales when name_en is missing", () => {
+    const exercise = makeExercise({
+      name_snapshot: "Gainage latéral",
+      exercise: catalogRow({ name: "Gainage latéral", name_en: null }),
+    })
+
+    render(exercise, "en")
+    expect(screen.getByText("Gainage latéral")).toBeInTheDocument()
+  })
+
+  it("falls back to the snapshot when the catalog row is absent", () => {
+    render(makeExercise({ name_snapshot: "Exercice supprimé" }), "en")
+
+    expect(screen.getByText("Exercice supprimé")).toBeInTheDocument()
   })
 })

--- a/src/components/builder/ExerciseRow.tsx
+++ b/src/components/builder/ExerciseRow.tsx
@@ -3,8 +3,9 @@ import { CSS } from "@dnd-kit/utilities"
 import { Link } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { GripVertical, Pencil, Timer, Trash2 } from "lucide-react"
-import type { WorkoutExercise } from "@/types/database"
+import type { WorkoutExerciseWithExercise } from "@/types/database"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { useExerciseFromLibrary } from "@/hooks/useExerciseFromLibrary"
 import { formatDurationShort } from "@/lib/formatters"
 import { Button } from "@/components/ui/button"
@@ -12,7 +13,7 @@ import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
 import { AdminOnly } from "@/components/admin/AdminOnly"
 
 interface ExerciseRowProps {
-  exercise: WorkoutExercise
+  exercise: WorkoutExerciseWithExercise
   onTap: () => void
   onDelete: () => void
 }
@@ -20,6 +21,7 @@ interface ExerciseRowProps {
 export function ExerciseRow({ exercise, onTap, onDelete }: ExerciseRowProps) {
   const { t } = useTranslation("builder")
   const { formatWeight } = useWeightUnit()
+  const { exerciseName } = useCatalogLabels()
   const { data: libExercise } = useExerciseFromLibrary(exercise.exercise_id)
   const {
     attributes,
@@ -63,7 +65,7 @@ export function ExerciseRow({ exercise, onTap, onDelete }: ExerciseRowProps) {
       <div className="flex-1 cursor-pointer" onClick={onTap}>
         <div className="flex items-center gap-2">
           <ExerciseThumbnail imageUrl={libExercise?.image_url} emoji={exercise.emoji_snapshot} className="h-7 w-7" />
-          <span className="text-sm font-medium">{exercise.name_snapshot}</span>
+          <span className="text-sm font-medium">{exerciseName(exercise)}</span>
         </div>
         <p className="flex flex-wrap items-center gap-x-1 text-xs text-muted-foreground">
           <span>

--- a/src/components/builder/ExerciseSelectionContent.tsx
+++ b/src/components/builder/ExerciseSelectionContent.tsx
@@ -6,6 +6,7 @@ import {
   useDeleteExercise,
 } from "@/hooks/useBuilderMutations"
 import type { Exercise } from "@/types/database"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { ExerciseInfoDialog } from "@/components/exercise/ExerciseInfoDialog"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
 import { FeedbackTrigger } from "@/components/feedback/FeedbackTrigger"
@@ -173,6 +174,7 @@ export function ExerciseSelectionList({
   state: ExerciseSelectionState
 }) {
   const { t, selectedIds, toggleSelected, grouped } = state
+  const { catalogName } = useCatalogLabels()
 
   return (
     <>
@@ -201,7 +203,7 @@ export function ExerciseSelectionList({
                     emoji={ex.emoji}
                     className="h-8 w-8 shrink-0 rounded-md"
                   />
-                  <span className="truncate">{ex.name}</span>
+                  <span className="truncate">{catalogName(ex)}</span>
                   {ex.difficulty_level && (
                     <Badge
                       className={cn(

--- a/src/components/builder/PerRoundGrid.tsx
+++ b/src/components/builder/PerRoundGrid.tsx
@@ -6,6 +6,7 @@ import type {
   PerRoundCell,
 } from "@/types/database"
 import { useUpdatePerRound } from "@/hooks/useBlockMutations"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
 import { Input } from "@/components/ui/input"
@@ -58,6 +59,7 @@ function PerRoundExerciseRow({
 }: PerRoundExerciseRowProps) {
   const { t } = useTranslation("builder")
   const { unit, toDisplay, toKg } = useWeightUnit()
+  const { exerciseName } = useCatalogLabels()
   const updatePerRound = useUpdatePerRound()
 
   const isDuration = blockExercise.exercise?.measurement_type === "duration"
@@ -114,7 +116,7 @@ function PerRoundExerciseRow({
           className="h-7 w-7 shrink-0"
         />
         <p className="truncate text-sm font-medium">
-          {blockExercise.name_snapshot}
+          {exerciseName(blockExercise)}
         </p>
       </div>
 

--- a/src/components/generator/ExerciseSwapPicker.test.tsx
+++ b/src/components/generator/ExerciseSwapPicker.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest"
+import { screen } from "@testing-library/react"
+
+import { renderWithProviders } from "@/test/utils"
+import type { ExerciseListItem } from "@/types/database"
+import { ExerciseSwapPicker } from "./ExerciseSwapPicker"
+
+vi.mock("@/hooks/useExerciseById", () => ({
+  useExerciseById: () => ({ data: null, isLoading: false }),
+}))
+
+const POOL = [
+  {
+    id: "lib-1",
+    name: "Développé couché",
+    name_en: "Bench Press",
+    muscle_group: "Pectoraux",
+    equipment: "barbell",
+    emoji: "💪",
+  },
+  {
+    id: "lib-2",
+    name: "Gainage latéral",
+    name_en: null,
+    muscle_group: "Pectoraux",
+    equipment: "bodyweight",
+    emoji: "🧘",
+  },
+] as ExerciseListItem[]
+
+const render = (locale: "en" | "fr") =>
+  renderWithProviders(
+    <ExerciseSwapPicker
+      pool={POOL}
+      currentExerciseIds={[]}
+      muscleGroup="Pectoraux"
+      onSelect={vi.fn()}
+      onClose={vi.fn()}
+    />,
+    { locale },
+  )
+
+describe("ExerciseSwapPicker", () => {
+  // The picker feeds the rows the session localizes. If it stayed on `name`, the
+  // user would pick "Développé couché" and watch an English name appear in its
+  // place — the mixed-language screen this epic exists to remove.
+  it("offers English names to an English reader", () => {
+    render("en")
+
+    expect(screen.getByText("Bench Press")).toBeInTheDocument()
+    expect(screen.queryByText("Développé couché")).not.toBeInTheDocument()
+  })
+
+  it("offers French names to a French reader", () => {
+    render("fr")
+
+    expect(screen.getByText("Développé couché")).toBeInTheDocument()
+    expect(screen.queryByText("Bench Press")).not.toBeInTheDocument()
+  })
+
+  it("keeps the canonical name in both locales when name_en is missing", () => {
+    render("en")
+
+    expect(screen.getByText("Gainage latéral")).toBeInTheDocument()
+  })
+
+  it("still filters candidates on the canonical muscle group", () => {
+    renderWithProviders(
+      <ExerciseSwapPicker
+        pool={POOL}
+        currentExerciseIds={[]}
+        muscleGroup="Dos"
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />,
+      { locale: "en" },
+    )
+
+    expect(screen.queryByText("Bench Press")).not.toBeInTheDocument()
+  })
+})

--- a/src/components/generator/ExerciseSwapPicker.tsx
+++ b/src/components/generator/ExerciseSwapPicker.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Info } from "lucide-react"
 import { ExerciseDetailSheet } from "@/components/generator/ExerciseDetailSheet"
 import { useExerciseById } from "@/hooks/useExerciseById"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { cn } from "@/lib/utils"
 import type { ExerciseListItem } from "@/types/database"
 
@@ -22,6 +23,7 @@ export function ExerciseSwapPicker({
   onClose,
 }: ExerciseSwapPickerProps) {
   const { t } = useTranslation("generator")
+  const { catalogName } = useCatalogLabels()
   const [inspectedExerciseId, setInspectedExerciseId] = useState<string | null>(null)
   // Rich fields (instructions/youtube) deferred until the user opens the info
   // sheet. Hits the per-id cache seeded by `useWorkoutExercises` when the
@@ -66,7 +68,7 @@ export function ExerciseSwapPicker({
                 )}
               >
                 <span>{exercise.emoji}</span>
-                <span className="truncate">{exercise.name}</span>
+                <span className="truncate">{catalogName(exercise)}</span>
               </button>
               <button
                 type="button"

--- a/src/components/workout/BlockRunner.tsx
+++ b/src/components/workout/BlockRunner.tsx
@@ -26,6 +26,7 @@ import { useBlockSession } from "@/hooks/useBlockSession"
 import { useCountdown } from "@/hooks/useCountdown"
 import { useKeepScreenAwake } from "@/hooks/useKeepScreenAwake"
 import { useExerciseById } from "@/hooks/useExerciseById"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { playFinishBeeps } from "@/lib/audio"
 import { BlockProgressBars } from "@/components/workout/BlockProgressBars"
 import { CountdownRing } from "@/components/workout/CountdownRing"
@@ -57,6 +58,7 @@ export function BlockRunner({
 }: BlockRunnerProps) {
   const { t } = useTranslation("workout")
   const { formatWeight } = useWeightUnit()
+  const { exerciseName } = useCatalogLabels()
   const {
     state,
     remainingSeconds,
@@ -191,8 +193,10 @@ export function BlockRunner({
       state.phase === "transition" ? block.transition_seconds : block.rest_seconds
     const nextLabel =
       state.phase === "transition"
-        ? t("blockRunner.next", { name: nextExercise?.name_snapshot ?? "" })
-        : t("blockRunner.nextRound", { name: nextExercise?.name_snapshot ?? "" })
+        ? t("blockRunner.next", { name: nextExercise ? exerciseName(nextExercise) : "" })
+        : t("blockRunner.nextRound", {
+            name: nextExercise ? exerciseName(nextExercise) : "",
+          })
 
     return (
       <div
@@ -257,7 +261,7 @@ export function BlockRunner({
           <div className="flex flex-col items-center gap-1.5">
             <div className="text-4xl">{blockExercise?.emoji_snapshot}</div>
             <h2 className="text-2xl font-bold leading-tight">
-              {blockExercise?.name_snapshot}
+              {blockExercise ? exerciseName(blockExercise) : null}
             </h2>
             <div className="flex items-center gap-2">
               {blockExercise && (

--- a/src/components/workout/BlockSessionCard.test.tsx
+++ b/src/components/workout/BlockSessionCard.test.tsx
@@ -32,6 +32,42 @@ const block: ExerciseBlockWithExercises = {
   exercises: [be("A", "Push-ups"), be("B", "Squats")],
 }
 
+describe("BlockSessionCard — locale", () => {
+  const localizedBlock: ExerciseBlockWithExercises = {
+    ...block,
+    exercises: [
+      {
+        ...be("A", "Développé couché"),
+        exercise: {
+          id: "ex-A",
+          name: "Développé couché",
+          name_en: "Bench Press",
+          muscle_group: "Pectoraux",
+          equipment: "barbell",
+          emoji: "💪",
+        } as BlockExerciseWithExercise["exercise"],
+      },
+    ],
+  }
+
+  it("names the block's exercises in English for an English reader", () => {
+    renderWithProviders(<BlockSessionCard block={localizedBlock} />, {
+      locale: "en",
+    })
+
+    expect(screen.getByText("Bench Press")).toBeInTheDocument()
+  })
+
+  it("keeps the French names for a French reader", () => {
+    renderWithProviders(<BlockSessionCard block={localizedBlock} />, {
+      locale: "fr",
+    })
+
+    expect(screen.getByText("Développé couché")).toBeInTheDocument()
+    expect(screen.queryByText("Bench Press")).not.toBeInTheDocument()
+  })
+})
+
 describe("BlockSessionCard", () => {
   it("shows the block label, exercise list and starts on click", async () => {
     const user = userEvent.setup()

--- a/src/components/workout/BlockSessionCard.tsx
+++ b/src/components/workout/BlockSessionCard.tsx
@@ -3,6 +3,7 @@ import { CheckCircle2, Dumbbell, Layers, Play, RotateCcw } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 import { compactNumberSequence } from "@/lib/blockPrescription"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { cn } from "@/lib/utils"
 import type {
   BlockExerciseWithExercise,
@@ -34,6 +35,7 @@ export function BlockSessionCard({
 }: BlockSessionCardProps) {
   const { t } = useTranslation("workout")
   const { formatWeight } = useWeightUnit()
+  const { exerciseName } = useCatalogLabels()
 
   const renderPrescription = (be: BlockExerciseWithExercise) => {
     const isDuration = be.exercise?.measurement_type === "duration"
@@ -107,7 +109,7 @@ export function BlockSessionCard({
             className="flex items-center gap-2 rounded-lg bg-muted/30 px-3 py-2 text-sm"
           >
             <span className="text-lg">{be.emoji_snapshot}</span>
-            <span className="truncate font-medium">{be.name_snapshot}</span>
+            <span className="truncate font-medium">{exerciseName(be)}</span>
             {renderPrescription(be)}
           </li>
         ))}

--- a/src/components/workout/ExerciseDetail.tsx
+++ b/src/components/workout/ExerciseDetail.tsx
@@ -22,7 +22,11 @@ import { useLastSession } from "@/hooks/useLastSession"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 import { useExerciseFromLibrary } from "@/hooks/useExerciseFromLibrary"
 import { useProgressionSuggestion } from "@/hooks/useProgressionSuggestion"
-import type { ExerciseListItem, WorkoutExercise } from "@/types/database"
+import type {
+  ExerciseListItem,
+  WorkoutExerciseWithLabel,
+} from "@/types/database"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { ExerciseInstructionsPanel } from "@/components/exercise/ExerciseInstructionsPanel"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
 import { AdminOnly } from "@/components/admin/AdminOnly"
@@ -36,14 +40,17 @@ import { ProgressionPill } from "@/components/workout/ProgressionPill"
 export interface ExerciseDetailEditSessionProps {
   exercisePool: ExerciseListItem[]
   poolLoading: boolean
-  allExercises: WorkoutExercise[]
-  onSwapExerciseChosen: (row: WorkoutExercise, picked: ExerciseListItem) => void
-  onDeleteRequested: (row: WorkoutExercise) => void
-  onSwapBrowseLibrary: (row: WorkoutExercise) => void
+  allExercises: WorkoutExerciseWithLabel[]
+  onSwapExerciseChosen: (
+    row: WorkoutExerciseWithLabel,
+    picked: ExerciseListItem,
+  ) => void
+  onDeleteRequested: (row: WorkoutExerciseWithLabel) => void
+  onSwapBrowseLibrary: (row: WorkoutExerciseWithLabel) => void
 }
 
 interface ExerciseDetailProps {
-  exercise: WorkoutExercise
+  exercise: WorkoutExerciseWithLabel
   sessionId: string
   sessionStartedAt?: number | null
   isReadOnly: boolean
@@ -66,6 +73,7 @@ export function ExerciseDetail({
   const { t } = useTranslation("workout")
   const { t: tFeedback } = useTranslation("feedback")
   const { formatWeight } = useWeightUnit()
+  const { exerciseName } = useCatalogLabels()
   const { data: lastSession } = useLastSession(exercise.exercise_id, sessionStartedAt)
   const { data: libExercise } = useExerciseFromLibrary(exercise.exercise_id)
   const [swapPanelOpen, setSwapPanelOpen] = useState(false)
@@ -87,7 +95,7 @@ export function ExerciseDetail({
         <div className="flex flex-wrap items-center gap-2">
           <ExerciseThumbnail imageUrl={libExercise?.image_url} emoji={exercise.emoji_snapshot} className="h-10 w-10" />
           <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
-            <h2 className="text-xl font-bold">{exercise.name_snapshot}</h2>
+            <h2 className="text-xl font-bold">{exerciseName(exercise)}</h2>
             <Badge variant="default" className="w-fit shrink-0 text-xs font-normal">
               {exercise.muscle_snapshot}
             </Badge>
@@ -207,7 +215,7 @@ export function ExerciseDetail({
         open={historyOpen}
         onOpenChange={setHistoryOpen}
         exerciseId={exercise.exercise_id}
-        exerciseName={exercise.name_snapshot}
+        exerciseName={exerciseName(exercise)}
         muscleLabel={exercise.muscle_snapshot}
         bodyMapMuscleGroup={libExercise?.muscle_group ?? exercise.muscle_snapshot}
         emojiSnapshot={exercise.emoji_snapshot}

--- a/src/components/workout/ExerciseEditRowControls.test.tsx
+++ b/src/components/workout/ExerciseEditRowControls.test.tsx
@@ -4,7 +4,7 @@ import { renderWithProviders } from "@/test/utils"
 import { ExerciseEditRowControls } from "./ExerciseEditRowControls"
 import type {
   ExerciseListItem,
-  WorkoutExercise,
+  WorkoutExerciseWithLabel,
 } from "@/types/database"
 import type { ProgressionSuggestion } from "@/lib/progression"
 
@@ -17,12 +17,13 @@ vi.mock("@/lib/supabase", () => ({
 }))
 
 function makeExercise(
-  overrides: Partial<WorkoutExercise> = {},
-): WorkoutExercise {
+  overrides: Partial<WorkoutExerciseWithLabel> = {},
+): WorkoutExerciseWithLabel {
   return {
     id: "we-1",
     workout_day_id: "day-1",
     exercise_id: "ex-1",
+    exercise: null,
     name_snapshot: "Bench Press",
     muscle_snapshot: "chest",
     emoji_snapshot: "🏋️",

--- a/src/components/workout/ExerciseEditRowControls.tsx
+++ b/src/components/workout/ExerciseEditRowControls.tsx
@@ -15,16 +15,23 @@ import { ProgressionPill } from "@/components/workout/ProgressionPill"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 import { formatDurationShort } from "@/lib/formatters"
 import type { ProgressionSuggestion } from "@/lib/progression"
-import type { ExerciseListItem, WorkoutExercise } from "@/types/database"
+import type {
+  ExerciseListItem,
+  WorkoutExerciseWithLabel,
+} from "@/types/database"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 
 export interface ExerciseEditRowControlsProps {
-  exercise: WorkoutExercise
+  exercise: WorkoutExerciseWithLabel
   exercisePool: ExerciseListItem[]
   poolLoading: boolean
   currentExerciseIds: string[]
-  onSwapExerciseChosen: (row: WorkoutExercise, picked: ExerciseListItem) => void
-  onDeleteRequested: (row: WorkoutExercise) => void
-  onSwapBrowseLibrary: (row: WorkoutExercise) => void
+  onSwapExerciseChosen: (
+    row: WorkoutExerciseWithLabel,
+    picked: ExerciseListItem,
+  ) => void
+  onDeleteRequested: (row: WorkoutExerciseWithLabel) => void
+  onSwapBrowseLibrary: (row: WorkoutExerciseWithLabel) => void
   onInspectDetails: (exerciseId: string) => void
   /** Pre-session list: opens library sheet. In-session detail uses unified menu instead. */
   showDetailsMenuItem?: boolean
@@ -53,6 +60,7 @@ export function ExerciseEditRowControls({
 }: ExerciseEditRowControlsProps) {
   const { t } = useTranslation("workout")
   const { formatWeight } = useWeightUnit()
+  const { exerciseName } = useCatalogLabels()
   const [swapPanelOpen, setSwapPanelOpen] = useState(false)
 
   const showSkeleton = isLoadingSuggestion && suggestion === undefined
@@ -120,7 +128,7 @@ export function ExerciseEditRowControls({
         <span className="text-2xl leading-none">{ex.emoji_snapshot}</span>
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-medium text-foreground">
-            {ex.name_snapshot}
+            {exerciseName(ex)}
           </p>
           {showSkeleton ? (
             <Skeleton

--- a/src/components/workout/ExerciseStrip.test.tsx
+++ b/src/components/workout/ExerciseStrip.test.tsx
@@ -6,7 +6,7 @@ import { sessionAtom, prFlagsAtom } from "@/store/atoms"
 import type {
   Exercise,
   ExerciseBlockWithExercises,
-  WorkoutExercise,
+  WorkoutExerciseWithLabel,
 } from "@/types/database"
 import type { SessionItem } from "@/lib/sessionItems"
 import { ExerciseStrip } from "./ExerciseStrip"
@@ -14,18 +14,19 @@ import { ExerciseStrip } from "./ExerciseStrip"
 /** Strip tests only assert labels/overlays; thumbnails use snapshots without library rows. */
 const emptyLibraryById: ReadonlyMap<string, Exercise> = new Map()
 
-const soloItems = (exercises: WorkoutExercise[]): SessionItem[] =>
+const soloItems = (exercises: WorkoutExerciseWithLabel[]): SessionItem[] =>
   exercises.map((exercise) => ({
     kind: "solo",
     sort_order: exercise.sort_order,
     exercise,
   }))
 
-const EXERCISES: WorkoutExercise[] = [
+const EXERCISES: WorkoutExerciseWithLabel[] = [
   {
     id: "ex-1",
     workout_day_id: "day-1",
     exercise_id: "lib-1",
+    exercise: null,
     name_snapshot: "Bench Press",
     muscle_snapshot: "chest",
     emoji_snapshot: "🏋️",
@@ -46,6 +47,7 @@ const EXERCISES: WorkoutExercise[] = [
     id: "ex-2",
     workout_day_id: "day-1",
     exercise_id: "lib-2",
+    exercise: null,
     name_snapshot: "Squat",
     muscle_snapshot: "legs",
     emoji_snapshot: "🦵",
@@ -66,6 +68,7 @@ const EXERCISES: WorkoutExercise[] = [
     id: "ex-3",
     workout_day_id: "day-1",
     exercise_id: "lib-3",
+    exercise: null,
     name_snapshot: "Deadlift",
     muscle_snapshot: "back",
     emoji_snapshot: "💪",
@@ -83,6 +86,54 @@ const EXERCISES: WorkoutExercise[] = [
     template_updated_at: "2020-01-01T00:00:00Z",
   },
 ]
+
+describe("ExerciseStrip — locale", () => {
+  const localized = (): WorkoutExerciseWithLabel => ({
+    ...EXERCISES[0],
+    name_snapshot: "Développé couché",
+    exercise: {
+      id: "lib-1",
+      name: "Développé couché",
+      name_en: "Bench Press",
+      muscle_group: "Pectoraux",
+      equipment: "barbell",
+      emoji: "💪",
+    },
+  })
+
+  const renderStrip = (
+    exercise: WorkoutExerciseWithLabel,
+    locale: "en" | "fr",
+  ) =>
+    renderWithProviders(
+      <ExerciseStrip
+        items={soloItems([exercise])}
+        libraryById={emptyLibraryById}
+        activeIndex={0}
+        onSelectIndex={() => {}}
+      />,
+      { locale },
+    )
+
+  it("labels the active slot in English for an English reader", () => {
+    renderStrip(localized(), "en")
+
+    expect(screen.getByText("Bench Press")).toBeInTheDocument()
+  })
+
+  it("keeps the French label for a French reader", () => {
+    renderStrip(localized(), "fr")
+
+    expect(screen.getByText("Développé couché")).toBeInTheDocument()
+    expect(screen.queryByText("Bench Press")).not.toBeInTheDocument()
+  })
+
+  it("falls back to the snapshot when the row carries no catalog embed", () => {
+    renderStrip({ ...EXERCISES[0], name_snapshot: "Rowing barre" }, "en")
+
+    expect(screen.getByText("Rowing barre")).toBeInTheDocument()
+  })
+})
 
 describe("ExerciseStrip", () => {
   it("renders all exercise names", () => {

--- a/src/components/workout/ExerciseStrip.tsx
+++ b/src/components/workout/ExerciseStrip.tsx
@@ -10,9 +10,10 @@ import {
 import type {
   Exercise,
   ExerciseBlockWithExercises,
-  WorkoutExercise,
+  WorkoutExerciseWithLabel,
 } from "@/types/database"
 import type { SessionItem } from "@/lib/sessionItems"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
 import { cn } from "@/lib/utils"
 
@@ -77,7 +78,7 @@ export function ExerciseStrip({
 }
 
 interface StripItemProps {
-  exercise: WorkoutExercise
+  exercise: WorkoutExerciseWithLabel
   libraryExercise: Exercise | undefined
   isActive: boolean
   hasPr: boolean
@@ -90,6 +91,8 @@ const StripItem = forwardRef<HTMLButtonElement, StripItemProps>(
     { exercise, libraryExercise, isActive, hasPr, isCompleted, onSelect },
     ref,
   ) {
+    const { exerciseName } = useCatalogLabels()
+
     return (
       <button
         ref={ref}
@@ -116,7 +119,7 @@ const StripItem = forwardRef<HTMLButtonElement, StripItemProps>(
           className="aspect-4/3 w-full rounded-none"
         />
         <span className="w-full truncate px-1.5 py-1.5 text-center text-[0.65rem] font-medium leading-tight">
-          {exercise.name_snapshot}
+          {exerciseName(exercise)}
         </span>
       </button>
     )

--- a/src/components/workout/ExerciseSwapInlinePanel.test.tsx
+++ b/src/components/workout/ExerciseSwapInlinePanel.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest"
 import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { renderWithProviders } from "@/test/utils"
-import type { Exercise, WorkoutExercise } from "@/types/database"
+import type { Exercise, WorkoutExerciseWithLabel } from "@/types/database"
 
 // Stub the hook to avoid pulling `@/lib/supabase` (which needs real env vars)
 // via the ExerciseSwapPicker → inspection-sheet import chain.
@@ -33,10 +33,11 @@ function fakeExercise(overrides: Partial<Exercise> & { id: string }): Exercise {
   }
 }
 
-const ROW: WorkoutExercise = {
+const ROW: WorkoutExerciseWithLabel = {
   id: "row-1",
   workout_day_id: "day-1",
   exercise_id: "bench",
+  exercise: null,
   name_snapshot: "Bench",
   muscle_snapshot: "Pectoraux",
   emoji_snapshot: "🏋️",

--- a/src/components/workout/ExerciseSwapInlinePanel.tsx
+++ b/src/components/workout/ExerciseSwapInlinePanel.tsx
@@ -2,14 +2,20 @@ import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ExerciseSwapPicker } from "@/components/generator/ExerciseSwapPicker"
-import type { ExerciseListItem, WorkoutExercise } from "@/types/database"
+import type {
+  ExerciseListItem,
+  WorkoutExerciseWithLabel,
+} from "@/types/database"
 
 export interface ExerciseSwapInlinePanelProps {
-  exercise: WorkoutExercise
+  exercise: WorkoutExerciseWithLabel
   exercisePool: ExerciseListItem[]
   currentExerciseIds: string[]
-  onSwapExerciseChosen: (row: WorkoutExercise, picked: ExerciseListItem) => void
-  onSwapBrowseLibrary: (row: WorkoutExercise) => void
+  onSwapExerciseChosen: (
+    row: WorkoutExerciseWithLabel,
+    picked: ExerciseListItem,
+  ) => void
+  onSwapBrowseLibrary: (row: WorkoutExerciseWithLabel) => void
   onDismiss: () => void
   /** Extra class on outer wrapper (e.g. pre-session list indent). */
   className?: string

--- a/src/components/workout/PreSessionExerciseList.tsx
+++ b/src/components/workout/PreSessionExerciseList.tsx
@@ -9,19 +9,22 @@ import type { ProgressionSuggestion } from "@/lib/progression"
 import type {
   ExerciseBlockWithExercises,
   ExerciseListItem,
-  WorkoutExercise,
+  WorkoutExerciseWithLabel,
 } from "@/types/database"
 
 export interface PreSessionExerciseListProps {
-  exercises: WorkoutExercise[]
+  exercises: WorkoutExerciseWithLabel[]
   /** Blocks for the day — rendered read-only, interleaved with solos by sort_order (#351). */
   blocks?: ExerciseBlockWithExercises[]
   /** Slim pool from `useExerciseLibrary` — rich fields (instructions/youtube) are fetched on demand in inspect sheets. */
   exercisePool: ExerciseListItem[]
   poolLoading: boolean
-  onSwapExerciseChosen: (row: WorkoutExercise, picked: ExerciseListItem) => void
-  onDeleteRequested: (row: WorkoutExercise) => void
-  onSwapBrowseLibrary: (row: WorkoutExercise) => void
+  onSwapExerciseChosen: (
+    row: WorkoutExerciseWithLabel,
+    picked: ExerciseListItem,
+  ) => void
+  onDeleteRequested: (row: WorkoutExerciseWithLabel) => void
+  onSwapBrowseLibrary: (row: WorkoutExerciseWithLabel) => void
   onRequestAddExerciseSheet: () => void
   onInspectExercise: (exerciseId: string) => void
   /**

--- a/src/hooks/useCatalogLabels.ts
+++ b/src/hooks/useCatalogLabels.ts
@@ -21,6 +21,16 @@ export function useCatalogLabels() {
       exerciseName: (source: CatalogNameSource) =>
         resolveExerciseName(source, language),
 
+      /**
+       * The same rule for a bare catalog row — picker and library lists read the
+       * catalog directly, so there is no snapshot to fall back to. Keeping it
+       * here rather than at the call sites is what stops a picker from showing a
+       * French name next to the English one it just produced.
+       */
+      catalogName: (
+        row: { name?: string | null; name_en?: string | null } | null,
+      ) => resolveExerciseName({ exercise: row }, language),
+
       /** Falls back to the raw value: snapshots hold pre-taxonomy muscle names. */
       muscleLabel: (value: string | null | undefined) => {
         const key = muscleLabelKey(value)

--- a/src/lib/catalogLabels.test.ts
+++ b/src/lib/catalogLabels.test.ts
@@ -69,7 +69,7 @@ describe("resolveExerciseName", () => {
   })
 
   it("returns an empty string rather than throwing when nothing resolves", () => {
-    expect(resolveExerciseName({}, "en")).toBe("")
+    expect(resolveExerciseName({ exercise: null }, "en")).toBe("")
   })
 
   it("trims the value it returns", () => {

--- a/src/lib/catalogLabels.ts
+++ b/src/lib/catalogLabels.ts
@@ -9,13 +9,15 @@ import { EQUIPMENT_TAXONOMY } from "@/lib/catalogTaxonomy"
 import { MUSCLE_TAXONOMY } from "@/lib/trainingBalance"
 
 /**
- * Loose on which snapshot column it finds — an embedded `workout_exercises` row
+ * `exercise` is required, though nullable — pass `exercise: null` when there is
+ * genuinely no catalog row. A row that merely *forgot* the embed would resolve to
+ * its snapshot and quietly serve French names to English readers, so requiring
+ * the key turns that into a compile error at the call site rather than a bug on
+ * screen.
+ *
+ * Either snapshot column satisfies it: an embedded `workout_exercises` row
  * (`name_snapshot`) and an enriched `set_log` (`exercise_name_snapshot`) both fit
  * without a wrapper.
- *
- * `exercise` is required, though nullable: a row that never carried the embed
- * would resolve to its snapshot and quietly serve French names to English
- * readers. Requiring the key turns that into a compile error at the call site.
  */
 export interface CatalogNameSource {
   exercise: { name?: string | null; name_en?: string | null } | null

--- a/src/lib/catalogLabels.ts
+++ b/src/lib/catalogLabels.ts
@@ -9,11 +9,16 @@ import { EQUIPMENT_TAXONOMY } from "@/lib/catalogTaxonomy"
 import { MUSCLE_TAXONOMY } from "@/lib/trainingBalance"
 
 /**
- * Loose on purpose: serves an embedded `workout_exercises` row (`name_snapshot`)
- * and an enriched `set_log` (`exercise_name_snapshot`) without a wrapper.
+ * Loose on which snapshot column it finds — an embedded `workout_exercises` row
+ * (`name_snapshot`) and an enriched `set_log` (`exercise_name_snapshot`) both fit
+ * without a wrapper.
+ *
+ * `exercise` is required, though nullable: a row that never carried the embed
+ * would resolve to its snapshot and quietly serve French names to English
+ * readers. Requiring the key turns that into a compile error at the call site.
  */
 export interface CatalogNameSource {
-  exercise?: { name?: string | null; name_en?: string | null } | null
+  exercise: { name?: string | null; name_en?: string | null } | null
   name_snapshot?: string | null
   exercise_name_snapshot?: string | null
 }

--- a/src/lib/mergeWorkoutExercises.test.ts
+++ b/src/lib/mergeWorkoutExercises.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest"
 import { mergeWorkoutExercises } from "@/lib/mergeWorkoutExercises"
 import type { PreSessionExercisePatch } from "@/types/preSessionOverrides"
-import type { WorkoutExercise } from "@/types/database"
+import type { WorkoutExerciseWithLabel } from "@/types/database"
 
 function row(
-  partial: Partial<WorkoutExercise> & Pick<WorkoutExercise, "id" | "sort_order">,
-): WorkoutExercise {
+  partial: Partial<WorkoutExerciseWithLabel> & Pick<WorkoutExerciseWithLabel, "id" | "sort_order">,
+): WorkoutExerciseWithLabel {
   return {
     workout_day_id: "d1",
     exercise_id: "e1",
+    exercise: null,
     name_snapshot: "A",
     muscle_snapshot: "m",
     emoji_snapshot: "🏋️",
@@ -57,6 +58,7 @@ describe("mergeWorkoutExercises", () => {
       id: "1",
       sort_order: 0,
       exercise_id: "e2",
+      exercise: null,
       name_snapshot: "New",
     })
     const patch: PreSessionExercisePatch = {

--- a/src/lib/mergeWorkoutExercises.ts
+++ b/src/lib/mergeWorkoutExercises.ts
@@ -1,10 +1,10 @@
 import type { PreSessionExercisePatch } from "@/types/preSessionOverrides"
-import type { WorkoutExercise } from "@/types/database"
+import type { WorkoutExerciseWithLabel } from "@/types/database"
 
 export function mergeWorkoutExercises(
-  base: WorkoutExercise[],
+  base: WorkoutExerciseWithLabel[],
   patch: PreSessionExercisePatch,
-): WorkoutExercise[] {
+): WorkoutExerciseWithLabel[] {
   return [
     ...base
       .filter((row) => !patch.deletedIds.has(row.id))

--- a/src/lib/sessionExercisePatchStorage.test.ts
+++ b/src/lib/sessionExercisePatchStorage.test.ts
@@ -1,16 +1,17 @@
 import { afterEach, describe, expect, it } from "vitest"
 import { emptyPreSessionPatch } from "@/types/preSessionOverrides"
-import type { WorkoutExercise } from "@/types/database"
+import type { WorkoutExerciseWithLabel } from "@/types/database"
 import {
   clearSessionExercisePatchStorage,
   loadSessionExercisePatch,
   saveSessionExercisePatch,
 } from "./sessionExercisePatchStorage"
 
-const row = (id: string): WorkoutExercise => ({
+const row = (id: string): WorkoutExerciseWithLabel => ({
   id,
   workout_day_id: "d",
   exercise_id: "e",
+  exercise: null,
   name_snapshot: "N",
   muscle_snapshot: "M",
   emoji_snapshot: "🏋️",

--- a/src/lib/sessionItems.test.ts
+++ b/src/lib/sessionItems.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, it } from "vitest"
 import { buildSessionItems, sessionItemId } from "@/lib/sessionItems"
 import type {
   ExerciseBlockWithExercises,
-  WorkoutExercise,
+  WorkoutExerciseWithLabel,
 } from "@/types/database"
 
-function solo(id: string, sortOrder: number): WorkoutExercise {
+function solo(id: string, sortOrder: number): WorkoutExerciseWithLabel {
   return {
     id,
     workout_day_id: "day-1",
     exercise_id: `lib-${id}`,
+    exercise: null,
     name_snapshot: id,
     muscle_snapshot: "chest",
     emoji_snapshot: "💪",

--- a/src/lib/sessionItems.ts
+++ b/src/lib/sessionItems.ts
@@ -1,15 +1,16 @@
 import type {
   ExerciseBlockWithExercises,
-  WorkoutExercise,
+  WorkoutExerciseWithLabel,
 } from "@/types/database"
 
 /**
- * One slot in the active-session sequence (#351). Unlike the builder's
- * {@link DayItem}, the solo variant carries a plain `WorkoutExercise` (no
- * `exercise` embed) because the session works off the merged pre-session list.
+ * One slot in the active-session sequence (#351). The solo variant carries only
+ * the label fields of the catalog row, not the full embed the builder's
+ * {@link DayItem} holds: the session works off the merged pre-session list,
+ * where a swapped row is synthesised from the slim picker pool.
  */
 export type SessionItem =
-  | { kind: "solo"; sort_order: number; exercise: WorkoutExercise }
+  | { kind: "solo"; sort_order: number; exercise: WorkoutExerciseWithLabel }
   | { kind: "block"; sort_order: number; block: ExerciseBlockWithExercises }
 
 /**
@@ -18,7 +19,7 @@ export type SessionItem =
  * before blocks on equal `sort_order` for a stable order.
  */
 export function buildSessionItems(
-  exercises: WorkoutExercise[],
+  exercises: WorkoutExerciseWithLabel[],
   blocks: ExerciseBlockWithExercises[],
 ): SessionItem[] {
   const soloItems: SessionItem[] = exercises.map((exercise) => ({

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -123,7 +123,7 @@ import type {
   ExerciseListItem,
   SetLog,
   WorkoutDay,
-  WorkoutExercise,
+  WorkoutExerciseWithLabel,
 } from "@/types/database"
 import { useExerciseById } from "@/hooks/useExerciseById"
 
@@ -140,12 +140,12 @@ function isSyntheticRow(patch: PreSessionExercisePatch, rowId: string): boolean 
 
 function applySessionSwap(
   prev: PreSessionExercisePatch,
-  row: WorkoutExercise,
+  row: WorkoutExerciseWithLabel,
   picked: ExerciseListItem,
   weightStr: string,
 ): PreSessionExercisePatch {
   const next = clonePreSessionPatch(prev)
-  const newRow: WorkoutExercise = {
+  const newRow: WorkoutExerciseWithLabel = {
     ...row,
     exercise_id: picked.id,
     name_snapshot: picked.name,
@@ -153,6 +153,9 @@ function applySessionSwap(
     emoji_snapshot: picked.emoji,
     weight: weightStr,
     target_duration_seconds: null,
+    // The picker row carries the label fields, so a swapped exercise keeps its
+    // localized name instead of degrading to the snapshot it just wrote.
+    exercise: picked,
   }
   const addedIdx = next.addedRows.findIndex((r) => r.id === row.id)
   if (addedIdx >= 0) {
@@ -165,7 +168,7 @@ function applySessionSwap(
 
 function applySessionDelete(
   prev: PreSessionExercisePatch,
-  row: WorkoutExercise,
+  row: WorkoutExerciseWithLabel,
 ): PreSessionExercisePatch {
   const next = clonePreSessionPatch(prev)
   const addedIdx = next.addedRows.findIndex((r) => r.id === row.id)
@@ -180,7 +183,7 @@ function applySessionDelete(
 
 function applySessionAdd(
   prev: PreSessionExercisePatch,
-  row: WorkoutExercise,
+  row: WorkoutExerciseWithLabel,
 ): PreSessionExercisePatch {
   const next = clonePreSessionPatch(prev)
   next.addedRows.push(row)
@@ -188,8 +191,8 @@ function applySessionAdd(
 }
 
 type PendingScopeAction =
-  | { kind: "swap"; row: WorkoutExercise; picked: ExerciseListItem }
-  | { kind: "delete"; row: WorkoutExercise }
+  | { kind: "swap"; row: WorkoutExerciseWithLabel; picked: ExerciseListItem }
+  | { kind: "delete"; row: WorkoutExerciseWithLabel }
   | { kind: "add"; picked: ExerciseListItem }
 
 type SessionFinishedStats = {
@@ -266,7 +269,7 @@ export function WorkoutPage() {
   )
   const [deleteLoggedWarnOpen, setDeleteLoggedWarnOpen] = useState(false)
   const [deleteLoggedWarnRow, setDeleteLoggedWarnRow] =
-    useState<WorkoutExercise | null>(null)
+    useState<WorkoutExerciseWithLabel | null>(null)
   /** Bump on each blocked action so reopen works after dismiss; `open` is derived vs pause + dismiss generation. */
   const pauseBlockNonceRef = useRef(0)
   const [pauseBlockNonce, setPauseBlockNonce] = useState(0)
@@ -547,7 +550,7 @@ export function WorkoutPage() {
               ? -1
               : Math.max(...baseExercises.map((e) => e.sort_order))
           if (scope === "session") {
-            const newRow: WorkoutExercise = {
+            const newRow: WorkoutExerciseWithLabel = {
               id: crypto.randomUUID(),
               workout_day_id: dayId,
               exercise_id: picked.id,
@@ -569,6 +572,8 @@ export function WorkoutPage() {
               // Fresh client-side patch row — no template edit history yet.
               // Server-side INSERT will stamp the real value via DEFAULT now().
               template_updated_at: new Date().toISOString(),
+              // Keeps the localized name on a row added mid-session (see swap).
+              exercise: picked,
             }
             setPreSessionPatch((p) => applySessionAdd(p, newRow))
           } else {
@@ -612,7 +617,7 @@ export function WorkoutPage() {
   const activeSessionDayLabel =
     days?.find((d) => d.id === activeSessionDayId)?.label ?? ""
 
-  const openExerciseDeleteFlow = useCallback((row: WorkoutExercise) => {
+  const openExerciseDeleteFlow = useCallback((row: WorkoutExerciseWithLabel) => {
     const logged = session.isActive && (session.setsData[row.id]?.some((s) => s.done) ?? false)
     if (logged) {
       setDeleteLoggedWarnRow(row)
@@ -629,12 +634,12 @@ export function WorkoutPage() {
       exercisePool,
       poolLoading: exercisePoolLoading,
       allExercises: exercises,
-      onSwapExerciseChosen: (row: WorkoutExercise, picked: ExerciseListItem) => {
+      onSwapExerciseChosen: (row: WorkoutExerciseWithLabel, picked: ExerciseListItem) => {
         setPendingScope({ kind: "swap", row, picked })
         setScopeDialogOpen(true)
       },
       onDeleteRequested: openExerciseDeleteFlow,
-      onSwapBrowseLibrary: (row: WorkoutExercise) => {
+      onSwapBrowseLibrary: (row: WorkoutExerciseWithLabel) => {
         setSwapLibraryRowId(row.id)
       },
     }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -92,6 +92,20 @@ export interface WorkoutExerciseWithExercise extends WorkoutExercise {
   exercise: Exercise | null
 }
 
+/**
+ * A `workout_exercises` row that can resolve a localized label — either straight
+ * from the day query (which embeds the full catalog row) or synthesised
+ * in-session when the user swaps or adds an exercise from the picker.
+ *
+ * Narrower than `WorkoutExerciseWithExercise` on purpose: an `ExerciseListItem`
+ * from the slim pool satisfies the label fields without being a full `Exercise`,
+ * so a swapped row keeps its localized name instead of falling back to the
+ * snapshot.
+ */
+export type WorkoutExerciseWithLabel = WorkoutExercise & {
+  exercise: ExerciseLabelFields | null
+}
+
 /** One round's prescription for a single block exercise. `amount` = reps or duration seconds (per the exercise's measurement_type). */
 export interface PerRoundCell {
   amount: number

--- a/src/types/preSessionOverrides.test.ts
+++ b/src/types/preSessionOverrides.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import type { WorkoutExercise } from "@/types/database"
+import type { WorkoutExerciseWithLabel } from "@/types/database"
 import {
   clonePreSessionPatch,
   deserializePreSessionPatch,
@@ -7,11 +7,12 @@ import {
   serializePreSessionPatch,
 } from "@/types/preSessionOverrides"
 
-function fakeRow(id: string): WorkoutExercise {
+function fakeRow(id: string): WorkoutExerciseWithLabel {
   return {
     id,
     workout_day_id: "d",
     exercise_id: "e",
+    exercise: null,
     name_snapshot: "X",
     muscle_snapshot: "m",
     emoji_snapshot: "🏋️",
@@ -73,5 +74,38 @@ describe("serializePreSessionPatch / deserializePreSessionPatch", () => {
     expect(back.swappedRows.get("r1")?.id).toBe("r1")
     expect(back.addedRows).toHaveLength(1)
     expect(back.addedRows[0]?.id).toBe("add")
+  })
+
+  it("keeps the catalog embed carried by a swapped row", () => {
+    const p = emptyPreSessionPatch()
+    const embed = {
+      id: "lib-1",
+      name: "Développé couché",
+      name_en: "Bench Press",
+      muscle_group: "Pectoraux",
+      equipment: "barbell",
+      emoji: "💪",
+    }
+    p.addedRows.push({ ...fakeRow("add"), exercise: embed })
+
+    const back = deserializePreSessionPatch(serializePreSessionPatch(p))
+
+    expect(back.addedRows[0]?.exercise).toEqual(embed)
+  })
+
+  it("normalises a patch persisted before rows carried an embed", () => {
+    // A patch written by an older build has no `exercise` key at all; leaving it
+    // undefined would contradict the type every consumer relies on.
+    const { exercise: _dropped, ...legacyRow } = fakeRow("legacy")
+    const legacy = {
+      deletedIds: [],
+      swappedRows: [["r1", legacyRow]],
+      addedRows: [legacyRow],
+    } as unknown as ReturnType<typeof serializePreSessionPatch>
+
+    const back = deserializePreSessionPatch(legacy)
+
+    expect(back.addedRows[0]).toHaveProperty("exercise", null)
+    expect(back.swappedRows.get("r1")).toHaveProperty("exercise", null)
   })
 })

--- a/src/types/preSessionOverrides.test.ts
+++ b/src/types/preSessionOverrides.test.ts
@@ -76,7 +76,7 @@ describe("serializePreSessionPatch / deserializePreSessionPatch", () => {
     expect(back.addedRows[0]?.id).toBe("add")
   })
 
-  it("keeps the catalog embed carried by a swapped row", () => {
+  it("keeps the catalog embed on both swapped and added rows", () => {
     const p = emptyPreSessionPatch()
     const embed = {
       id: "lib-1",
@@ -86,10 +86,12 @@ describe("serializePreSessionPatch / deserializePreSessionPatch", () => {
       equipment: "barbell",
       emoji: "💪",
     }
+    p.swappedRows.set("r1", { ...fakeRow("r1"), exercise: embed })
     p.addedRows.push({ ...fakeRow("add"), exercise: embed })
 
     const back = deserializePreSessionPatch(serializePreSessionPatch(p))
 
+    expect(back.swappedRows.get("r1")?.exercise).toEqual(embed)
     expect(back.addedRows[0]?.exercise).toEqual(embed)
   })
 

--- a/src/types/preSessionOverrides.ts
+++ b/src/types/preSessionOverrides.ts
@@ -1,4 +1,4 @@
-import type { WorkoutExercise } from "@/types/database"
+import type { WorkoutExerciseWithLabel } from "@/types/database"
 
 /**
  * Ephemeral list edits (session-only swaps/adds/deletes). Cleared on day change (when not
@@ -7,8 +7,8 @@ import type { WorkoutExercise } from "@/types/database"
  */
 export interface PreSessionExercisePatch {
   deletedIds: Set<string>
-  swappedRows: Map<string, WorkoutExercise>
-  addedRows: WorkoutExercise[]
+  swappedRows: Map<string, WorkoutExerciseWithLabel>
+  addedRows: WorkoutExerciseWithLabel[]
 }
 
 export function emptyPreSessionPatch(): PreSessionExercisePatch {
@@ -32,9 +32,18 @@ export function clonePreSessionPatch(
 /** JSON-safe shape for persisting a patch (e.g. localStorage). */
 export interface SerializedPreSessionExercisePatch {
   deletedIds: string[]
-  swappedRows: [string, WorkoutExercise][]
-  addedRows: WorkoutExercise[]
+  swappedRows: [string, WorkoutExerciseWithLabel][]
+  addedRows: WorkoutExerciseWithLabel[]
 }
+
+/**
+ * A patch persisted before rows carried their catalog embed has no `exercise`
+ * key. Normalise on read so the runtime shape matches the type instead of
+ * leaving an `undefined` to be absorbed downstream.
+ */
+const withEmbed = (
+  row: WorkoutExerciseWithLabel,
+): WorkoutExerciseWithLabel => ({ ...row, exercise: row.exercise ?? null })
 
 export function serializePreSessionPatch(
   p: PreSessionExercisePatch,
@@ -51,7 +60,9 @@ export function deserializePreSessionPatch(
 ): PreSessionExercisePatch {
   return {
     deletedIds: new Set(s.deletedIds),
-    swappedRows: new Map(s.swappedRows),
-    addedRows: [...s.addedRows],
+    swappedRows: new Map(
+      s.swappedRows.map(([id, row]) => [id, withEmbed(row)] as const),
+    ),
+    addedRows: s.addedRows.map(withEmbed),
   }
 }


### PR DESCRIPTION
## What

Eleven surfaces stop reading `name_snapshot` and call `useCatalogLabels().exerciseName(row)`:

- **Session** — `ExerciseDetail`, `ExerciseStrip`, `ExerciseEditRowControls`, `BlockRunner`, `BlockSessionCard`, `WorkoutPage` toasts
- **Builder** — `ExerciseRow`, `ExerciseDetailForm`, `DayEditor`, `BlockCard`, `PerRoundGrid`

`name_snapshot` is still written everywhere it was. It stays the last link of the fallback chain, never a display source.

1800 tests pass — **1789 of them untouched**, which is the French non-regression guarantee.

## Why

This is the bulk of the user-visible win: `name_en` already travels in the payload, the surfaces just had to stop reading the frozen column.

## How

**A type had to be tightened first.** `CatalogNameSource.exercise` was optional in #427, which meant passing a row *without* the embed compiled cleanly and fell back to the snapshot — French names served to English readers, silently. That is this epic's own bug in an undetectable form, and on a 20-site mechanical substitution it was a matter of when, not if. Making the key required (nullable, but present) turned the whole pass into a compiler-driven migration.

**Session rows needed their own type.** The pre-session list is deliberately heterogeneous — `sessionItems.ts` said so in a comment. Rows from the day query carry the full catalog embed; rows synthesised when the user swaps or adds mid-session are built from the *slim* picker pool. So `WorkoutExerciseWithLabel` asks only for the label fields, which both shapes satisfy:

```ts
export type WorkoutExerciseWithLabel = WorkoutExercise & {
  exercise: ExerciseLabelFields | null
}
```

`ExerciseListItem` carries all six label columns, so `exercise: picked` on the swap path is enough — a swapped exercise keeps its localized name instead of degrading to the snapshot it just wrote (**story 10**).

**Persisted patches are normalised on read.** A pre-session patch written by an older build has no `exercise` key; leaving it `undefined` would contradict the type every consumer relies on. One line in the deserializer, one test.

**Logic stayed on canonical values**, as the ticket demands. The swap picker still filters on `muscle_snapshot`. Consumers that read weight/reps — `progression`, `sessionSetRow`, `rirSuggestion`, `sessionFinishStats`, `useAggregatedMuscles` — keep their narrow `WorkoutExercise` parameter: a labelled row is assignable to them, and they have no business seeing the embed. No React key was ever seated on a name, so nothing could remount on a language switch.

## Guards — all verified by mutation

| Mutation | Fails |
|---|---|
| builder row back to `name_snapshot` | English label test |
| session strip back to `name_snapshot` | English label test |
| block card back to `name_snapshot` | English label test |
| drop the persisted-patch normalisation | legacy-patch test |

Dual-locale coverage is one surface per family (builder row, session strip, block card), each asserting the English name appears **and** that the French reader never sees it.

## Separate commit worth a look: `npx tsc --noEmit` verifies nothing here

The repo rule recommended it for local type-checking. It is worse than no check — the root `tsconfig.json` is a solution file (`"files": []` plus references), so it loads zero files and exits 0 on a codebase that cannot compile. I planted a type error in `src/` and watched it pass. The rule now points at `tsc -b` / `tsc -p tsconfig.app.json --noEmit`, which is also what surfaced the 27 fixture errors this PR had to fix.

**Not closing #422** — part of it, ticket T149.

Made with [Cursor](https://cursor.com)