### PR TITLE
feat(i18n): translate muscle & equipment labels at display time (T151)

### DIFF
--- a/src/components/admin/enrichment/EnrichmentCard.tsx
+++ b/src/components/admin/enrichment/EnrichmentCard.tsx
@@ -6,6 +6,7 @@ import { Copy, Check, ExternalLink } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { ImageDropZone } from "@/components/admin/enrichment/ImageDropZone"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { uploadExerciseImage } from "@/lib/imageUpload"
 import { buildImagePrompt } from "@/lib/imagePrompt"
 import { supabase } from "@/lib/supabase"
@@ -19,6 +20,7 @@ interface EnrichmentCardProps {
 export function EnrichmentCard({ exercise }: EnrichmentCardProps) {
   const queryClient = useQueryClient()
   const user = useAtomValue(authAtom)
+  const { muscleLabel, equipmentLabel } = useCatalogLabels()
   const [copied, setCopied] = useState(false)
 
   const mutation = useMutation({
@@ -65,7 +67,8 @@ export function EnrichmentCard({ exercise }: EnrichmentCardProps) {
         <div className="min-w-0 flex-1">
           <h2 className="text-lg font-semibold leading-tight">{exercise.name}</h2>
           <p className="mt-0.5 text-sm text-muted-foreground">
-            {exercise.muscle_group} · {exercise.equipment}
+            {muscleLabel(exercise.muscle_group)} ·{" "}
+            {equipmentLabel(exercise.equipment)}
           </p>
         </div>
       </div>

--- a/src/components/admin/exercises-table/DataTable.test.tsx
+++ b/src/components/admin/exercises-table/DataTable.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { renderWithProviders } from "@/test/utils"
+import type { Exercise } from "@/types/database"
+import { DataTable } from "./DataTable"
+
+const exercise = (overrides: Partial<Exercise> & { id: string }): Exercise => ({
+  name: "Développé couché",
+  name_en: "Bench Press",
+  muscle_group: "Pectoraux",
+  equipment: "barbell",
+  emoji: "🏋️",
+  is_system: true,
+  created_at: "",
+  youtube_url: null,
+  instructions: null,
+  image_url: null,
+  difficulty_level: null,
+  source: null,
+  secondary_muscles: null,
+  reviewed_at: null,
+  reviewed_by: null,
+  ...overrides,
+})
+
+const DATA: Exercise[] = [
+  exercise({ id: "bench" }),
+  exercise({
+    id: "curl",
+    name: "Curl biceps",
+    name_en: "Bicep Curl",
+    muscle_group: "Biceps",
+    equipment: "dumbbell",
+  }),
+]
+
+function render(locale: "en" | "fr" = "en") {
+  return renderWithProviders(<DataTable data={DATA} />, { locale })
+}
+
+describe("admin exercises DataTable", () => {
+  it("translates the muscle and equipment cells", () => {
+    render()
+
+    expect(screen.getByText("Chest")).toBeInTheDocument()
+    expect(screen.getByText("Barbell")).toBeInTheDocument()
+  })
+
+  // The name column deliberately keeps the stored value: admins edit the
+  // catalog, so they need to see what is actually written in it.
+  it("keeps the stored name in the name column", () => {
+    render()
+
+    expect(screen.getByText("Développé couché")).toBeInTheDocument()
+    expect(screen.queryByText("Bench Press")).not.toBeInTheDocument()
+  })
+
+  // Searching for what is on screen has to work, or translating the cell made
+  // the table worse than when it showed the stored value.
+  it("searches on the translated muscle label", async () => {
+    const user = userEvent.setup()
+    render()
+
+    await user.type(screen.getByPlaceholderText(/search/i), "Chest")
+
+    expect(screen.getByText("Développé couché")).toBeInTheDocument()
+    expect(screen.queryByText("Curl biceps")).not.toBeInTheDocument()
+  })
+
+  it("searches on the translated equipment label", async () => {
+    const user = userEvent.setup()
+    render()
+
+    await user.type(screen.getByPlaceholderText(/search/i), "Dumbbell")
+
+    expect(screen.getByText("Curl biceps")).toBeInTheDocument()
+    expect(screen.queryByText("Développé couché")).not.toBeInTheDocument()
+  })
+
+  // An admin who has typed French muscle names for a year should not have to
+  // stop.
+  it("still searches on the stored canonical value", async () => {
+    const user = userEvent.setup()
+    render()
+
+    await user.type(screen.getByPlaceholderText(/search/i), "Pectoraux")
+
+    expect(screen.getByText("Développé couché")).toBeInTheDocument()
+    expect(screen.queryByText("Curl biceps")).not.toBeInTheDocument()
+  })
+})

--- a/src/components/admin/exercises-table/DataTable.tsx
+++ b/src/components/admin/exercises-table/DataTable.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/table"
 import type { Exercise } from "@/types/database"
 import { normalizeForSearch } from "@/lib/search"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { getColumns } from "./columns"
 import { DataTableToolbar } from "./DataTableToolbar"
 import { DataTablePagination } from "./DataTablePagination"
@@ -41,12 +42,18 @@ interface DataTableProps {
 
 export function DataTable({ data }: DataTableProps) {
   const { t } = useTranslation("admin")
+  const { muscleLabel, equipmentLabel } = useCatalogLabels()
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState("")
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [reviewFilter, setReviewFilter] = useState("all")
 
-  const columns = useMemo(() => getColumns(t), [t])
+  // Sorting and the search index stay on the canonical values behind the
+  // `accessorKey`s, so only the rendered cells follow the reader's locale.
+  const columns = useMemo(
+    () => getColumns(t, { muscleLabel, equipmentLabel }),
+    [t, muscleLabel, equipmentLabel],
+  )
 
   const reviewedCount = useMemo(
     () => data.filter((e) => e.reviewed_at).length,

--- a/src/components/admin/exercises-table/DataTable.tsx
+++ b/src/components/admin/exercises-table/DataTable.tsx
@@ -28,14 +28,6 @@ import { getColumns } from "./columns"
 import { DataTableToolbar } from "./DataTableToolbar"
 import { DataTablePagination } from "./DataTablePagination"
 
-const globalFilterFn: FilterFn<Exercise> = (row, _columnId, filterValue: string) => {
-  const term = normalizeForSearch(filterValue)
-  const name = normalizeForSearch(row.original.name)
-  const nameEn = normalizeForSearch(row.original.name_en ?? "")
-  const muscle = normalizeForSearch(row.original.muscle_group)
-  return name.includes(term) || nameEn.includes(term) || muscle.includes(term)
-}
-
 interface DataTableProps {
   data: Exercise[]
 }
@@ -48,11 +40,30 @@ export function DataTable({ data }: DataTableProps) {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [reviewFilter, setReviewFilter] = useState("all")
 
-  // Sorting and the search index stay on the canonical values behind the
-  // `accessorKey`s, so only the rendered cells follow the reader's locale.
+  // Sorting stays on the canonical values behind the `accessorKey`s; only the
+  // rendered cells follow the reader's locale.
   const columns = useMemo(
     () => getColumns(t, { muscleLabel, equipmentLabel }),
     [t, muscleLabel, equipmentLabel],
+  )
+
+  /**
+   * Searches both spellings on purpose: the visible label, because typing what
+   * is on screen has to work, and the stored value, because an admin who has
+   * been typing "Pectoraux" for a year shouldn't have to stop.
+   */
+  const globalFilterFn = useMemo<FilterFn<Exercise>>(
+    () => (row, _columnId, filterValue: string) => {
+      const term = normalizeForSearch(filterValue)
+      return [
+        row.original.name,
+        row.original.name_en ?? "",
+        row.original.muscle_group,
+        muscleLabel(row.original.muscle_group),
+        equipmentLabel(row.original.equipment),
+      ].some((field) => normalizeForSearch(field).includes(term))
+    },
+    [muscleLabel, equipmentLabel],
   )
 
   const reviewedCount = useMemo(

--- a/src/components/admin/exercises-table/columns.tsx
+++ b/src/components/admin/exercises-table/columns.tsx
@@ -5,7 +5,19 @@ import type { Exercise } from "@/types/database"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 
-export function getColumns(t: (key: string) => string): ColumnDef<Exercise>[] {
+/**
+ * Passed in rather than read from `useCatalogLabels` here: this is a plain
+ * factory, not a component, so the hook has to stay at the table level.
+ */
+interface CatalogLabels {
+  muscleLabel: (value: string | null | undefined) => string
+  equipmentLabel: (slug: string | null | undefined) => string
+}
+
+export function getColumns(
+  t: (key: string) => string,
+  { muscleLabel, equipmentLabel }: CatalogLabels,
+): ColumnDef<Exercise>[] {
   return [
     {
       accessorKey: "name",
@@ -42,7 +54,7 @@ export function getColumns(t: (key: string) => string): ColumnDef<Exercise>[] {
       ),
       cell: ({ row }) => (
         <Badge variant="secondary" className="text-xs">
-          {row.original.muscle_group}
+          {muscleLabel(row.original.muscle_group)}
         </Badge>
       ),
     },
@@ -61,7 +73,7 @@ export function getColumns(t: (key: string) => string): ColumnDef<Exercise>[] {
       ),
       cell: ({ row }) => (
         <span className="text-sm text-muted-foreground">
-          {row.original.equipment || "—"}
+          {equipmentLabel(row.original.equipment) || "—"}
         </span>
       ),
     },

--- a/src/components/builder/ExerciseDetailForm.tsx
+++ b/src/components/builder/ExerciseDetailForm.tsx
@@ -83,7 +83,7 @@ export function ExerciseDetailForm({
 }: ExerciseDetailFormProps) {
   const { t } = useTranslation("builder")
   const { unit, toDisplay, toKg } = useWeightUnit()
-  const { exerciseName } = useCatalogLabels()
+  const { exerciseName, muscleLabel } = useCatalogLabels()
   const updateExercise = useUpdateExercise()
 
   const [form, setForm] = useState<FormState>(() =>
@@ -164,7 +164,7 @@ export function ExerciseDetailForm({
               {exerciseName(exercise)}
             </h2>
             <p className="text-sm text-muted-foreground">
-              {exercise.muscle_snapshot}
+              {muscleLabel(libExercise?.muscle_group ?? exercise.muscle_snapshot)}
             </p>
           </div>
         </div>

--- a/src/components/builder/ExerciseFilterPanel.test.tsx
+++ b/src/components/builder/ExerciseFilterPanel.test.tsx
@@ -4,10 +4,11 @@ import userEvent from "@testing-library/user-event"
 import { renderWithProviders } from "@/test/utils"
 import { ExerciseFilterPanel } from "./ExerciseFilterPanel"
 
+/** Canonical values, as the filter options RPC returns them. */
 const MUSCLE_GROUPS = ["Abdos", "Biceps", "Dos", "Pectoraux"]
 const EQUIPMENT = ["barbell", "bodyweight", "dumbbell", "machine"]
 
-function renderPanel(overrides = {}) {
+function renderPanel(overrides = {}, locale: "en" | "fr" = "en") {
   const defaultProps = {
     muscleGroups: MUSCLE_GROUPS,
     equipmentTypes: EQUIPMENT,
@@ -20,15 +21,24 @@ function renderPanel(overrides = {}) {
     onDifficultyChange: vi.fn(),
     ...overrides,
   }
-  const result = renderWithProviders(<ExerciseFilterPanel {...defaultProps} />)
+  const result = renderWithProviders(<ExerciseFilterPanel {...defaultProps} />, {
+    locale,
+  })
   return { ...result, ...defaultProps }
 }
 
 describe("ExerciseFilterPanel", () => {
-  it("renders muscle group pills", () => {
+  it("renders muscle group pills with translated labels", () => {
     renderPanel()
-    for (const group of MUSCLE_GROUPS) {
-      expect(screen.getByRole("button", { name: group })).toBeInTheDocument()
+    for (const label of ["Abs", "Biceps", "Back", "Chest"]) {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument()
+    }
+  })
+
+  it("labels muscle pills in French for a French reader", () => {
+    renderPanel({}, "fr")
+    for (const label of MUSCLE_GROUPS) {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument()
     }
   })
 
@@ -40,11 +50,13 @@ describe("ExerciseFilterPanel", () => {
     expect(screen.getByRole("button", { name: "Bodyweight" })).toBeInTheDocument()
   })
 
-  it("calls onMuscleGroupChange when a muscle group is clicked", async () => {
+  // The point of the ticket: the label is translated, the value sent back to
+  // the query never is.
+  it("filters on the canonical value behind a translated pill", async () => {
     const { onMuscleGroupChange } = renderPanel()
     const user = userEvent.setup()
 
-    await user.click(screen.getByRole("button", { name: "Pectoraux" }))
+    await user.click(screen.getByRole("button", { name: "Chest" }))
     expect(onMuscleGroupChange).toHaveBeenCalledWith("Pectoraux")
   })
 
@@ -54,7 +66,7 @@ describe("ExerciseFilterPanel", () => {
     })
     const user = userEvent.setup()
 
-    await user.click(screen.getByRole("button", { name: "Pectoraux" }))
+    await user.click(screen.getByRole("button", { name: "Chest" }))
     expect(onMuscleGroupChange).toHaveBeenCalledWith(null)
   })
 
@@ -88,8 +100,15 @@ describe("ExerciseFilterPanel", () => {
 
   it("applies active style to selected muscle group", () => {
     renderPanel({ selectedMuscleGroup: "Dos" })
-    const btn = screen.getByRole("button", { name: "Dos" })
+    const btn = screen.getByRole("button", { name: "Back" })
     expect(btn.className).toContain("bg-primary")
+  })
+
+  it("renders a muscle value outside the taxonomy as-is", () => {
+    renderPanel({ muscleGroups: ["Ischios / Bas du dos"] })
+    expect(
+      screen.getByRole("button", { name: "Ischios / Bas du dos" }),
+    ).toBeInTheDocument()
   })
 
   it("applies active style to selected equipment", () => {

--- a/src/components/builder/ExerciseFilterPanel.tsx
+++ b/src/components/builder/ExerciseFilterPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { cn } from "@/lib/utils"
 
 const DIFFICULTY_ORDER = ["beginner", "intermediate", "advanced"] as const
@@ -28,7 +29,9 @@ export function ExerciseFilterPanel({
   onDifficultyChange,
 }: ExerciseFilterPanelProps) {
   const { t } = useTranslation("builder")
-  const { t: tCatalog } = useTranslation("catalog")
+  // Labels only: every pill keeps the canonical value as its key and as what it
+  // sends back to the filter.
+  const { muscleLabel, equipmentLabel } = useCatalogLabels()
 
   const sortedDifficultyLevels = useMemo(
     () =>
@@ -74,7 +77,7 @@ export function ExerciseFilterPanel({
                 : "border-border bg-background text-muted-foreground hover:bg-accent",
             )}
           >
-            {group}
+            {muscleLabel(group)}
           </button>
         ))}
       </div>
@@ -93,7 +96,7 @@ export function ExerciseFilterPanel({
                 : "border-border bg-background text-muted-foreground hover:bg-accent",
             )}
           >
-            {tCatalog(`equipment.${eq}`)}
+            {equipmentLabel(eq)}
           </button>
         ))}
       </div>

--- a/src/components/builder/ExerciseLibraryPicker.test.tsx
+++ b/src/components/builder/ExerciseLibraryPicker.test.tsx
@@ -233,7 +233,7 @@ describe("ExerciseLibraryPicker", () => {
 
     await user.click(screen.getByLabelText("Filters"))
     expect(screen.getByRole("button", { name: "Barbell" })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Pectoraux" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Chest" })).toBeInTheDocument()
   })
 
   it("filters by equipment when a pill is selected", async () => {
@@ -253,7 +253,7 @@ describe("ExerciseLibraryPicker", () => {
     const user = userEvent.setup()
 
     await user.click(screen.getByLabelText("Filters"))
-    await user.click(screen.getByRole("button", { name: "Pectoraux" }))
+    await user.click(screen.getByRole("button", { name: "Chest" }))
 
     expect(screen.getByText("Bench Press")).toBeInTheDocument()
     expect(screen.queryByText("Lateral Raises")).not.toBeInTheDocument()
@@ -317,7 +317,7 @@ describe("ExerciseLibraryPicker", () => {
     const user = userEvent.setup()
 
     await user.click(screen.getByLabelText("Filters"))
-    await user.click(screen.getByRole("button", { name: "Pectoraux" }))
+    await user.click(screen.getByRole("button", { name: "Chest" }))
     await user.click(screen.getByRole("button", { name: "Dumbbell" }))
 
     expect(screen.getByText("Dumbbell Fly")).toBeInTheDocument()
@@ -434,7 +434,7 @@ describe("ExerciseLibraryPicker", () => {
     ).toBeInTheDocument()
 
     await user.click(screen.getByLabelText("Filters"))
-    await user.click(screen.getByRole("button", { name: "Pectoraux" }))
+    await user.click(screen.getByRole("button", { name: "Chest" }))
 
     expect(screen.queryByText("Lateral Raises")).not.toBeInTheDocument()
     expect(
@@ -505,7 +505,7 @@ describe("ExerciseLibraryPicker", () => {
     ).toBeInTheDocument()
 
     await user.click(screen.getByLabelText("Filters"))
-    await user.click(screen.getByRole("button", { name: "Pectoraux" }))
+    await user.click(screen.getByRole("button", { name: "Chest" }))
 
     expect(screen.queryByText("Lateral Raises")).not.toBeInTheDocument()
     expect(

--- a/src/components/builder/ExerciseRow.tsx
+++ b/src/components/builder/ExerciseRow.tsx
@@ -21,7 +21,7 @@ interface ExerciseRowProps {
 export function ExerciseRow({ exercise, onTap, onDelete }: ExerciseRowProps) {
   const { t } = useTranslation("builder")
   const { formatWeight } = useWeightUnit()
-  const { exerciseName } = useCatalogLabels()
+  const { exerciseName, muscleLabel } = useCatalogLabels()
   const { data: libExercise } = useExerciseFromLibrary(exercise.exercise_id)
   const {
     attributes,
@@ -69,7 +69,8 @@ export function ExerciseRow({ exercise, onTap, onDelete }: ExerciseRowProps) {
         </div>
         <p className="flex flex-wrap items-center gap-x-1 text-xs text-muted-foreground">
           <span>
-            {exercise.muscle_snapshot} &middot; {summary}
+            {muscleLabel(libExercise?.muscle_group ?? exercise.muscle_snapshot)}{" "}
+            &middot; {summary}
           </span>
           <span className="inline-flex items-center gap-0.5">
             &middot; <Timer className="h-3 w-3" />

--- a/src/components/builder/ExerciseSelectionContent.tsx
+++ b/src/components/builder/ExerciseSelectionContent.tsx
@@ -174,18 +174,20 @@ export function ExerciseSelectionList({
   state: ExerciseSelectionState
 }) {
   const { t, selectedIds, toggleSelected, grouped } = state
-  const { catalogName } = useCatalogLabels()
+  const { catalogName, muscleLabel } = useCatalogLabels()
 
   return (
     <>
       <CommandEmpty>{t("noExercisesFound")}</CommandEmpty>
       {grouped &&
         Object.entries(grouped).map(([muscle, exList]) => (
-          <CommandGroup key={muscle} heading={muscle}>
+          <CommandGroup key={muscle} heading={muscleLabel(muscle)}>
             {exList.map((ex) => (
               <CommandItem
                 key={ex.id}
-                value={`${ex.name} ${ex.name_en ?? ""} ${ex.muscle_group}`}
+                // Both spellings of both fields, so searching matches what the
+                // reader sees *and* what a French user has always typed.
+                value={`${ex.name} ${ex.name_en ?? ""} ${ex.muscle_group} ${muscleLabel(ex.muscle_group)}`}
                 onSelect={() => {}}
                 className="flex items-center justify-between gap-2"
               >

--- a/src/components/exercise/ExerciseInfoDialog.tsx
+++ b/src/components/exercise/ExerciseInfoDialog.tsx
@@ -2,6 +2,7 @@ import { Activity, AlertTriangle, Info, Pencil, Settings2, Wind } from "lucide-r
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import type { Exercise } from "@/types/database"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { AdminOnly } from "@/components/admin/AdminOnly"
 import { ExerciseThumbnail } from "./ExerciseThumbnail"
 import {
@@ -21,6 +22,7 @@ interface ExerciseInfoDialogProps {
 
 export function ExerciseInfoDialog({ exercise }: ExerciseInfoDialogProps) {
   const { t } = useTranslation("exercise")
+  const { catalogName } = useCatalogLabels()
 
   const hasInstructions =
     exercise.instructions &&
@@ -50,7 +52,7 @@ export function ExerciseInfoDialog({ exercise }: ExerciseInfoDialogProps) {
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <ExerciseThumbnail imageUrl={exercise.image_url} emoji={exercise.emoji} className="h-8 w-8" />
-            {exercise.name}
+            {catalogName(exercise)}
             <AdminOnly>
               <Link
                 to={`/admin/exercises/${exercise.id}`}

--- a/src/components/generator/ConstraintStep.test.tsx
+++ b/src/components/generator/ConstraintStep.test.tsx
@@ -55,10 +55,10 @@ describe("ConstraintStep", () => {
     expect(screen.getByText("Full Gym")).toBeInTheDocument()
   })
 
-  it("renders muscle group pills from hook data", () => {
+  it("renders muscle group pills from hook data, translated", () => {
     setup()
-    expect(screen.getByText("Pectoraux")).toBeInTheDocument()
-    expect(screen.getByText("Dos")).toBeInTheDocument()
+    expect(screen.getByText("Chest")).toBeInTheDocument()
+    expect(screen.getByText("Back")).toBeInTheDocument()
     expect(screen.getByText("Biceps")).toBeInTheDocument()
   })
 
@@ -91,10 +91,11 @@ describe("ConstraintStep", () => {
     )
   })
 
+  // Clicked by its English label, constrained by its canonical value.
   it("selects a specific muscle group and deselects full-body", async () => {
     const user = userEvent.setup()
     const { onChange } = setup({ muscleGroups: ["full-body"] })
-    await user.click(screen.getByText("Pectoraux"))
+    await user.click(screen.getByText("Chest"))
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ muscleGroups: ["Pectoraux"] }),
     )
@@ -103,7 +104,7 @@ describe("ConstraintStep", () => {
   it("falls back to full-body when last muscle group is deselected", async () => {
     const user = userEvent.setup()
     const { onChange } = setup({ muscleGroups: ["Pectoraux"] })
-    await user.click(screen.getByText("Pectoraux"))
+    await user.click(screen.getByText("Chest"))
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ muscleGroups: ["full-body"] }),
     )

--- a/src/components/generator/ConstraintStep.tsx
+++ b/src/components/generator/ConstraintStep.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { publicSite } from "@/lib/publicSite"
 import { useExerciseFilterOptions } from "@/hooks/useExerciseFilterOptions"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import {
   AI_FOCUS_AREAS_MAX_LENGTH,
   isFocusAreasTooLong,
@@ -39,6 +40,7 @@ export function ConstraintStep({
   isLoading,
 }: ConstraintStepProps) {
   const { t } = useTranslation("generator")
+  const { muscleLabel } = useCatalogLabels()
   const { data: filterOptions } = useExerciseFilterOptions()
   const muscleGroups = filterOptions?.muscle_groups ?? []
 
@@ -155,7 +157,7 @@ export function ConstraintStep({
                 !isFullBody && constraints.muscleGroups.includes(mg),
               )}
             >
-              {mg}
+              {muscleLabel(mg)}
             </button>
           ))}
         </div>

--- a/src/components/generator/ExerciseAddPicker.test.tsx
+++ b/src/components/generator/ExerciseAddPicker.test.tsx
@@ -56,11 +56,11 @@ describe("ExerciseAddPicker", () => {
     expect(screen.getByText("Barbell Row")).toBeInTheDocument()
   })
 
-  it("groups exercises by muscle group", () => {
+  it("groups exercises by muscle group, under translated headings", () => {
     setup()
-    expect(screen.getByText("Pectoraux")).toBeInTheDocument()
+    expect(screen.getByText("Chest")).toBeInTheDocument()
     expect(screen.getByText("Biceps")).toBeInTheDocument()
-    expect(screen.getByText("Dos")).toBeInTheDocument()
+    expect(screen.getByText("Back")).toBeInTheDocument()
   })
 
   it("filters exercises by search term", async () => {

--- a/src/components/generator/ExerciseAddPicker.tsx
+++ b/src/components/generator/ExerciseAddPicker.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Search } from "lucide-react"
 import { cn, groupBy } from "@/lib/utils"
 import { normalizeForSearch } from "@/lib/search"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { Input } from "@/components/ui/input"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
 import type { ExerciseListItem } from "@/types/database"
@@ -21,6 +22,7 @@ export function ExerciseAddPicker({
   onClose,
 }: ExerciseAddPickerProps) {
   const { t } = useTranslation("generator")
+  const { catalogName, muscleLabel } = useCatalogLabels()
   const [search, setSearch] = useState("")
 
   const candidates = useMemo(() => {
@@ -73,7 +75,7 @@ export function ExerciseAddPicker({
           {[...grouped.entries()].map(([group, exercises]) => (
             <div key={group}>
               <span className="sticky top-0 block bg-card px-1 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                {group}
+                {muscleLabel(group)}
               </span>
               {exercises.map((exercise) => (
                 <button
@@ -89,7 +91,7 @@ export function ExerciseAddPicker({
                     emoji={exercise.emoji}
                     className="h-7 w-7 rounded"
                   />
-                  <span className="truncate">{exercise.name}</span>
+                  <span className="truncate">{catalogName(exercise)}</span>
                 </button>
               ))}
             </div>

--- a/src/components/generator/ExerciseDetailSheet.tsx
+++ b/src/components/generator/ExerciseDetailSheet.tsx
@@ -7,6 +7,7 @@ import {
   SheetTitle,
   SheetDescription,
 } from "@/components/ui/sheet"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
 import { InstructionSection } from "@/components/exercise/InstructionSection"
 import { getYouTubeEmbedUrl } from "@/lib/youtube"
@@ -25,6 +26,7 @@ export function ExerciseDetailSheet({
   onOpenChange,
 }: ExerciseDetailSheetProps) {
   const { t } = useTranslation("exercise")
+  const { catalogName, muscleLabel, equipmentLabel } = useCatalogLabels()
 
   if (!exercise) return null
 
@@ -41,15 +43,15 @@ export function ExerciseDetailSheet({
           />
           <SheetTitle className="flex items-center gap-2">
             <span className="text-xl">{exercise.emoji}</span>
-            {exercise.name}
+            {catalogName(exercise)}
           </SheetTitle>
           <SheetDescription className="flex items-center gap-2">
             <span className="rounded bg-muted px-1.5 py-0.5 text-xs">
-              {exercise.muscle_group}
+              {muscleLabel(exercise.muscle_group)}
             </span>
             {exercise.equipment && (
               <span className="rounded bg-muted px-1.5 py-0.5 text-xs">
-                {exercise.equipment}
+                {equipmentLabel(exercise.equipment)}
               </span>
             )}
           </SheetDescription>
@@ -101,7 +103,7 @@ export function ExerciseDetailSheet({
               >
                 <iframe
                   src={embedUrl}
-                  title={exercise.name}
+                  title={catalogName(exercise)}
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                   allowFullScreen
                   className="absolute inset-0 h-full w-full"

--- a/src/components/generator/PreviewExerciseCard.test.tsx
+++ b/src/components/generator/PreviewExerciseCard.test.tsx
@@ -65,7 +65,7 @@ describe("PreviewExerciseCard", () => {
   it("renders exercise name, muscle group, and sets×reps", () => {
     setup()
     expect(screen.getByText("Bench Press")).toBeInTheDocument()
-    expect(screen.getByText("Pectoraux")).toBeInTheDocument()
+    expect(screen.getByText("Chest")).toBeInTheDocument()
     expect(screen.getByText("3 × 10")).toBeInTheDocument()
   })
 

--- a/src/components/generator/PreviewExerciseCard.tsx
+++ b/src/components/generator/PreviewExerciseCard.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { X, ArrowLeftRight, CircleHelp } from "lucide-react"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { Button } from "@/components/ui/button"
 import type { GeneratedExercise } from "@/types/generator"
 
@@ -23,6 +24,7 @@ export function PreviewExerciseCard({
   onUpdateReps,
 }: PreviewExerciseCardProps) {
   const { t } = useTranslation("generator")
+  const { catalogName, muscleLabel } = useCatalogLabels()
 
   return (
     <div className="flex items-center gap-3 rounded-lg border bg-card p-3">
@@ -41,13 +43,13 @@ export function PreviewExerciseCard({
           onClick={() => onInfo(index)}
         >
           <span className="truncate text-sm font-medium">
-            {item.exercise.name}
+            {catalogName(item.exercise)}
           </span>
           <CircleHelp className="h-4 w-4 shrink-0 text-primary" />
         </button>
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <span className="rounded bg-muted px-1.5 py-0.5">
-            {item.exercise.muscle_group}
+            {muscleLabel(item.exercise.muscle_group)}
           </span>
           <span>{item.isCompound ? t("compound") : t("isolation")}</span>
         </div>

--- a/src/components/history/balance/BalanceInsights.tsx
+++ b/src/components/history/balance/BalanceInsights.tsx
@@ -1,17 +1,12 @@
-import type { TFunction } from "i18next"
 import { useTranslation } from "react-i18next"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import {
   type BalanceBand,
-  type MuscleTaxonomy,
   type PairInsight,
   zeroVolumeMuscles,
 } from "@/lib/trainingBalance"
 import type { VolumeByMuscleRow } from "@/lib/volumeByMuscleGroup"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-
-function muscleLabel(t: TFunction<"catalog">, m: MuscleTaxonomy) {
-  return t(`muscles.${m}`)
-}
 
 interface BalanceInsightsProps {
   band: BalanceBand
@@ -25,7 +20,7 @@ export function BalanceInsights({
   muscles,
 }: BalanceInsightsProps) {
   const { t } = useTranslation("history")
-  const { t: tCatalog } = useTranslation("catalog")
+  const { muscleLabel } = useCatalogLabels()
 
   const untrainedFocus = new Set(
     pairInsights
@@ -49,19 +44,19 @@ export function BalanceInsights({
           <p key={insight.pairName} className="border-l-2 border-primary/40 pl-3">
             {insight.kind === "untrained"
               ? t("balance.insightUntrained", {
-                  weak: muscleLabel(tCatalog, insight.focusMuscle),
-                  strong: muscleLabel(tCatalog, insight.otherMuscle),
+                  weak: muscleLabel(insight.focusMuscle),
+                  strong: muscleLabel(insight.otherMuscle),
                 })
               : t("balance.insightSkewed", {
-                  strong: muscleLabel(tCatalog, insight.focusMuscle),
-                  weak: muscleLabel(tCatalog, insight.otherMuscle),
+                  strong: muscleLabel(insight.focusMuscle),
+                  weak: muscleLabel(insight.otherMuscle),
                 })}
           </p>
         ))}
 
         {extraZeros.map((m) => (
           <p key={m} className="border-l-2 border-muted-foreground/30 pl-3">
-            {t("balance.zeroVolume", { muscle: muscleLabel(tCatalog, m) })}
+            {t("balance.zeroVolume", { muscle: muscleLabel(m) })}
           </p>
         ))}
       </CardContent>

--- a/src/components/history/balance/MuscleBreakdownTable.tsx
+++ b/src/components/history/balance/MuscleBreakdownTable.tsx
@@ -1,7 +1,7 @@
-import type { TFunction } from "i18next"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ChevronDown } from "lucide-react"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { formatCompactNumber } from "@/lib/formatters"
 import type { VolumeByMuscleRow } from "@/lib/volumeByMuscleGroup"
 import {
@@ -20,10 +20,6 @@ import {
 } from "@/components/ui/table"
 import { cn } from "@/lib/utils"
 
-function muscleLabel(t: TFunction<"catalog">, key: string) {
-  return t(`muscles.${key}`)
-}
-
 interface MuscleBreakdownTableProps {
   muscles: readonly VolumeByMuscleRow[]
   className?: string
@@ -34,7 +30,7 @@ export function MuscleBreakdownTable({
   className,
 }: MuscleBreakdownTableProps) {
   const { t, i18n } = useTranslation("history")
-  const { t: tCatalog } = useTranslation("catalog")
+  const { muscleLabel } = useCatalogLabels()
   const [open, setOpen] = useState(false)
 
   const totalSets = useMemo(
@@ -105,7 +101,7 @@ export function MuscleBreakdownTable({
             {rows.map((m) => (
               <TableRow key={m.muscle_group}>
                 <TableCell className="font-medium">
-                  {muscleLabel(tCatalog, m.muscle_group)}
+                  {muscleLabel(m.muscle_group)}
                 </TableCell>
                 <TableCell className="text-right tabular-nums">
                   {fmtSets.format(m.total_sets)}

--- a/src/components/library/SavedWorkoutsSection.test.tsx
+++ b/src/components/library/SavedWorkoutsSection.test.tsx
@@ -84,6 +84,17 @@ describe("SavedWorkoutsSection", () => {
     expect(screen.getAllByText("Chest")).toHaveLength(1)
   })
 
+  // Without an embed there is nothing canonical to collapse on, and a legacy
+  // English snapshot renders identically to the French one it duplicates.
+  it("collapses rows with no embed whose snapshots render the same label", () => {
+    render([
+      row({ id: "we-1", muscle_snapshot: "Chest" }),
+      row({ id: "we-2", muscle_snapshot: "Pectoraux" }),
+    ])
+
+    expect(screen.getAllByText("Chest")).toHaveLength(1)
+  })
+
   it("falls back to the snapshot when the catalog row is missing", () => {
     render([row({ id: "we-1", muscle_snapshot: "Deltoïdes post." })])
 

--- a/src/components/library/SavedWorkoutsSection.test.tsx
+++ b/src/components/library/SavedWorkoutsSection.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { screen } from "@testing-library/react"
+import { renderWithProviders } from "@/test/utils"
+import type { SavedWorkout } from "@/hooks/useSavedWorkouts"
+
+const mockUseSavedWorkouts = vi.fn<() => { data: SavedWorkout[] }>()
+
+vi.mock("@/hooks/useSavedWorkouts", () => ({
+  useSavedWorkouts: () => mockUseSavedWorkouts(),
+}))
+vi.mock("@/hooks/useDeleteSavedWorkout", () => ({
+  useDeleteSavedWorkout: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+vi.mock("@/hooks/useStartSavedWorkout", () => ({
+  useStartSavedWorkout: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+import { SavedWorkoutsSection } from "./SavedWorkoutsSection"
+
+type SavedRow = SavedWorkout["workout_exercises"][number]
+
+const row = (overrides: Partial<SavedRow> & { id: string }): SavedRow => ({
+  name_snapshot: "Développé couché",
+  emoji_snapshot: "🏋️",
+  sets: 3,
+  reps: "8",
+  muscle_snapshot: "Pectoraux",
+  exercise: null,
+  ...overrides,
+})
+
+const workout = (rows: SavedRow[]): SavedWorkout =>
+  ({
+    id: "day-1",
+    label: "Push draft",
+    saved_at: "2026-01-01T10:00:00Z",
+    workout_exercises: rows,
+  }) as SavedWorkout
+
+function render(rows: SavedRow[], locale: "en" | "fr" = "en") {
+  mockUseSavedWorkouts.mockReturnValue({ data: [workout(rows)] })
+  return renderWithProviders(<SavedWorkoutsSection />, { locale })
+}
+
+const catalogRow = (muscleGroup: string) => ({
+  id: "bench",
+  name: "Développé couché",
+  name_en: "Bench Press",
+  muscle_group: muscleGroup,
+  equipment: "barbell",
+  emoji: "🏋️",
+})
+
+describe("SavedWorkoutsSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each([
+    ["en", "Chest"],
+    ["fr", "Pectoraux"],
+  ] as const)("labels the muscle badge in %s", (locale, label) => {
+    render([row({ id: "we-1", exercise: catalogRow("Pectoraux") })], locale)
+
+    expect(screen.getByText(label)).toBeInTheDocument()
+  })
+
+  // Two rows, one muscle: deduplicating on the frozen spelling would print the
+  // same badge twice as soon as the snapshots disagree.
+  it("collapses rows whose snapshots disagree but whose catalog muscle matches", () => {
+    render([
+      row({
+        id: "we-1",
+        muscle_snapshot: "Chest",
+        exercise: catalogRow("Pectoraux"),
+      }),
+      row({
+        id: "we-2",
+        muscle_snapshot: "Pectoraux",
+        exercise: catalogRow("Pectoraux"),
+      }),
+    ])
+
+    expect(screen.getAllByText("Chest")).toHaveLength(1)
+  })
+
+  it("falls back to the snapshot when the catalog row is missing", () => {
+    render([row({ id: "we-1", muscle_snapshot: "Deltoïdes post." })])
+
+    expect(screen.getByText("Deltoïdes post.")).toBeInTheDocument()
+  })
+})

--- a/src/components/library/SavedWorkoutsSection.tsx
+++ b/src/components/library/SavedWorkoutsSection.tsx
@@ -101,12 +101,14 @@ function SavedWorkoutCard({
   const { t } = useTranslation("library")
   const { muscleLabel } = useCatalogLabels()
 
-  // Deduplicate on the canonical value, not on the snapshot: two rows for the
-  // same muscle can hold different frozen spellings and would show up twice.
+  // Deduplicated on the rendered label rather than on the stored value: this
+  // list only answers "which muscles does this workout hit", and two rows can
+  // reach the same label from different spellings — a frozen "Chest" and a
+  // canonical "Pectoraux" both read "Chest" for an English reader.
   const muscles = [
     ...new Set(
-      workout.workout_exercises.map(
-        (e) => e.exercise?.muscle_group ?? e.muscle_snapshot,
+      workout.workout_exercises.map((e) =>
+        muscleLabel(e.exercise?.muscle_group ?? e.muscle_snapshot),
       ),
     ),
   ]
@@ -139,7 +141,7 @@ function SavedWorkoutCard({
         <div className="flex flex-wrap gap-1">
           {muscles.map((m) => (
             <Badge key={m} variant="secondary" className="text-[10px]">
-              {muscleLabel(m)}
+              {m}
             </Badge>
           ))}
         </div>

--- a/src/components/library/SavedWorkoutsSection.tsx
+++ b/src/components/library/SavedWorkoutsSection.tsx
@@ -7,6 +7,7 @@ import { Bookmark, Play, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { sessionAtom, isQuickWorkoutAtom } from "@/store/atoms"
 import {
   useSavedWorkouts,
@@ -98,9 +99,16 @@ function SavedWorkoutCard({
   isPending: boolean
 }) {
   const { t } = useTranslation("library")
+  const { muscleLabel } = useCatalogLabels()
 
+  // Deduplicate on the canonical value, not on the snapshot: two rows for the
+  // same muscle can hold different frozen spellings and would show up twice.
   const muscles = [
-    ...new Set(workout.workout_exercises.map((e) => e.muscle_snapshot)),
+    ...new Set(
+      workout.workout_exercises.map(
+        (e) => e.exercise?.muscle_group ?? e.muscle_snapshot,
+      ),
+    ),
   ]
 
   return (
@@ -131,7 +139,7 @@ function SavedWorkoutCard({
         <div className="flex flex-wrap gap-1">
           {muscles.map((m) => (
             <Badge key={m} variant="secondary" className="text-[10px]">
-              {m}
+              {muscleLabel(m)}
             </Badge>
           ))}
         </div>

--- a/src/components/workout/ExerciseDetail.tsx
+++ b/src/components/workout/ExerciseDetail.tsx
@@ -73,7 +73,7 @@ export function ExerciseDetail({
   const { t } = useTranslation("workout")
   const { t: tFeedback } = useTranslation("feedback")
   const { formatWeight } = useWeightUnit()
-  const { exerciseName } = useCatalogLabels()
+  const { exerciseName, muscleLabel } = useCatalogLabels()
   const { data: lastSession } = useLastSession(exercise.exercise_id, sessionStartedAt)
   const { data: libExercise } = useExerciseFromLibrary(exercise.exercise_id)
   const [swapPanelOpen, setSwapPanelOpen] = useState(false)
@@ -97,7 +97,7 @@ export function ExerciseDetail({
           <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
             <h2 className="text-xl font-bold">{exerciseName(exercise)}</h2>
             <Badge variant="default" className="w-fit shrink-0 text-xs font-normal">
-              {exercise.muscle_snapshot}
+              {muscleLabel(libExercise?.muscle_group ?? exercise.muscle_snapshot)}
             </Badge>
           </div>
           <DropdownMenu>
@@ -216,7 +216,9 @@ export function ExerciseDetail({
         onOpenChange={setHistoryOpen}
         exerciseId={exercise.exercise_id}
         exerciseName={exerciseName(exercise)}
-        muscleLabel={exercise.muscle_snapshot}
+        muscleLabel={muscleLabel(
+          libExercise?.muscle_group ?? exercise.muscle_snapshot,
+        )}
         bodyMapMuscleGroup={libExercise?.muscle_group ?? exercise.muscle_snapshot}
         emojiSnapshot={exercise.emoji_snapshot}
         imageUrl={libExercise?.image_url}

--- a/src/components/workout/ExerciseSwapInlinePanel.test.tsx
+++ b/src/components/workout/ExerciseSwapInlinePanel.test.tsx
@@ -99,6 +99,34 @@ describe("ExerciseSwapInlinePanel", () => {
     expect(onSwapBrowseLibrary).toHaveBeenCalledWith(ROW)
   })
 
+  // The pool is filtered on `muscle_group`, so a row frozen with a spelling the
+  // taxonomy never had would offer zero candidates if the snapshot were used.
+  it("finds same-muscle candidates for a row whose snapshot predates the taxonomy", () => {
+    renderWithProviders(
+      <ExerciseSwapInlinePanel
+        exercise={{
+          ...ROW,
+          muscle_snapshot: "Chest",
+          exercise: {
+            id: "bench",
+            name: "Développé couché",
+            name_en: "Bench Press",
+            muscle_group: "Pectoraux",
+            equipment: "barbell",
+            emoji: "🏋️",
+          },
+        }}
+        exercisePool={POOL}
+        currentExerciseIds={["bench"]}
+        onSwapExerciseChosen={vi.fn()}
+        onSwapBrowseLibrary={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole("button", { name: /pec fly/i })).toBeInTheDocument()
+  })
+
   it("calls onSwapExerciseChosen and onDismiss when a same-muscle candidate is picked", async () => {
     const user = userEvent.setup()
     const onSwapExerciseChosen = vi.fn()

--- a/src/components/workout/ExerciseSwapInlinePanel.tsx
+++ b/src/components/workout/ExerciseSwapInlinePanel.tsx
@@ -48,7 +48,10 @@ export function ExerciseSwapInlinePanel({
           <ExerciseSwapPicker
             pool={exercisePool}
             currentExerciseIds={currentExerciseIds}
-            muscleGroup={ex.muscle_snapshot}
+            // The pool is filtered on the canonical `muscle_group`, so feeding it
+            // a snapshot silently empties the list for any row frozen with a
+            // pre-taxonomy (or English) spelling.
+            muscleGroup={ex.exercise?.muscle_group ?? ex.muscle_snapshot}
             onSelect={(picked) => {
               onSwapExerciseChosen(ex, picked)
               onDismiss()

--- a/src/components/workout/SwapExerciseSheet.tsx
+++ b/src/components/workout/SwapExerciseSheet.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import { Info, Loader2, RefreshCw, Search, SlidersHorizontal } from "lucide-react"
 import { useExerciseLibraryPaginated } from "@/hooks/useExerciseLibraryPaginated"
 import { useExerciseFilterOptions } from "@/hooks/useExerciseFilterOptions"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { ExerciseFilterPanel } from "@/components/builder/ExerciseFilterPanel"
 import { ExerciseDetailSheet } from "@/components/generator/ExerciseDetailSheet"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
@@ -37,6 +38,7 @@ export function SwapExerciseSheet({
 }: SwapExerciseSheetProps) {
   const { t } = useTranslation("workout")
   const { t: tBuilder } = useTranslation("builder")
+  const { catalogName, muscleLabel } = useCatalogLabels()
 
   const [searchInput, setSearchInput] = useState("")
   const [searchDebounced, setSearchDebounced] = useState("")
@@ -177,7 +179,7 @@ export function SwapExerciseSheet({
               {[...grouped.entries()].map(([group, exercises]) => (
                 <div key={group}>
                   <span className="sticky top-0 z-10 block bg-background px-1 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                    {group}
+                    {muscleLabel(group)}
                   </span>
                   {exercises.map((exercise) => (
                     <div key={exercise.id} className="flex items-center gap-1">
@@ -194,7 +196,9 @@ export function SwapExerciseSheet({
                           emoji={exercise.emoji}
                           className="h-7 w-7 rounded"
                         />
-                        <span className="truncate">{exercise.name}</span>
+                        <span className="truncate">
+                          {catalogName(exercise)}
+                        </span>
                       </button>
                       <button
                         type="button"

--- a/src/pages/AdminReviewPage.tsx
+++ b/src/pages/AdminReviewPage.tsx
@@ -10,6 +10,7 @@ import { ExerciseEditForm } from "@/components/admin/exercise-form/ExerciseEditF
 import { ExerciseReviewToolbar } from "@/components/admin/review/ExerciseReviewToolbar"
 import { fromFormValues } from "@/components/admin/exercise-form/transforms"
 import { useAdminUpdateExercise } from "@/hooks/useAdminUpdateExercise"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import {
   useExercisesForReview,
   useReviewTotalCount,
@@ -19,6 +20,7 @@ import type { ExerciseFormValues } from "@/components/admin/exercise-form/schema
 
 export function AdminReviewPage() {
   const { t } = useTranslation("admin")
+  const { muscleLabel, equipmentLabel } = useCatalogLabels()
   const queryClient = useQueryClient()
   const { data: exercises, isLoading } = useExercisesForReview()
   const { data: totalCount } = useReviewTotalCount()
@@ -112,7 +114,8 @@ export function AdminReviewPage() {
                     {exercise!.name}
                   </h2>
                   <p className="mt-0.5 text-sm text-muted-foreground">
-                    {exercise!.muscle_group} · {exercise!.equipment}
+                    {muscleLabel(exercise!.muscle_group)} ·{" "}
+                    {equipmentLabel(exercise!.equipment)}
                   </p>
                 </div>
               </div>

--- a/src/pages/library/ExerciseLibraryExercisePage.test.tsx
+++ b/src/pages/library/ExerciseLibraryExercisePage.test.tsx
@@ -46,12 +46,12 @@ vi.mock("@/components/library/AddExerciseToDaySheet", () => ({
   AddExerciseToDaySheet: () => <div data-testid="add-sheet-mock" />,
 }))
 
-function renderAt(path: string) {
+function renderAt(path: string, locale: "en" | "fr" = "en") {
   return renderWithProviders(
     <Routes>
       <Route path="/library/exercises/:exerciseId" element={<ExerciseLibraryExercisePage />} />
     </Routes>,
-    { initialEntries: [path] },
+    { initialEntries: [path], locale },
   )
 }
 
@@ -84,7 +84,7 @@ describe("ExerciseLibraryExercisePage", () => {
 
   it("renders exercise detail and add CTA", async () => {
     mockUseExerciseFromLibrary.mockReturnValue({
-      data: stubExercise({ name: "Bench Press" }),
+      data: stubExercise({ name: "Développé couché", name_en: "Bench Press" }),
       isLoading: false,
     })
     const user = userEvent.setup()
@@ -95,6 +95,40 @@ describe("ExerciseLibraryExercisePage", () => {
 
     await user.click(screen.getByRole("button", { name: /add to session/i }))
     expect(screen.getByTestId("add-sheet-mock")).toBeInTheDocument()
+  })
+
+  it.each([
+    ["en", "Bench Press", "Chest", "Barbell"],
+    ["fr", "Développé couché", "Pectoraux", "Barre"],
+  ] as const)(
+    "labels the exercise, its muscle and its equipment in %s",
+    (locale, name, muscle, equipment) => {
+      mockUseExerciseFromLibrary.mockReturnValue({
+        data: stubExercise({
+          name: "Développé couché",
+          name_en: "Bench Press",
+          muscle_group: "Pectoraux",
+          equipment: "barbell",
+        }),
+        isLoading: false,
+      })
+      renderAt(`/library/exercises/${VALID_ID}`, locale)
+
+      expect(screen.getByRole("heading", { name })).toBeInTheDocument()
+      expect(screen.getByText(muscle)).toBeInTheDocument()
+      expect(screen.getByText(equipment)).toBeInTheDocument()
+    },
+  )
+
+  it("renders a muscle value that predates the taxonomy as-is", () => {
+    mockUseExerciseFromLibrary.mockReturnValue({
+      // No `muscles.*` key will ever match this one.
+      data: stubExercise({ muscle_group: "Deltoïdes post." }),
+      isLoading: false,
+    })
+    renderAt(`/library/exercises/${VALID_ID}`)
+
+    expect(screen.getByText("Deltoïdes post.")).toBeInTheDocument()
   })
 
   it("renders feedback trigger for content issues", () => {

--- a/src/pages/library/ExerciseLibraryExercisePage.tsx
+++ b/src/pages/library/ExerciseLibraryExercisePage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { Link, useParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { ArrowLeft, Pencil } from "lucide-react"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { useExerciseFromLibrary } from "@/hooks/useExerciseFromLibrary"
 import { AdminOnly } from "@/components/admin/AdminOnly"
 import { ExerciseInstructionsPanel } from "@/components/exercise/ExerciseInstructionsPanel"
@@ -24,6 +25,7 @@ export function ExerciseLibraryExercisePage() {
   const { t } = useTranslation("library")
   const { t: tBuilder } = useTranslation("builder")
   const { t: tWorkout } = useTranslation("workout")
+  const { catalogName, muscleLabel, equipmentLabel } = useCatalogLabels()
   const { exerciseId } = useParams<{ exerciseId: string }>()
   const [addOpen, setAddOpen] = useState(false)
 
@@ -73,7 +75,9 @@ export function ExerciseLibraryExercisePage() {
           >
             <ArrowLeft className="h-5 w-5" />
           </Link>
-          <h1 className="min-w-0 flex-1 text-xl font-bold leading-tight">{exercise.name}</h1>
+          <h1 className="min-w-0 flex-1 text-xl font-bold leading-tight">
+            {catalogName(exercise)}
+          </h1>
         </div>
 
         <div
@@ -109,10 +113,10 @@ export function ExerciseLibraryExercisePage() {
 
           <div className="flex flex-wrap items-center justify-center gap-2">
             <Badge variant="default" className="text-xs font-normal">
-              {exercise.muscle_group}
+              {muscleLabel(exercise.muscle_group)}
             </Badge>
             <Badge variant="secondary" className="text-xs font-normal">
-              {exercise.equipment}
+              {equipmentLabel(exercise.equipment)}
             </Badge>
             {exercise.difficulty_level && (
               <Badge

--- a/src/pages/library/ExerciseLibraryPage.tsx
+++ b/src/pages/library/ExerciseLibraryPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import { ArrowLeft, Loader2, RefreshCw, Search, SlidersHorizontal } from "lucide-react"
 import { useExerciseLibraryPaginated } from "@/hooks/useExerciseLibraryPaginated"
 import { useExerciseFilterOptions } from "@/hooks/useExerciseFilterOptions"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import type { Exercise } from "@/types/database"
 import { ExerciseFilterPanel } from "@/components/builder/ExerciseFilterPanel"
 import { ExerciseThumbnail } from "@/components/exercise/ExerciseThumbnail"
@@ -19,6 +20,7 @@ const SEARCH_DEBOUNCE_MS = 300
 export function ExerciseLibraryPage() {
   const { t } = useTranslation("library")
   const { t: tBuilder } = useTranslation("builder")
+  const { catalogName, muscleLabel, equipmentLabel } = useCatalogLabels()
   const navigate = useNavigate()
 
   const [searchInput, setSearchInput] = useState("")
@@ -157,7 +159,8 @@ export function ExerciseLibraryPage() {
               <CommandEmpty>{tBuilder("noExercisesFound")}</CommandEmpty>
               {grouped &&
                 Object.entries(grouped).map(([muscle, exList]) => (
-                  <CommandGroup key={muscle} heading={muscle}>
+                  // Keyed and grouped on the canonical value, headed by its label.
+                  <CommandGroup key={muscle} heading={muscleLabel(muscle)}>
                     {exList.map((ex) => (
                       <CommandItem
                         key={ex.id}
@@ -171,10 +174,12 @@ export function ExerciseLibraryPage() {
                           className="mr-3 h-16 w-16 shrink-0 rounded-lg"
                         />
                         <div className="flex min-w-0 flex-1 flex-col gap-1">
-                          <span className="truncate font-medium">{ex.name}</span>
+                          <span className="truncate font-medium">
+                            {catalogName(ex)}
+                          </span>
                           <div className="flex flex-wrap items-center gap-1.5">
                             <Badge variant="secondary" className="w-fit text-xs font-normal">
-                              {ex.equipment}
+                              {equipmentLabel(ex.equipment)}
                             </Badge>
                             {ex.difficulty_level && (
                               <Badge


### PR DESCRIPTION
## What

- Muscle and equipment labels are now resolved at display time through `useCatalogLabels`, across the library, builder, session, generator, history and read-only admin surfaces.
- The three competing translation patterns collapse into one: a local `muscleLabel(t, …)` helper duplicated in two balance components, an inline `tCatalog(\`equipment.${eq}\`)` in the builder, and raw text everywhere else.
- Exercise **names** on the library and generator surfaces are localized too — they were missed by T149, and translating only their badges would have shipped cards reading "Développé couché · Chest".
- Two latent bugs the sweep exposed are fixed (details below).

## Why

`muscle_snapshot` stores raw French (`"Pectoraux"`) and was translated **nowhere** except the History balance tab, while the equipment slug was rendered raw on the library detail page. An English reader got "Bench Press · Pectoraux" — fixing names alone was never going to be enough, which is the most visible half of #417.

Storage does not move: `muscle_group` stays canonical French and `equipment` stays an English slug (per the Tech Plan; the migration to English slugs is tracked separately in #423). Only the display layer changes, which means existing programs and history read correctly with no migration and no backfill.

## How

Every value now travels two paths that must not be confused: it is a **label** when it reaches the screen and a **key** everywhere else. Keys are untouched — React `key`s, `groupBy` maps, `filter_muscle_group` / `filter_equipment` RPC arguments, `.in("muscle_group", …)`, `TAXONOMY_TO_SLUGS` and every `BodyMap` prop still carry the canonical value. The filter panel test states the contract in one line: it clicks the pill labelled **"Chest"** and asserts the query receives **`"Pectoraux"`**.

Out-of-taxonomy values (`"Deltoïdes post."`, `"Ischios / Bas du dos"`) still exist in the database and have no key; `muscleLabel` falls back to the raw value, and there are tests for it on both a badge and a pill.

Three deliberate calls beyond the ticket's letter:

- **Snapshot vs catalog.** Several surfaces rendered `muscle_snapshot` while `exercise.muscle_group` was already on the payload. They now prefer the catalog value, so a stale frozen spelling no longer wins over the live one.
- **Swap picker filter** (`ExerciseSwapInlinePanel`). It fed `muscle_snapshot` into a pool filtered on `muscle_group`, so any row frozen with a pre-taxonomy or English spelling silently offered zero candidates. Now filtered on the canonical value, with a regression test.
- **cmdk search token.** The builder picker's search string embedded the raw French muscle only, so an English reader typing "chest" found nothing. It now carries both spellings, leaving French search intact.

Admin read-only surfaces (review page, enrichment card, exercises table) follow the reader's locale. The `SelectItem`s in the exercise edit form deliberately **do not**: there the displayed text *is* the stored value, and an editor needs to see what they are about to write. Sorting and the admin search index likewise stay on the canonical values behind the `accessorKey`s.

### Tests

Dual-locale coverage on a badge (library detail), a pill (filter panel) and a grouping heading, plus the out-of-taxonomy fallback, the canonical-dedupe of saved-workout badges, and the swap-filter regression. Seven mutations run against the new guards — reverting each fix (label back to raw, dedupe back to the snapshot, pill sending the label instead of the canonical value, dropping the taxonomy fallback) kills its test.

Six existing tests were asserting French text while rendering in English; they now query the translated label and keep asserting the canonical value in the callback, which makes them stronger rather than merely green. One of them (`ExerciseLibraryExercisePage`) was passing by accident on a fixture whose `name` and `name_en` disagreed.

Part of #422 — T151.
