### PR TITLE
feat(i18n): group session history on exercise_id, not on the frozen name

### DIFF
--- a/.cursor/rules/build-sandbox-caveat.mdc
+++ b/.cursor/rules/build-sandbox-caveat.mdc
@@ -36,3 +36,23 @@ npx tsc --noEmit
 # ✅ actually loads src/ and the test files
 npx tsc -p tsconfig.app.json --noEmit
 ```
+
+## Run vitest with the Supabase env stripped
+
+CI has no `.env`, so `src/lib/supabase.ts` throws `supabaseUrl is required.`
+**at import time** there. Locally `.env.local` supplies one, which hides the
+failure: a component test that forgets `vi.mock("@/lib/supabase")` passes on your
+machine and dies in CI before a single test runs.
+
+Reproduce CI by emptying the two variables:
+
+```bash
+VITE_SUPABASE_URL= VITE_SUPABASE_ANON_KEY= npx vitest run
+```
+
+Any test whose component tree reaches the client — directly or transitively —
+needs the stub the other ~50 test files use:
+
+```ts
+vi.mock("@/lib/supabase", () => ({ supabase: { from: vi.fn() } }))
+```

--- a/src/components/history/BlockHistoryCard.test.tsx
+++ b/src/components/history/BlockHistoryCard.test.tsx
@@ -4,9 +4,11 @@ import userEvent from "@testing-library/user-event"
 import { renderWithProviders } from "@/test/utils"
 import { BlockHistoryCard } from "./BlockHistoryCard"
 import type { BlockHistoryGroup } from "@/lib/sessionHistoryGrouping"
-import type { SetLog } from "@/types/database"
+import type { ExerciseLabelFields, SetLogWithExercise } from "@/types/database"
 
-function makeLog(overrides: Partial<SetLog> = {}): SetLog {
+function makeLog(
+  overrides: Partial<SetLogWithExercise> = {},
+): SetLogWithExercise {
   return {
     id: crypto.randomUUID(),
     session_id: "sess-1",
@@ -22,15 +24,26 @@ function makeLog(overrides: Partial<SetLog> = {}): SetLog {
     logged_at: "2026-06-15T10:00:00.000Z",
     rir: null,
     rest_seconds: null,
+    exercise: null,
     ...overrides,
   }
 }
+
+const catalogRow = (name: string, name_en: string): ExerciseLabelFields => ({
+  id: "ex-1",
+  name,
+  name_en,
+  muscle_group: "Pectoraux",
+  equipment: "bodyweight",
+  emoji: "🔥",
+})
 
 /** 2 exercises × 2 rounds, spanning 10:00:00 → 10:04:32 (272s) — a full grid. */
 function makeCompleteGroup(): BlockHistoryGroup {
   const cell = (beId: string, name: string, round: number, at: string) => ({
     blockExerciseId: beId,
-    name,
+    exercise: null,
+    exercise_name_snapshot: name,
     emoji: "🔥",
     log: makeLog({ block_exercise_id: beId, set_number: round, logged_at: at }),
   })
@@ -78,6 +91,37 @@ describe("BlockHistoryCard", () => {
     await userEvent.click(screen.getByRole("button"))
 
     expect(onOpen).toHaveBeenCalledWith(group)
+  })
+
+  it.each([
+    ["en", "Jumping Jacks", "Pompes sautées"],
+    ["fr", "Pompes sautées", "Jumping Jacks"],
+  ] as const)(
+    "labels circuit cells in %s",
+    async (locale, expected, hidden) => {
+      const group = makeCompleteGroup()
+      group.rounds[0].cells[0].exercise = catalogRow(
+        "Pompes sautées",
+        "Jumping Jacks",
+      )
+
+      renderWithProviders(
+        <BlockHistoryCard group={group} formatWeight={(kg) => `${kg} kg`} />,
+        { locale },
+      )
+
+      expect(await screen.findByText(expected)).toBeInTheDocument()
+      expect(screen.queryByText(hidden)).not.toBeInTheDocument()
+    },
+  )
+
+  it("falls back to the snapshot when a cell has no catalog row", () => {
+    renderWithProviders(
+      <BlockHistoryCard group={makeCompleteGroup()} formatWeight={(kg) => `${kg} kg`} />,
+      { locale: "en" },
+    )
+
+    expect(screen.getAllByText("Burpees").length).toBeGreaterThan(0)
   })
 
   it("shows no completion time for an incomplete run (ragged grid)", () => {

--- a/src/components/history/BlockHistoryCard.tsx
+++ b/src/components/history/BlockHistoryCard.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { Layers, Timer } from "lucide-react"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { formatSecondsMMSS } from "@/lib/formatters"
 import {
   isRunComplete,
@@ -39,6 +40,7 @@ export function BlockHistoryCard({
   onOpen?: (group: BlockHistoryGroup) => void
 }) {
   const { t } = useTranslation("history")
+  const { exerciseName } = useCatalogLabels()
   const cells = groupCells(group)
   const completionTime = isRunComplete(cells)
     ? formatSecondsMMSS(runCompletionSeconds(cells))
@@ -81,7 +83,7 @@ export function BlockHistoryCard({
                   className="flex items-center gap-2 text-xs"
                 >
                   <span aria-hidden>{cell.emoji}</span>
-                  <span className="flex-1 truncate">{cell.name}</span>
+                  <span className="flex-1 truncate">{exerciseName(cell)}</span>
                   <span className="tabular-nums text-muted-foreground">
                     {cell.log.duration_seconds != null
                       ? formatSecondsMMSS(cell.log.duration_seconds)

--- a/src/components/history/ExerciseTab.test.tsx
+++ b/src/components/history/ExerciseTab.test.tsx
@@ -1,0 +1,75 @@
+import { vi, describe, it, expect, beforeEach } from "vitest"
+import { screen, waitFor, act } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { renderWithProviders, type TestLocale } from "@/test/utils"
+import { authAtom } from "@/store/atoms"
+import { ExerciseTab } from "./ExerciseTab"
+
+const selectFn = vi.fn()
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: vi.fn(() => ({ select: selectFn })) },
+}))
+
+const fetchExercisesByIds = vi.hoisted(() => vi.fn())
+vi.mock("@/lib/fetchExercisesByIds", () => ({ fetchExercisesByIds }))
+
+vi.mock("@/components/history/ExerciseChart", () => ({
+  ExerciseChart: () => <div>chart</div>,
+}))
+
+function renderTab(locale: TestLocale) {
+  const rendered = renderWithProviders(<ExerciseTab />, { locale })
+  act(() => {
+    rendered.store.set(authAtom, { id: "user-1" } as never)
+  })
+  return rendered
+}
+
+describe("ExerciseTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectFn.mockResolvedValue({
+      data: [{ exercise_id: "a", exercise_name_snapshot: "Développé couché" }],
+      error: null,
+    })
+    fetchExercisesByIds.mockResolvedValue([
+      {
+        id: "a",
+        name: "Développé couché",
+        name_en: "Bench Press",
+        muscle_group: "Pectoraux",
+        equipment: "barbell",
+        emoji: "🏋️",
+      },
+    ])
+  })
+
+  it("filters on the label it displays, not on the snapshot", async () => {
+    renderTab("en")
+
+    await userEvent.click(screen.getByRole("combobox"))
+    await waitFor(() =>
+      expect(screen.getByText("Bench Press")).toBeInTheDocument(),
+    )
+
+    // The snapshot is French; typing what's on screen has to find the row.
+    await userEvent.type(
+      screen.getByPlaceholderText("Search exercises…"),
+      "Bench",
+    )
+
+    expect(screen.getByText("Bench Press")).toBeInTheDocument()
+  })
+
+  it("shows the French label to a French reader", async () => {
+    renderTab("fr")
+
+    await userEvent.click(screen.getByRole("combobox"))
+
+    await waitFor(() =>
+      expect(screen.getByText("Développé couché")).toBeInTheDocument(),
+    )
+    expect(screen.queryByText("Bench Press")).not.toBeInTheDocument()
+  })
+})

--- a/src/components/history/SessionRow.test.tsx
+++ b/src/components/history/SessionRow.test.tsx
@@ -9,6 +9,10 @@ import type {
 } from "@/types/database"
 import { SessionRow } from "./SessionRow"
 
+// The circuit sheet pulls in the real client transitively, which throws on
+// import when the env has no Supabase URL — as CI's does.
+vi.mock("@/lib/supabase", () => ({ supabase: { from: vi.fn() } }))
+
 const useSessionSetLogs = vi.hoisted(() => vi.fn())
 vi.mock("@/hooks/useSessionSetLogs", () => ({ useSessionSetLogs }))
 

--- a/src/components/history/SessionRow.test.tsx
+++ b/src/components/history/SessionRow.test.tsx
@@ -1,0 +1,114 @@
+import { vi, describe, it, expect, beforeEach } from "vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { renderWithProviders, mockQueryResult, type TestLocale } from "@/test/utils"
+import type {
+  ExerciseLabelFields,
+  Session,
+  SetLogWithExercise,
+} from "@/types/database"
+import { SessionRow } from "./SessionRow"
+
+const useSessionSetLogs = vi.hoisted(() => vi.fn())
+vi.mock("@/hooks/useSessionSetLogs", () => ({ useSessionSetLogs }))
+
+const useSessionBlockMeta = vi.hoisted(() => vi.fn())
+vi.mock("@/hooks/useSessionBlockMeta", () => ({ useSessionBlockMeta }))
+
+const session: Session = {
+  id: "sess-1",
+  user_id: "user-1",
+  workout_day_id: "day-1",
+  workout_label_snapshot: "Lundi",
+  started_at: "2026-06-15T10:00:00.000Z",
+  finished_at: "2026-06-15T11:00:00.000Z",
+  active_duration_ms: 3_600_000,
+  total_sets_done: 3,
+  has_skipped_sets: false,
+  cycle_id: "cyc-1",
+}
+
+const catalog = (name: string, name_en: string): ExerciseLabelFields => ({
+  id: "ex-1",
+  name,
+  name_en,
+  muscle_group: "Pectoraux",
+  equipment: "barbell",
+  emoji: "🏋️",
+})
+
+const log = (over: Partial<SetLogWithExercise> = {}): SetLogWithExercise => ({
+  id: crypto.randomUUID(),
+  session_id: "sess-1",
+  exercise_id: "ex-1",
+  block_exercise_id: null,
+  exercise_name_snapshot: "Frozen name",
+  set_number: 1,
+  reps_logged: "10",
+  duration_seconds: null,
+  weight_logged: 100,
+  estimated_1rm: null,
+  was_pr: false,
+  logged_at: "2026-06-15T10:00:00.000Z",
+  rir: null,
+  rest_seconds: null,
+  exercise: null,
+  ...over,
+})
+
+async function expand(locale: TestLocale) {
+  renderWithProviders(<SessionRow session={session} />, { locale })
+  await userEvent.click(screen.getByRole("button"))
+}
+
+describe("SessionRow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useSessionBlockMeta.mockReturnValue(mockQueryResult(new Map()))
+  })
+
+  it.each([
+    ["en", "Bench Press", "Développé couché"],
+    ["fr", "Développé couché", "Bench Press"],
+  ] as const)("names a solo group in %s", async (locale, expected, hidden) => {
+    useSessionSetLogs.mockReturnValue(
+      mockQueryResult([log({ exercise: catalog("Développé couché", "Bench Press") })]),
+    )
+
+    await expand(locale)
+
+    expect(screen.getByText(expected)).toBeInTheDocument()
+    expect(screen.queryByText(hidden)).not.toBeInTheDocument()
+    expect(screen.queryByText("Frozen name")).not.toBeInTheDocument()
+  })
+
+  it("falls back to the snapshot when the catalog row is gone", async () => {
+    useSessionSetLogs.mockReturnValue(mockQueryResult([log({ exercise: null })]))
+
+    await expand("en")
+
+    expect(screen.getByText("Frozen name")).toBeInTheDocument()
+  })
+
+  it("shows a revisited exercise once, in the order it was trained", async () => {
+    const bench = catalog("Développé couché", "Bench Press")
+    const row = { ...catalog("Rowing", "Barbell Row"), id: "ex-2" }
+    useSessionSetLogs.mockReturnValue(
+      mockQueryResult([
+        log({ exercise_id: "a", exercise: bench, set_number: 1, logged_at: "2026-06-15T10:00:00Z" }),
+        log({ exercise_id: "b", exercise: row, set_number: 1, logged_at: "2026-06-15T10:02:00Z" }),
+        log({ exercise_id: "a", exercise: bench, set_number: 2, logged_at: "2026-06-15T10:04:00Z" }),
+      ]),
+    )
+
+    await expand("en")
+
+    // One heading each, Bench first because it was logged first — alphabetical
+    // order would have put "Barbell Row" on top.
+    expect(screen.getAllByText("Bench Press")).toHaveLength(1)
+    const headings = screen
+      .getAllByText(/Bench Press|Barbell Row/)
+      .map((el) => el.textContent)
+    expect(headings).toEqual(["Bench Press", "Barbell Row"])
+  })
+})

--- a/src/components/history/SessionRow.tsx
+++ b/src/components/history/SessionRow.tsx
@@ -5,6 +5,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { Badge } from "@/components/ui/badge"
 import { useSessionSetLogs } from "@/hooks/useSessionSetLogs"
 import { useSessionBlockMeta } from "@/hooks/useSessionBlockMeta"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 import { computeEpley1RM } from "@/lib/epley"
 import { formatDate, formatSecondsMMSS } from "@/lib/formatters"
@@ -16,6 +17,7 @@ import type { Session, SetLog } from "@/types/database"
 
 function SessionSetLogs({ sessionId }: { sessionId: string }) {
   const { t } = useTranslation("history")
+  const { exerciseName } = useCatalogLabels()
   const { formatWeight } = useWeightUnit()
   const { data: logs, isLoading } = useSessionSetLogs(sessionId)
   const [openCircuit, setOpenCircuit] = useState<BlockHistoryGroup | null>(null)
@@ -49,7 +51,9 @@ function SessionSetLogs({ sessionId }: { sessionId: string }) {
           />
         ) : (
           <div key={item.key}>
-            <p className="mb-1 text-xs font-semibold text-foreground">{item.name}</p>
+            <p className="mb-1 text-xs font-semibold text-foreground">
+              {exerciseName(item)}
+            </p>
             <div className="grid grid-cols-[2rem_1fr_1fr_1fr_auto] gap-x-2 gap-y-0.5 text-xs">
               <span className="text-muted-foreground">#</span>
               <span className="text-muted-foreground">{t("workout:reps", { defaultValue: "Reps" })}</span>

--- a/src/hooks/useExerciseHistory.test.ts
+++ b/src/hooks/useExerciseHistory.test.ts
@@ -1,6 +1,6 @@
 import { vi, describe, it, expect, beforeEach } from "vitest"
 import { waitFor, act } from "@testing-library/react"
-import { renderHookWithProviders } from "@/test/utils"
+import { renderHookWithProviders, type TestLocale } from "@/test/utils"
 import { authAtom } from "@/store/atoms"
 import { useExerciseHistory } from "./useExerciseHistory"
 
@@ -26,8 +26,8 @@ function mockLogs(rows: { exercise_id: string; exercise_name_snapshot: string }[
   selectFn.mockResolvedValue({ data: rows, error: null })
 }
 
-function render() {
-  const rendered = renderHookWithProviders(() => useExerciseHistory())
+function render(locale: TestLocale = "en") {
+  const rendered = renderHookWithProviders(() => useExerciseHistory(), { locale })
   act(() => {
     rendered.store.set(authAtom, { id: "user-1" } as never)
   })
@@ -65,22 +65,65 @@ describe("useExerciseHistory", () => {
     expect(fetchExercisesByIds.mock.calls[0][1]).not.toContain("*")
   })
 
-  it("attaches the catalog row so T150 can localize the label", async () => {
-    mockLogs([{ exercise_id: "a", exercise_name_snapshot: "Développé couché" }])
+  it.each([
+    ["en", "Bench Press"],
+    ["fr", "Développé couché"],
+  ] as const)("labels the option in %s", async (locale, expected) => {
+    mockLogs([{ exercise_id: "a", exercise_name_snapshot: "Frozen" }])
     fetchExercisesByIds.mockResolvedValue([
       catalogRow("a", "Développé couché", "Bench Press"),
     ])
 
-    const { result } = render()
+    const { result } = render(locale)
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     expect(result.current.data).toEqual([
       {
         id: "a",
-        name: "Développé couché",
+        name: expected,
         exercise: catalogRow("a", "Développé couché", "Bench Press"),
       },
     ])
+  })
+
+  it("sorts on the resolved label, not on the snapshot", async () => {
+    mockLogs([
+      { exercise_id: "a", exercise_name_snapshot: "Abdos" },
+      { exercise_id: "z", exercise_name_snapshot: "Zurcher" },
+    ])
+    // English labels invert the French alphabetical order, so sorting on the
+    // snapshot would hand an English reader a list that isn't alphabetical.
+    fetchExercisesByIds.mockResolvedValue([
+      catalogRow("a", "Abdos", "Zebra Crunch"),
+      catalogRow("z", "Zurcher", "Air Squat"),
+    ])
+
+    const { result } = render("en")
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.map((o) => o.name)).toEqual([
+      "Air Squat",
+      "Zebra Crunch",
+    ])
+  })
+
+  it("re-labels from cache when the language changes, without refetching", async () => {
+    mockLogs([{ exercise_id: "a", exercise_name_snapshot: "Frozen" }])
+    fetchExercisesByIds.mockResolvedValue([
+      catalogRow("a", "Développé couché", "Bench Press"),
+    ])
+
+    const { result, i18nInstance } = render("en")
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.[0].name).toBe("Bench Press")
+
+    await act(async () => {
+      await i18nInstance.changeLanguage("fr")
+    })
+
+    expect(result.current.data?.[0].name).toBe("Développé couché")
+    expect(selectFn).toHaveBeenCalledTimes(1)
+    expect(fetchExercisesByIds).toHaveBeenCalledTimes(1)
   })
 
   it("keeps the option with a null embed when the catalog omits the id", async () => {

--- a/src/hooks/useExerciseHistory.ts
+++ b/src/hooks/useExerciseHistory.ts
@@ -1,16 +1,27 @@
+import { useCallback } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
+import { useTranslation } from "react-i18next"
 import { supabase } from "@/lib/supabase"
 import { authAtom } from "@/store/atoms"
+import { resolveExerciseName } from "@/lib/catalogLabels"
 import { LABEL_EXERCISE_SELECT } from "@/lib/exerciseSelects"
 import { fetchExercisesByIds } from "@/lib/fetchExercisesByIds"
 import type { ExerciseLabelFields } from "@/types/database"
 
+/** What the query caches: locale-independent, so switching language never refetches. */
+interface ExerciseHistoryRow {
+  id: string
+  exercise: ExerciseLabelFields | null
+  exercise_name_snapshot: string
+}
+
 export interface ExerciseOption {
   id: string
   /**
-   * Snapshot name, kept as the display value here. T150 resolves the localized
-   * label from `exercise` and sorts on it.
+   * The label as it appears on screen, already resolved for the reader's locale.
+   * Consumers filter and sort on this, which is what stops a search for "Bench"
+   * from missing the row that reads "Bench Press".
    */
   name: string
   /** Catalog row for the localized label; null when it isn't readable. */
@@ -29,8 +40,25 @@ export interface ExerciseOption {
  */
 export function useExerciseHistory() {
   const user = useAtomValue(authAtom)
+  const { i18n } = useTranslation()
+  const { language } = i18n
 
-  return useQuery<ExerciseOption[]>({
+  // Labels and alphabetical order both depend on the locale, so they belong in
+  // `select` rather than in `queryFn`: changing language re-derives the list
+  // from cache instead of hitting the network again.
+  const toOptions = useCallback(
+    (rows: ExerciseHistoryRow[]): ExerciseOption[] =>
+      rows
+        .map((row) => ({
+          id: row.id,
+          name: resolveExerciseName(row, language),
+          exercise: row.exercise,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name, language)),
+    [language],
+  )
+
+  return useQuery<ExerciseHistoryRow[], Error, ExerciseOption[]>({
     queryKey: ["exercise-history"],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -56,14 +84,13 @@ export function useExerciseHistory() {
       )
       const catalogById = new Map(catalog.map((row) => [row.id, row] as const))
 
-      return ids
-        .map((id) => ({
-          id,
-          name: snapshotById.get(id) ?? "",
-          exercise: catalogById.get(id) ?? null,
-        }))
-        .sort((a, b) => a.name.localeCompare(b.name))
+      return ids.map((id) => ({
+        id,
+        exercise: catalogById.get(id) ?? null,
+        exercise_name_snapshot: snapshotById.get(id) ?? "",
+      }))
     },
+    select: toOptions,
     enabled: !!user,
   })
 }

--- a/src/hooks/useSessionSetLogs.test.ts
+++ b/src/hooks/useSessionSetLogs.test.ts
@@ -1,0 +1,60 @@
+import { vi, describe, it, expect, beforeEach } from "vitest"
+import { waitFor } from "@testing-library/react"
+import { renderHookWithProviders } from "@/test/utils"
+import { useSessionSetLogs } from "./useSessionSetLogs"
+
+const spies = vi.hoisted(() => ({
+  select: vi.fn(),
+  order: vi.fn(),
+}))
+
+vi.mock("@/lib/supabase", () => {
+  const chain = {
+    select: (arg: string) => {
+      spies.select(arg)
+      return chain
+    },
+    eq: () => chain,
+    order: (arg: string) => {
+      spies.order(arg)
+      return chain
+    },
+    then: (resolve: (v: { data: unknown[]; error: null }) => void) =>
+      resolve({ data: [], error: null }),
+  }
+  return { supabase: { from: () => chain } }
+})
+
+describe("useSessionSetLogs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("orders chronologically, not on the frozen name", async () => {
+    const { result } = renderHookWithProviders(() => useSessionSetLogs("sess-1"))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // The snapshot is a frozen French name: ordering on it made a session read
+    // in a different order depending on the reader's language.
+    expect(spies.order.mock.calls.map(([column]) => column)).toEqual([
+      "logged_at",
+      "set_number",
+    ])
+  })
+
+  it("embeds the catalog row so labels resolve at render", async () => {
+    const { result } = renderHookWithProviders(() => useSessionSetLogs("sess-1"))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(spies.select).toHaveBeenCalledWith(
+      expect.stringContaining("exercise:exercises("),
+    )
+  })
+
+  it("stays idle without a session", () => {
+    const { result } = renderHookWithProviders(() => useSessionSetLogs(null))
+
+    expect(result.current.fetchStatus).toBe("idle")
+    expect(spies.select).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useSessionSetLogs.ts
+++ b/src/hooks/useSessionSetLogs.ts
@@ -11,7 +11,10 @@ export function useSessionSetLogs(sessionId: string | null) {
         .from("set_logs")
         .select(`*, exercise:exercises(${LABEL_EXERCISE_SELECT})`)
         .eq("session_id", sessionId!)
-        .order("exercise_name_snapshot")
+        // Chronological, not alphabetical: the snapshot is a frozen French name,
+        // so ordering on it made the session read differently per locale — and
+        // it can't order a list whose labels are resolved at render (T150).
+        .order("logged_at")
         .order("set_number")
 
       if (error) throw error

--- a/src/lib/sessionHistoryGrouping.test.ts
+++ b/src/lib/sessionHistoryGrouping.test.ts
@@ -120,6 +120,27 @@ describe("groupSessionHistory", () => {
     expect(items.map((i) => i.key)).toEqual(["zzz", "aaa"])
   })
 
+  it("stays chronological when the caller hands over unsorted logs", () => {
+    const logs = [
+      log({ exercise_id: "row", logged_at: at(5) }),
+      log({ exercise_id: "bench", logged_at: at(9), set_number: 2 }),
+      log({
+        exercise_id: "bench",
+        logged_at: at(1),
+        set_number: 1,
+        exercise_name_snapshot: "Earliest",
+      }),
+    ]
+    const [bench, row] = groupSessionHistory(logs, new Map()) as SoloHistoryGroup[]
+
+    // Bench was trained first even though its earliest log arrives last.
+    expect([bench.key, row.key]).toEqual(["bench", "row"])
+    expect(bench.sets.map((s) => s.set_number)).toEqual([1, 2])
+    // The group describes itself with its earliest log, not with whichever one
+    // the caller happened to put first.
+    expect(bench.exercise_name_snapshot).toBe("Earliest")
+  })
+
   it("exposes the catalog row and the snapshot so the label resolves at render", () => {
     const embed = {
       id: "bench",

--- a/src/lib/sessionHistoryGrouping.test.ts
+++ b/src/lib/sessionHistoryGrouping.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from "vitest"
+import { resolveExerciseName } from "@/lib/catalogLabels"
 import {
   buildBlockMetaMap,
   groupSessionHistory,
   type BlockExerciseMetaRow,
   type BlockMeta,
+  type SoloHistoryGroup,
 } from "@/lib/sessionHistoryGrouping"
-import type { SetLog } from "@/types/database"
+import type { SetLogWithExercise } from "@/types/database"
 
-const log = (over: Partial<SetLog> = {}): SetLog => ({
+const log = (over: Partial<SetLogWithExercise> = {}): SetLogWithExercise => ({
   id: crypto.randomUUID(),
   session_id: "s1",
   exercise_id: "ex",
@@ -22,8 +24,12 @@ const log = (over: Partial<SetLog> = {}): SetLog => ({
   logged_at: "2026-06-13T10:00:00Z",
   rir: null,
   rest_seconds: null,
+  exercise: null,
   ...over,
 })
+
+const at = (minutes: number) =>
+  new Date(Date.UTC(2026, 5, 13, 10, minutes)).toISOString()
 
 const meta = (over: Partial<BlockMeta> = {}): BlockMeta => ({
   blockId: "blk1",
@@ -65,17 +71,79 @@ describe("buildBlockMetaMap", () => {
 })
 
 describe("groupSessionHistory", () => {
-  it("keeps solo-only sessions as consecutive-name groups", () => {
+  it("groups solos by exercise_id", () => {
     const logs = [
-      log({ exercise_name_snapshot: "Bench", set_number: 1 }),
-      log({ exercise_name_snapshot: "Bench", set_number: 2 }),
-      log({ exercise_name_snapshot: "Row", set_number: 1 }),
+      log({ exercise_id: "bench", set_number: 1, logged_at: at(0) }),
+      log({ exercise_id: "bench", set_number: 2, logged_at: at(2) }),
+      log({ exercise_id: "row", set_number: 1, logged_at: at(4) }),
     ]
     const items = groupSessionHistory(logs, new Map())
     expect(items).toHaveLength(2)
-    expect(items[0]).toMatchObject({ kind: "solo", name: "Bench" })
-    expect((items[0] as { sets: SetLog[] }).sets).toHaveLength(2)
-    expect(items[1]).toMatchObject({ kind: "solo", name: "Row" })
+    expect(items.map((i) => i.key)).toEqual(["bench", "row"])
+    expect((items[0] as SoloHistoryGroup).sets).toHaveLength(2)
+  })
+
+  it("keeps one group when a solo is revisited later in the session", () => {
+    // Logs now arrive in logging order, so a user who comes back to add a set
+    // interleaves them — consecutive-name grouping would show Bench twice.
+    const logs = [
+      log({ exercise_id: "bench", set_number: 1, logged_at: at(0) }),
+      log({ exercise_id: "row", set_number: 1, logged_at: at(2) }),
+      log({ exercise_id: "bench", set_number: 2, logged_at: at(4) }),
+    ]
+    const items = groupSessionHistory(logs, new Map())
+    expect(items).toHaveLength(2)
+    expect((items[0] as SoloHistoryGroup).sets.map((s) => s.set_number)).toEqual(
+      [1, 2],
+    )
+  })
+
+  it("keeps one group when the same exercise carries two different snapshots", () => {
+    const logs = [
+      log({ exercise_id: "squat", exercise_name_snapshot: "Squat", logged_at: at(0) }),
+      log({
+        exercise_id: "squat",
+        exercise_name_snapshot: "Barbell Squat",
+        logged_at: at(2),
+      }),
+    ]
+    const items = groupSessionHistory(logs, new Map())
+    expect(items).toHaveLength(1)
+  })
+
+  it("orders solo groups by their first log, not alphabetically", () => {
+    const logs = [
+      log({ exercise_id: "zzz", exercise_name_snapshot: "Zurcher", logged_at: at(0) }),
+      log({ exercise_id: "aaa", exercise_name_snapshot: "Arnold", logged_at: at(5) }),
+    ]
+    const items = groupSessionHistory(logs, new Map())
+    expect(items.map((i) => i.key)).toEqual(["zzz", "aaa"])
+  })
+
+  it("exposes the catalog row and the snapshot so the label resolves at render", () => {
+    const embed = {
+      id: "bench",
+      name: "Développé couché",
+      name_en: "Bench Press",
+      muscle_group: "Pectoraux",
+      equipment: "barbell",
+      emoji: "🏋️",
+    }
+    const logs = [
+      log({ exercise_id: "bench", exercise_name_snapshot: "Frozen", exercise: embed }),
+    ]
+    const [group] = groupSessionHistory(logs, new Map()) as SoloHistoryGroup[]
+
+    expect(group.exercise).toEqual(embed)
+    expect(group.exercise_name_snapshot).toBe("Frozen")
+    expect(resolveExerciseName(group, "en")).toBe("Bench Press")
+    expect(resolveExerciseName(group, "fr")).toBe("Développé couché")
+  })
+
+  it("falls back to the snapshot when the catalog row is gone", () => {
+    const logs = [log({ exercise_name_snapshot: "Deleted exo", exercise: null })]
+    const [group] = groupSessionHistory(logs, new Map()) as SoloHistoryGroup[]
+    expect(resolveExerciseName(group, "en")).toBe("Deleted exo")
   })
 
   it("groups block cells into one circuit, round-major, ordered by position", () => {
@@ -98,15 +166,39 @@ describe("groupSessionHistory", () => {
     expect(block.exerciseCount).toBe(2)
     expect(block.rounds.map((r) => r.round)).toEqual([1, 2])
     // position 0 (A) before position 1 (B) within each round
-    expect(block.rounds[0].cells.map((c) => c.name)).toEqual(["Curl A", "Curl B"])
+    expect(
+      block.rounds[0].cells.map((c) => c.exercise_name_snapshot),
+    ).toEqual(["Curl A", "Curl B"])
     expect(block.rounds[1].cells.map((c) => c.log.weight_logged)).toEqual([22, 17])
+  })
+
+  it("carries the catalog row onto block cells too", () => {
+    const metaById = new Map<string, BlockMeta>([["beA", meta()]])
+    const embed = {
+      id: "curl",
+      name: "Curl biceps",
+      name_en: "Biceps Curl",
+      muscle_group: "Biceps",
+      equipment: "dumbbell",
+      emoji: "💪",
+    }
+    const logs = [log({ block_exercise_id: "beA", exercise: embed })]
+    const [block] = groupSessionHistory(logs, metaById)
+    if (block.kind !== "block") throw new Error("expected block")
+
+    const [cell] = block.rounds[0].cells
+    expect(resolveExerciseName(cell, "en")).toBe("Biceps Curl")
+    expect(resolveExerciseName(cell, "fr")).toBe("Curl biceps")
   })
 
   it("treats a block log with missing meta as a solo (orphan fallback)", () => {
     const logs = [log({ block_exercise_id: "ghost", exercise_name_snapshot: "Deleted circuit exo" })]
     const items = groupSessionHistory(logs, new Map())
     expect(items).toHaveLength(1)
-    expect(items[0]).toMatchObject({ kind: "solo", name: "Deleted circuit exo" })
+    expect(items[0]).toMatchObject({
+      kind: "solo",
+      exercise_name_snapshot: "Deleted circuit exo",
+    })
   })
 
   it("renders circuits before solos, circuits ordered by day sort_order", () => {
@@ -120,7 +212,9 @@ describe("groupSessionHistory", () => {
       log({ block_exercise_id: "beEarly" }),
     ]
     const items = groupSessionHistory(logs, metaById)
-    expect(items.map((i) => (i.kind === "block" ? i.label : i.name))).toEqual([
+    expect(
+      items.map((i) => (i.kind === "block" ? i.label : i.exercise_name_snapshot)),
+    ).toEqual([
       "Early",
       "Late",
       "Solo squat",

--- a/src/lib/sessionHistoryGrouping.ts
+++ b/src/lib/sessionHistoryGrouping.ts
@@ -1,5 +1,10 @@
+import { groupBy } from "@/lib/utils"
 import type { CatalogNameSource } from "@/lib/catalogLabels"
 import type { ExerciseLabelFields, SetLogWithExercise } from "@/types/database"
+
+/** `set_number` breaks ties: bulk-inserted logs can share a `logged_at`. */
+const byLoggedThenSetNumber = (a: SetLogWithExercise, b: SetLogWithExercise) =>
+  Date.parse(a.logged_at) - Date.parse(b.logged_at) || a.set_number - b.set_number
 
 /**
  * Block metadata needed to render a circuit's history card, resolved per
@@ -94,10 +99,11 @@ export type SessionHistoryItem = SoloHistoryGroup | BlockHistoryGroup
  *   `metaById`. Orphaned block logs (template deleted → `ON DELETE SET NULL`,
  *   or meta not yet loaded) fall back to a flat solo group — snapshots on the
  *   row keep them coherent.
- * - Solo groups are keyed on `exercise_id` and ordered by their first log, so a
- *   revisited exercise stays one group and the session reads chronologically.
+ * - Solo groups are keyed on `exercise_id` and ordered by their earliest log, so
+ *   a revisited exercise stays one group and the session reads chronologically.
  *   Grouping on the name would split a renamed exercise in two, and would split
- *   every revisited one now that logs arrive in logging order.
+ *   every revisited one now that logs arrive in logging order. The output does
+ *   not depend on the order `logs` arrives in.
  * - Block cells are grouped by their parent `block_id`, split into rounds
  *   (`set_number`), and ordered within a round by the exercise's `position`.
  * - Circuits render first (by their day `sort_order`), then solos — a solo-only
@@ -114,25 +120,23 @@ export function groupSessionHistory(
 
   const soloLogs = logs.filter((log) => !isBlockLog(log))
   const soloGroups: SoloHistoryGroup[] = [
-    ...new Set(soloLogs.map((log) => log.exercise_id)),
+    ...groupBy(soloLogs, (log) => log.exercise_id),
   ]
-    .map((exerciseId) => {
-      const sets = soloLogs.filter((log) => log.exercise_id === exerciseId)
-      const [first] = sets
-      return {
-        kind: "solo" as const,
-        key: exerciseId,
-        exercise: first.exercise,
-        exercise_name_snapshot: first.exercise_name_snapshot,
-        sets,
-      }
+    // Sorted, not merely grouped: the result must not depend on the order the
+    // caller hands over, so every group derives its position *and* its identity
+    // from its earliest log rather than from whichever one arrived first.
+    .map(([exerciseId, logsForExercise]) => {
+      const sets = [...logsForExercise].sort(byLoggedThenSetNumber)
+      return { exerciseId, sets, first: sets[0] }
     })
-    // Explicit rather than relying on the caller's order: the query sorts on
-    // `logged_at`, but the contract shouldn't be a second place to break.
-    .sort(
-      (a, b) =>
-        Date.parse(a.sets[0].logged_at) - Date.parse(b.sets[0].logged_at),
-    )
+    .sort((a, b) => byLoggedThenSetNumber(a.first, b.first))
+    .map(({ exerciseId, sets, first }) => ({
+      kind: "solo" as const,
+      key: exerciseId,
+      exercise: first.exercise,
+      exercise_name_snapshot: first.exercise_name_snapshot,
+      sets,
+    }))
 
   const blockLogs = logs.filter(isBlockLog)
   const byBlockId = blockLogs.reduce<Map<string, SetLogWithExercise[]>>((acc, log) => {

--- a/src/lib/sessionHistoryGrouping.ts
+++ b/src/lib/sessionHistoryGrouping.ts
@@ -1,4 +1,5 @@
-import type { SetLog } from "@/types/database"
+import type { CatalogNameSource } from "@/lib/catalogLabels"
+import type { ExerciseLabelFields, SetLogWithExercise } from "@/types/database"
 
 /**
  * Block metadata needed to render a circuit's history card, resolved per
@@ -48,18 +49,26 @@ export function buildBlockMetaMap(
   )
 }
 
-export interface SoloHistoryGroup {
+/**
+ * Both history units extend {@link CatalogNameSource}: a caller renders the name
+ * with `exerciseName(group)` / `exerciseName(cell)` and cannot accidentally
+ * display the frozen snapshot, because no field holds a display-ready name.
+ */
+export interface SoloHistoryGroup extends CatalogNameSource {
   kind: "solo"
+  /** `exercise_id`: the group's identity, and a language-independent React key. */
   key: string
-  name: string
-  sets: SetLog[]
+  exercise: ExerciseLabelFields | null
+  exercise_name_snapshot: string
+  sets: SetLogWithExercise[]
 }
 
-export interface BlockHistoryCell {
+export interface BlockHistoryCell extends CatalogNameSource {
   blockExerciseId: string
-  name: string
+  exercise: ExerciseLabelFields | null
+  exercise_name_snapshot: string
   emoji: string | null
-  log: SetLog
+  log: SetLogWithExercise
 }
 
 export interface BlockHistoryRound {
@@ -85,41 +94,48 @@ export type SessionHistoryItem = SoloHistoryGroup | BlockHistoryGroup
  *   `metaById`. Orphaned block logs (template deleted → `ON DELETE SET NULL`,
  *   or meta not yet loaded) fall back to a flat solo group — snapshots on the
  *   row keep them coherent.
- * - Solo groups keep the existing consecutive-name behavior (logs arrive
- *   ordered by `exercise_name_snapshot`).
+ * - Solo groups are keyed on `exercise_id` and ordered by their first log, so a
+ *   revisited exercise stays one group and the session reads chronologically.
+ *   Grouping on the name would split a renamed exercise in two, and would split
+ *   every revisited one now that logs arrive in logging order.
  * - Block cells are grouped by their parent `block_id`, split into rounds
  *   (`set_number`), and ordered within a round by the exercise's `position`.
  * - Circuits render first (by their day `sort_order`), then solos — a solo-only
  *   session is therefore unchanged.
  */
 export function groupSessionHistory(
-  logs: SetLog[],
+  logs: SetLogWithExercise[],
   metaById: Map<string, BlockMeta>,
 ): SessionHistoryItem[] {
-  const isBlockLog = (log: SetLog): log is SetLog & { block_exercise_id: string } =>
+  const isBlockLog = (
+    log: SetLogWithExercise,
+  ): log is SetLogWithExercise & { block_exercise_id: string } =>
     log.block_exercise_id != null && metaById.has(log.block_exercise_id)
 
-  const soloGroups = logs
-    .filter((log) => !isBlockLog(log))
-    .reduce<SoloHistoryGroup[]>((groups, log) => {
-      const last = groups.at(-1)
-      if (last && last.name === log.exercise_name_snapshot) {
-        last.sets.push(log)
-        return groups
+  const soloLogs = logs.filter((log) => !isBlockLog(log))
+  const soloGroups: SoloHistoryGroup[] = [
+    ...new Set(soloLogs.map((log) => log.exercise_id)),
+  ]
+    .map((exerciseId) => {
+      const sets = soloLogs.filter((log) => log.exercise_id === exerciseId)
+      const [first] = sets
+      return {
+        kind: "solo" as const,
+        key: exerciseId,
+        exercise: first.exercise,
+        exercise_name_snapshot: first.exercise_name_snapshot,
+        sets,
       }
-      return [
-        ...groups,
-        {
-          kind: "solo",
-          key: `solo-${groups.length}-${log.exercise_name_snapshot}`,
-          name: log.exercise_name_snapshot,
-          sets: [log],
-        },
-      ]
-    }, [])
+    })
+    // Explicit rather than relying on the caller's order: the query sorts on
+    // `logged_at`, but the contract shouldn't be a second place to break.
+    .sort(
+      (a, b) =>
+        Date.parse(a.sets[0].logged_at) - Date.parse(b.sets[0].logged_at),
+    )
 
   const blockLogs = logs.filter(isBlockLog)
-  const byBlockId = blockLogs.reduce<Map<string, SetLog[]>>((acc, log) => {
+  const byBlockId = blockLogs.reduce<Map<string, SetLogWithExercise[]>>((acc, log) => {
     const { blockId } = metaById.get(log.block_exercise_id)!
     acc.set(blockId, [...(acc.get(blockId) ?? []), log])
     return acc
@@ -141,7 +157,8 @@ export function groupSessionHistory(
             )
             .map((log) => ({
               blockExerciseId: log.block_exercise_id!,
-              name: log.exercise_name_snapshot,
+              exercise: log.exercise,
+              exercise_name_snapshot: log.exercise_name_snapshot,
               emoji: metaById.get(log.block_exercise_id!)!.emoji,
               log,
             })),


### PR DESCRIPTION
## What

- Session history groups solos on `exercise_id` and orders them by their first log, instead of grouping consecutive identical `exercise_name_snapshot` values sorted alphabetically by that same snapshot.
- `SoloHistoryGroup` and `BlockHistoryCell` no longer carry a display-ready `name`; both extend `CatalogNameSource`, so surfaces render with `exerciseName(group)` / `exerciseName(cell)`.
- `useExerciseHistory` hands out options whose `name` is already resolved for the reader's locale, sorted with `localeCompare` in that locale — so `ExerciseTab` filters and displays the same string.

## Why

History was the one surface in this epic where the snapshotted name was **not** just a label: it was the SQL sort key, the grouping key and the React key at once. Localizing it naively would have reshuffled a session's contents per language, which is why T150 existed as a separate ticket rather than being folded into T149.

Two real bugs fell out of the same root cause:

- An exercise **revisited** later in a session showed up as two separate groups, because grouping only merged *consecutive* logs. Alphabetical ordering hid this most of the time; chronological ordering would have exposed it on every superset. The ordering change and the grouping change therefore had to land together.
- The same applies to a **renamed** exercise: two snapshots for one `exercise_id` split the group in two.
- The history picker filtered on the snapshot while displaying the resolved label, so an English reader typing `Bench` found nothing for the row that reads `Bench Press`.

## How

**Grouping.** `groupSessionHistory` derives one group per distinct `exercise_id` and sorts on the first log's `logged_at`, explicitly rather than by trusting the caller's order — the query sorts too, and I didn't want a second place for that to break. The block branch is untouched: circuits stay ordered by `blockSortOrder`, still render before solos, and the two lists are not merged by `logged_at`. The mutating `reduce` (`last.sets.push`) is gone, per the repo's functional-style rule.

**Typing carries the rule.** Neither history unit holds a name a caller could print by mistake — the only way to get a label is to resolve one. That is enforced at compile time: extending `CatalogNameSource` requires the (nullable) `exercise` key, which is what surfaced the `BlockHistoryCard` fixtures that needed updating.

**Locale stays out of the cache.** `useExerciseHistory` resolves labels and sorts in react-query's `select`, not in `queryFn`. Switching language re-derives the picker from cache; the network is untouched. Putting the locale in the `queryKey` would have refetched every `set_log` the user owns just to re-alphabetise ~140 rows.

**Ordering.** `useSessionSetLogs` moves from `.order("exercise_name_snapshot")` to `.order("logged_at").order("set_number")`. Verified the other consumers don't depend on the old order: `useBlockSession` folds logs into a `Set`, and `summarizeSessionLogs` already groups by `exercise_id`.

## Guards — all verified by mutation

Each mutation was applied, the targeted test run, and the file reverted. All eight were killed.

| Mutation | Fails |
|---|---|
| SQL order back to the frozen name | `useSessionSetLogs` order test |
| grouping keyed on the name again | grouping: revisited + renamed |
| solo groups sorted alphabetically | grouping: order-by-first-log |
| session row renders the snapshot | `SessionRow` dual-locale |
| circuit cell renders the snapshot | `BlockHistoryCard` dual-locale |
| picker filters on the French name | `ExerciseTab` filter test |
| picker sorted on raw id | `useExerciseHistory` sort test |
| locale moved into the query key | `useExerciseHistory` no-refetch test |

## Out of scope — one gap worth a ticket

`ExerciseListPreview` (the "day already done" card on `WorkoutPage`, fed by `summarizeSessionLogs` / `templateToPreviewItems`) still prints the raw snapshot. It's a session surface T149 missed rather than a history one, and both its data sources already carry the embed, so it's a small follow-up. Flagging rather than smuggling it in here.

Also noted while reading `search_exercises`: its `ORDER BY` ranks French-name matches above `name_en` matches regardless of the reader's locale, so an English reader typing `press` sees French-matching rows first. Candidate follow-up for the epic.

**Not closing #422** — part of it, ticket T150.
