### PR TITLE
feat(i18n): localize the end-of-day recap (T155)

### DIFF
--- a/src/components/workout/ExerciseListPreview.test.tsx
+++ b/src/components/workout/ExerciseListPreview.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest"
+import { screen } from "@testing-library/react"
+import { renderWithProviders } from "@/test/utils"
+import type { ExercisePreviewItem } from "@/lib/sessionSummary"
+import { ExerciseListPreview } from "./ExerciseListPreview"
+
+const item = (
+  overrides: Partial<ExercisePreviewItem> = {},
+): ExercisePreviewItem => ({
+  id: "we-1",
+  emoji: "🏋️",
+  exercise: { name: "Développé couché", name_en: "Bench Press" },
+  name_snapshot: "Développé couché",
+  sets: 3,
+  reps: "10",
+  maxWeight: 80,
+  ...overrides,
+})
+
+function render(items: ExercisePreviewItem[], locale: "en" | "fr" = "en") {
+  return renderWithProviders(<ExerciseListPreview items={items} />, { locale })
+}
+
+describe("ExerciseListPreview", () => {
+  it.each([
+    ["en", "Bench Press"],
+    ["fr", "Développé couché"],
+  ] as const)("names the recapped exercise in %s", (locale, name) => {
+    render([item()], locale)
+
+    expect(screen.getByText(name)).toBeInTheDocument()
+  })
+
+  // The recap sits under a session screen that already reads English; a French
+  // name here was the last visible seam (#431).
+  it("does not leak the French name to an English reader", () => {
+    render([item()])
+
+    expect(screen.queryByText("Développé couché")).not.toBeInTheDocument()
+  })
+
+  it("falls back to the frozen snapshot when the catalog row is gone", () => {
+    render([item({ exercise: null, name_snapshot: "Exercice supprimé" })])
+
+    expect(screen.getByText("Exercice supprimé")).toBeInTheDocument()
+  })
+
+  // An exercise the catalog never translated: the French name is all there is,
+  // and showing it beats showing nothing.
+  it("falls back to the French name when name_en is null", () => {
+    render([item({ exercise: { name: "Gainage latéral", name_en: null } })])
+
+    expect(screen.getByText("Gainage latéral")).toBeInTheDocument()
+  })
+
+  it("renders nothing for an empty recap", () => {
+    const { container } = render([])
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("keeps showing the set and rep line next to the name", () => {
+    render([item({ sets: 4, reps: "8–10" })])
+
+    expect(screen.getByText(/4 × 8–10/)).toBeInTheDocument()
+  })
+})

--- a/src/components/workout/ExerciseListPreview.tsx
+++ b/src/components/workout/ExerciseListPreview.tsx
@@ -1,4 +1,5 @@
 import type { ExercisePreviewItem } from "@/lib/sessionSummary"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { useWeightUnit } from "@/hooks/useWeightUnit"
 
 interface ExerciseListPreviewProps {
@@ -7,6 +8,7 @@ interface ExerciseListPreviewProps {
 
 export function ExerciseListPreview({ items }: ExerciseListPreviewProps) {
   const { formatWeight } = useWeightUnit()
+  const { exerciseName } = useCatalogLabels()
 
   if (items.length === 0) return null
 
@@ -20,7 +22,7 @@ export function ExerciseListPreview({ items }: ExerciseListPreviewProps) {
           <span className="text-2xl leading-none">{item.emoji}</span>
           <div className="min-w-0 flex-1">
             <p className="truncate text-sm font-medium text-foreground">
-              {item.name}
+              {exerciseName(item)}
             </p>
             <p className="text-xs text-muted-foreground">
               {item.sets} × {item.reps}

--- a/src/lib/catalogLabels.test.ts
+++ b/src/lib/catalogLabels.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest"
 
 import source from "./catalogLabels.ts?raw"
+import { importsOf } from "@/test/imports"
 import {
   equipmentLabelKey,
   isEnglish,
@@ -22,9 +23,7 @@ describe("purity", () => {
   it.each(["react", "i18next", "@/lib/supabase"])(
     "does not import %s",
     (module) => {
-      expect(source).not.toMatch(
-        new RegExp(`from\\s+["']${module.replace("/", "\\/")}`),
-      )
+      expect(importsOf(source, module)).toEqual([])
     },
   )
 })

--- a/src/lib/sessionSummary.test.ts
+++ b/src/lib/sessionSummary.test.ts
@@ -1,14 +1,32 @@
 import { describe, expect, it } from "vitest"
+import source from "./sessionSummary.ts?raw"
 import { summarizeSessionLogs, templateToPreviewItems } from "./sessionSummary"
-import type { SetLog, WorkoutExercise } from "@/types/database"
+import { resolveExerciseName } from "./catalogLabels"
+import type {
+  ExerciseLabelFields,
+  SetLogWithExercise,
+  WorkoutExerciseWithLabel,
+} from "@/types/database"
+
+const catalogRow = (
+  overrides: Partial<ExerciseLabelFields> = {},
+): ExerciseLabelFields => ({
+  id: "ex-1",
+  name: "Développé couché",
+  name_en: "Bench Press",
+  muscle_group: "Pectoraux",
+  equipment: "barbell",
+  emoji: "🏋️",
+  ...overrides,
+})
 
 const makeLog = (
-  overrides: Partial<SetLog> &
+  overrides: Partial<SetLogWithExercise> &
     Pick<
-      SetLog,
+      SetLogWithExercise,
       "exercise_id" | "exercise_name_snapshot" | "set_number" | "weight_logged"
     > & { reps_logged?: string | null; duration_seconds?: number | null },
-): SetLog => ({
+): SetLogWithExercise => ({
   id: "log-1",
   session_id: "sess-1",
   block_exercise_id: null,
@@ -19,12 +37,14 @@ const makeLog = (
   rest_seconds: null,
   reps_logged: null,
   duration_seconds: null,
+  exercise: null,
   ...overrides,
 })
 
 const makeExercise = (
-  overrides: Partial<WorkoutExercise> & Pick<WorkoutExercise, "id" | "exercise_id">,
-): WorkoutExercise => ({
+  overrides: Partial<WorkoutExerciseWithLabel> &
+    Pick<WorkoutExerciseWithLabel, "id" | "exercise_id">,
+): WorkoutExerciseWithLabel => ({
   workout_day_id: "day-1",
   name_snapshot: "Test Exercise",
   muscle_snapshot: "chest",
@@ -42,12 +62,23 @@ const makeExercise = (
   weight_increment: null,
   max_weight_reached: false,
   template_updated_at: "2020-01-01T00:00:00Z",
+  exercise: null,
   ...overrides,
+})
+
+describe("purity", () => {
+  // These builders feed a recap that has to read in the user's language, but
+  // they must not know which language that is: the same built item is rendered
+  // by a component that resolves the label. An i18next import here would bake
+  // the name back in.
+  it.each(["react", "i18next"])("does not import %s", (module) => {
+    expect(source).not.toMatch(new RegExp(`from\\s+["']${module}`))
+  })
 })
 
 describe("summarizeSessionLogs", () => {
   it("groups logs by exercise and counts actual sets", () => {
-    const logs: SetLog[] = [
+    const logs = [
       makeLog({ exercise_id: "ex-1", exercise_name_snapshot: "Bench Press", set_number: 1, reps_logged: "10", weight_logged: 80 }),
       makeLog({ exercise_id: "ex-1", exercise_name_snapshot: "Bench Press", set_number: 2, reps_logged: "10", weight_logged: 80 }),
       makeLog({ exercise_id: "ex-1", exercise_name_snapshot: "Bench Press", set_number: 3, reps_logged: "8", weight_logged: 85 }),
@@ -65,7 +96,7 @@ describe("summarizeSessionLogs", () => {
   })
 
   it("uses uniform reps when all sets have the same value", () => {
-    const logs: SetLog[] = [
+    const logs = [
       makeLog({ exercise_id: "ex-1", exercise_name_snapshot: "Squat", set_number: 1, reps_logged: "12", weight_logged: 100 }),
       makeLog({ exercise_id: "ex-1", exercise_name_snapshot: "Squat", set_number: 2, reps_logged: "12", weight_logged: 100 }),
     ]
@@ -77,7 +108,7 @@ describe("summarizeSessionLogs", () => {
   })
 
   it("preserves template sort order", () => {
-    const logs: SetLog[] = [
+    const logs = [
       makeLog({ exercise_id: "ex-b", exercise_name_snapshot: "B Exercise", set_number: 1, reps_logged: "10", weight_logged: 40 }),
       makeLog({ exercise_id: "ex-a", exercise_name_snapshot: "A Exercise", set_number: 1, reps_logged: "10", weight_logged: 60 }),
     ]
@@ -88,19 +119,57 @@ describe("summarizeSessionLogs", () => {
 
     const result = summarizeSessionLogs(logs, template)
 
-    expect(result[0].name).toBe("A Exercise")
-    expect(result[1].name).toBe("B Exercise")
+    expect(result.map((i) => i.exercise_name_snapshot)).toEqual([
+      "A Exercise",
+      "B Exercise",
+    ])
   })
 
   it("falls back to a default emoji when exercise is not in template", () => {
-    const logs: SetLog[] = [
+    const logs = [
       makeLog({ exercise_id: "ex-new", exercise_name_snapshot: "Added Mid-Session", set_number: 1, reps_logged: "10", weight_logged: 20 }),
     ]
 
     const result = summarizeSessionLogs(logs, [])
 
     expect(result[0].emoji).toBe("🏋️")
-    expect(result[0].name).toBe("Added Mid-Session")
+    expect(result[0].exercise_name_snapshot).toBe("Added Mid-Session")
+  })
+
+  // One built item, two locales, two names: proof that nothing was baked at
+  // build time.
+  it("hands the recap a source that resolves in either language", () => {
+    const logs = [
+      makeLog({
+        exercise_id: "ex-1",
+        exercise_name_snapshot: "Développé couché",
+        set_number: 1,
+        reps_logged: "10",
+        weight_logged: 80,
+        exercise: catalogRow(),
+      }),
+    ]
+
+    const [item] = summarizeSessionLogs(logs, [])
+
+    expect(resolveExerciseName(item, "en")).toBe("Bench Press")
+    expect(resolveExerciseName(item, "fr")).toBe("Développé couché")
+  })
+
+  it("keeps the frozen snapshot when the catalog row is gone", () => {
+    const logs = [
+      makeLog({
+        exercise_id: "ex-gone",
+        exercise_name_snapshot: "Exercice supprimé",
+        set_number: 1,
+        reps_logged: "10",
+        weight_logged: 80,
+      }),
+    ]
+
+    const [item] = summarizeSessionLogs(logs, [])
+
+    expect(resolveExerciseName(item, "en")).toBe("Exercice supprimé")
   })
 })
 
@@ -116,7 +185,8 @@ describe("templateToPreviewItems", () => {
     expect(result[0]).toEqual({
       id: "we-1",
       emoji: "🏋️",
-      name: "Bench",
+      exercise: null,
+      name_snapshot: "Bench",
       sets: 3,
       reps: "10",
       maxWeight: 80,
@@ -159,5 +229,21 @@ describe("templateToPreviewItems", () => {
     const result = templateToPreviewItems(exercises)
 
     expect(result[0].reps).toBe("12")
+  })
+
+  it("hands the recap a source that resolves in either language", () => {
+    const exercises = [
+      makeExercise({
+        id: "we-1",
+        exercise_id: "ex-1",
+        name_snapshot: "Développé couché",
+        exercise: catalogRow(),
+      }),
+    ]
+
+    const [item] = templateToPreviewItems(exercises)
+
+    expect(resolveExerciseName(item, "en")).toBe("Bench Press")
+    expect(resolveExerciseName(item, "fr")).toBe("Développé couché")
   })
 })

--- a/src/lib/sessionSummary.test.ts
+++ b/src/lib/sessionSummary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import source from "./sessionSummary.ts?raw"
 import { summarizeSessionLogs, templateToPreviewItems } from "./sessionSummary"
 import { resolveExerciseName } from "./catalogLabels"
+import { importsOf } from "@/test/imports"
 import type {
   ExerciseLabelFields,
   SetLogWithExercise,
@@ -72,7 +73,7 @@ describe("purity", () => {
   // by a component that resolves the label. An i18next import here would bake
   // the name back in.
   it.each(["react", "i18next"])("does not import %s", (module) => {
-    expect(source).not.toMatch(new RegExp(`from\\s+["']${module}`))
+    expect(importsOf(source, module)).toEqual([])
   })
 })
 

--- a/src/lib/sessionSummary.ts
+++ b/src/lib/sessionSummary.ts
@@ -1,6 +1,11 @@
 import { formatDurationShort, formatSecondsMMSS } from "@/lib/formatters"
 import { groupBy } from "@/lib/utils"
-import type { SetLog, WorkoutExercise } from "@/types/database"
+import type { CatalogNameSource } from "@/lib/catalogLabels"
+import type {
+  SetLog,
+  SetLogWithExercise,
+  WorkoutExerciseWithLabel,
+} from "@/types/database"
 
 function setLogDisplayValue(log: SetLog): string {
   if (log.duration_seconds != null) {
@@ -43,10 +48,14 @@ function repsRangeLabel(
   return unique.join("–")
 }
 
-export interface ExercisePreviewItem {
+/**
+ * Carries the name *source* rather than a name: the recap is rendered in the
+ * reader's language (ADR 0010), which these builders have no business knowing.
+ * `ExerciseListPreview` resolves it via `useCatalogLabels`.
+ */
+export interface ExercisePreviewItem extends CatalogNameSource {
   id: string
   emoji: string
-  name: string
   sets: number
   reps: string
   maxWeight: number
@@ -58,8 +67,8 @@ export interface ExercisePreviewItem {
  * Exercises that appear in logs but not in the template are appended at the end.
  */
 export function summarizeSessionLogs(
-  logs: SetLog[],
-  templateExercises: WorkoutExercise[],
+  logs: SetLogWithExercise[],
+  templateExercises: WorkoutExerciseWithLabel[],
 ): ExercisePreviewItem[] {
   const logsByExercise = groupBy(logs, (log) => log.exercise_id)
 
@@ -67,7 +76,8 @@ export function summarizeSessionLogs(
     [...logsByExercise].map(([exerciseId, exerciseLogs]) => [
       exerciseId,
       {
-        name: exerciseLogs[0].exercise_name_snapshot,
+        exercise: exerciseLogs[0].exercise,
+        exercise_name_snapshot: exerciseLogs[0].exercise_name_snapshot,
         reps: exerciseLogs.map(setLogDisplayValue),
         maxWeight: Math.max(...exerciseLogs.map((l) => l.weight_logged)),
         hasDuration: exerciseLogs.some((l) => l.duration_seconds != null),
@@ -75,18 +85,19 @@ export function summarizeSessionLogs(
     ]),
   )
 
-  const emojiByExerciseId = new Map<string, string>()
-  const orderByExerciseId = new Map<string, number>()
-  for (const ex of templateExercises) {
-    emojiByExerciseId.set(ex.exercise_id, ex.emoji_snapshot)
-    orderByExerciseId.set(ex.exercise_id, ex.sort_order)
-  }
+  const emojiByExerciseId = new Map(
+    templateExercises.map((ex) => [ex.exercise_id, ex.emoji_snapshot]),
+  )
+  const orderByExerciseId = new Map(
+    templateExercises.map((ex) => [ex.exercise_id, ex.sort_order]),
+  )
 
   const items: ExercisePreviewItem[] = [...grouped].map(
     ([exerciseId, entry]) => ({
       id: exerciseId,
       emoji: emojiByExerciseId.get(exerciseId) ?? "🏋️",
-      name: entry.name,
+      exercise: entry.exercise,
+      exercise_name_snapshot: entry.exercise_name_snapshot,
       sets: entry.reps.length,
       reps: repsRangeLabel(
         entry.reps,
@@ -107,7 +118,7 @@ export function summarizeSessionLogs(
 
 /** Converts template exercises into the same preview shape. */
 export function templateToPreviewItems(
-  exercises: WorkoutExercise[],
+  exercises: WorkoutExerciseWithLabel[],
 ): ExercisePreviewItem[] {
   return exercises.map((ex) => {
     const duration = ex.target_duration_seconds
@@ -115,7 +126,8 @@ export function templateToPreviewItems(
     return {
       id: ex.id,
       emoji: ex.emoji_snapshot,
-      name: ex.name_snapshot,
+      exercise: ex.exercise,
+      name_snapshot: ex.name_snapshot,
       sets: ex.sets,
       reps: hasDuration ? formatDurationShort(duration) : ex.reps,
       maxWeight: Number(ex.weight),

--- a/src/test/imports.test.ts
+++ b/src/test/imports.test.ts
@@ -19,6 +19,29 @@ describe("importedModules", () => {
   it("ignores a module named in prose", () => {
     expect(importedModules("// i18next is deliberately absent here")).toEqual([])
   })
+
+  // A bare import has no `from`, so a guard reading only `from "…"` lets it
+  // through — and importing a module purely for its side effects is exactly how
+  // React ends up in the graph of something that claims not to need it.
+  it("collects side-effect imports", () => {
+    expect(importedModules('import "@/lib/i18n"')).toEqual(["@/lib/i18n"])
+  })
+
+  it("collects dynamic imports", () => {
+    expect(
+      importedModules('const m = await import("react-i18next")'),
+    ).toEqual(["react-i18next"])
+  })
+
+  it("collects re-exports", () => {
+    expect(importedModules('export { useMemo } from "react"')).toEqual(["react"])
+  })
+
+  it("collects type-only imports", () => {
+    expect(importedModules('import type { TFunction } from "i18next"')).toEqual([
+      "i18next",
+    ])
+  })
 })
 
 describe("importsOf", () => {
@@ -29,6 +52,10 @@ describe("importsOf", () => {
 
     expect(importsOf(source, "i18next")).toEqual(["react-i18next"])
     expect(importsOf(source, "react")).toEqual(["react-i18next"])
+  })
+
+  it("counts a side-effect import of the i18n module", () => {
+    expect(importsOf('import "@/lib/i18n"', "i18n")).toEqual(["@/lib/i18n"])
   })
 
   it("finds nothing in a pure module", () => {

--- a/src/test/imports.test.ts
+++ b/src/test/imports.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest"
+import { importedModules, importsOf } from "./imports"
+
+describe("importedModules", () => {
+  it("collects specifiers across quote styles", () => {
+    const source = [
+      'import { useMemo } from "react"',
+      "import { useTranslation } from 'react-i18next'",
+      'import { groupBy } from "@/lib/utils"',
+    ].join("\n")
+
+    expect(importedModules(source)).toEqual([
+      "react",
+      "react-i18next",
+      "@/lib/utils",
+    ])
+  })
+
+  it("ignores a module named in prose", () => {
+    expect(importedModules("// i18next is deliberately absent here")).toEqual([])
+  })
+})
+
+describe("importsOf", () => {
+  // The case the previous regex missed: this is an i18next import, and the
+  // whole purpose of a purity guard is to catch it.
+  it("counts react-i18next as an i18next import", () => {
+    const source = "import { useTranslation } from \"react-i18next\""
+
+    expect(importsOf(source, "i18next")).toEqual(["react-i18next"])
+    expect(importsOf(source, "react")).toEqual(["react-i18next"])
+  })
+
+  it("finds nothing in a pure module", () => {
+    const source = [
+      'import { formatDurationShort } from "@/lib/formatters"',
+      'import type { SetLog } from "@/types/database"',
+    ].join("\n")
+
+    expect(importsOf(source, "react")).toEqual([])
+    expect(importsOf(source, "i18next")).toEqual([])
+  })
+})

--- a/src/test/imports.ts
+++ b/src/test/imports.ts
@@ -2,15 +2,19 @@
  * Import specifiers of a module read with `?raw`, for the purity guards that
  * assert a pure lib pulls in neither React nor i18next.
  *
- * Parsing the specifiers and matching against the whole string is the point.
- * A regex anchored on the opening quote — `from\s+["']i18next` — reads as if it
- * forbids i18next while silently allowing `from "react-i18next"`, which is
- * exactly how a React developer would break purity.
+ * Covers all three ways a module can name a dependency — `from "x"`, the
+ * side-effect `import "x"`, and the dynamic `import("x")` — because a guard
+ * that only reads one of them announces a purity it isn't checking.
+ *
+ * Type-only imports are listed too. That is a deliberate false positive: a
+ * module that claims to need no i18n has no reason to name i18next at all, and
+ * the day one legitimately needs a type, the failing test is the right place to
+ * have that conversation.
  */
 export function importedModules(source: string): string[] {
-  return [...source.matchAll(/from\s+["']([^"']+)["']/g)].map(
-    ([, specifier]) => specifier,
-  )
+  return [
+    ...source.matchAll(/\b(?:from|import)\s*\(?\s*["']([^"']+)["']/g),
+  ].map(([, specifier]) => specifier)
 }
 
 /** Specifiers that pull in `module`, directly or as part of its ecosystem. */

--- a/src/test/imports.ts
+++ b/src/test/imports.ts
@@ -1,0 +1,21 @@
+/**
+ * Import specifiers of a module read with `?raw`, for the purity guards that
+ * assert a pure lib pulls in neither React nor i18next.
+ *
+ * Parsing the specifiers and matching against the whole string is the point.
+ * A regex anchored on the opening quote — `from\s+["']i18next` — reads as if it
+ * forbids i18next while silently allowing `from "react-i18next"`, which is
+ * exactly how a React developer would break purity.
+ */
+export function importedModules(source: string): string[] {
+  return [...source.matchAll(/from\s+["']([^"']+)["']/g)].map(
+    ([, specifier]) => specifier,
+  )
+}
+
+/** Specifiers that pull in `module`, directly or as part of its ecosystem. */
+export function importsOf(source: string, module: string): string[] {
+  return importedModules(source).filter((specifier) =>
+    specifier.includes(module),
+  )
+}


### PR DESCRIPTION
Closes #431. Part of #422.

## What

The end-of-day recap on `WorkoutPage` now reads in the user's language. It was the last French island inside surfaces T149 / T150 had otherwise localized: an English reader finishing a day saw **Développé couché** in the recap, directly under a session screen saying **Bench Press**.

## Why it needed more than a call swap

`sessionSummary.ts` baked a display-ready `name` at *build* time from the snapshot columns. `ExercisePreviewItem` now carries the name **source** instead — the catalog embed plus the snapshot, the same shape `SoloHistoryGroup` and `BlockHistoryCell` already use — and `ExerciseListPreview` resolves it at render via `useCatalogLabels`.

Both inputs already carried the embed after T149 / T150, so this costs **no new query and no new column**. Only the plumbing changed.

## How

- `ExercisePreviewItem extends CatalogNameSource`; both builders hand over `exercise` + their respective snapshot column (`exercise_name_snapshot` for logs, `name_snapshot` for the template). Either satisfies the interface, so neither needs a wrapper.
- `summarizeSessionLogs` / `templateToPreviewItems` stay pure — no React, no i18next — guarded by a source-level purity test.
- Replaced the two `for` loops that filled mutable `Map`s with `new Map(exercises.map(...))`, per the repo's functional-style rule, since the change landed on those lines anyway.

## A guard that wasn't guarding

Writing the purity test surfaced a hole in the convention T147 introduced. The regex was:

```
from\s+["']i18next
```

Anchored on the opening quote, it claimed a module imports no i18next while allowing the one import a React developer would actually write:

```ts
import { useTranslation } from "react-i18next"   // passed the guard
```

Found by checking the checker instead of trusting it. Both purity guards (here and in `catalogLabels.test.ts`) now share `importsOf`, which parses the specifiers and matches on substring — and that helper has its own test, so the missed case is permanently encoded rather than fixed in passing.

## Tests

- Dual-locale test on `ExerciseListPreview`, plus a case asserting the French name does **not** leak to an English reader.
- Fallbacks: catalog row gone → frozen snapshot; `name_en` null → French name.
- `sessionSummary` tests now resolve one built item under **both** locales, which is what proves nothing is baked at build time. Fixtures deliberately hold a snapshot that differs from `name_en`, so any lost embed or re-baked name fails the assertion.
- 1860 tests pass, `tsc -b` and lint clean.

## Acceptance

- [x] English reader sees English names in the recap, French reader French ones, no refetch on switch
- [x] Exercise absent from the catalog (or null `name_en`) falls back to the snapshot
- [x] Dual-locale test on `ExerciseListPreview` + builders asserted display-agnostic
- [x] `sessionSummary.ts` imports neither React nor i18next

Made with [Cursor](https://cursor.com)