### PR TITLE
feat(i18n): persist the display locale on the user profile (T152)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { useSetAtom } from "jotai"
 import { Outlet, useLocation } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { drawerOpenAtom } from "@/store/atoms"
+import { useHydrateLocaleFromProfile } from "@/hooks/useProfileLocale"
 import { SessionTimerChip } from "@/components/SessionTimerChip"
 import { SyncStatusChip } from "@/components/SyncStatusChip"
 import { SideDrawer } from "@/components/SideDrawer"
@@ -15,6 +16,9 @@ import { AchievementUnlockOverlay } from "@/components/achievements/AchievementU
 export function AppShell() {
   const { t } = useTranslation()
   const setDrawerOpen = useSetAtom(drawerOpenAtom)
+  // Runs where auth is already resolved, which is the earliest the profile's
+  // language is readable at all.
+  useHydrateLocaleFromProfile()
   const { pathname } = useLocation()
   const hideSessionChrome = pathname.startsWith("/cycle-summary")
 

--- a/src/components/SideDrawer.test.tsx
+++ b/src/components/SideDrawer.test.tsx
@@ -14,9 +14,14 @@ import { useBadgeStatus } from "@/hooks/useBadgeStatus"
 import { renderWithProviders, mockQueryResult } from "@/test/utils"
 import { SideDrawer } from "./SideDrawer"
 
-const { mockSignOut } = vi.hoisted(() => ({
-  mockSignOut: vi.fn().mockResolvedValue({}),
-}))
+const { mockSignOut, mockEq, mockUpdate } = vi.hoisted(() => {
+  const mockEq = vi.fn().mockResolvedValue({ error: null })
+  return {
+    mockSignOut: vi.fn().mockResolvedValue({}),
+    mockEq,
+    mockUpdate: vi.fn(() => ({ eq: mockEq })),
+  }
+})
 
 vi.mock("@/lib/supabase", () => ({
   supabase: {
@@ -25,6 +30,7 @@ vi.mock("@/lib/supabase", () => ({
       getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
       onAuthStateChange: vi.fn(),
     },
+    from: vi.fn(() => ({ update: mockUpdate })),
   },
   clearUserState: vi.fn(),
 }))
@@ -195,6 +201,7 @@ describe("SideDrawer achievements", () => {
         session_duration_minutes: 60,
         active_title_tier_id: "tier-42",
         timezone: "Europe/Paris",
+        locale: null,
         created_at: "2026-01-01",
         updated_at: "2026-01-01",
       }),
@@ -233,5 +240,43 @@ describe("SideDrawer achievements", () => {
     renderDrawer()
     const dialog = await screen.findByRole("dialog")
     expect(within(dialog).queryByText("Iron Warrior")).not.toBeInTheDocument()
+  })
+})
+
+describe("SideDrawer language switch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEq.mockResolvedValue({ error: null })
+    localStorage.clear()
+  })
+
+  it("switches the UI and syncs the choice to the profile", async () => {
+    const user = userEvent.setup()
+    renderDrawer()
+
+    await user.click(screen.getByRole("button", { name: "FR" }))
+
+    // localStorage is what the next boot reads, so it has to win locally...
+    await waitFor(() => {
+      expect(localStorage.getItem("locale")).toBe('"fr"')
+    })
+    // ...and the profile only carries the choice to the user's other devices.
+    expect(mockUpdate).toHaveBeenCalledWith({ locale: "fr" })
+    expect(mockEq).toHaveBeenCalledWith("user_id", "user-1")
+  })
+
+  // The switch has already taken effect locally when the write goes out, so a
+  // failure has nothing to tell the user.
+  it("keeps the UI switched when the profile write fails", async () => {
+    mockEq.mockRejectedValue(new Error("offline"))
+    const user = userEvent.setup()
+    renderDrawer()
+
+    await user.click(screen.getByRole("button", { name: "FR" }))
+
+    await waitFor(() => {
+      expect(localStorage.getItem("locale")).toBe('"fr"')
+    })
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
   })
 })

--- a/src/components/SideDrawer.tsx
+++ b/src/components/SideDrawer.tsx
@@ -48,6 +48,7 @@ import { supabase } from "@/lib/supabase"
 import { publicSite } from "@/lib/publicSite"
 import { useInstallPrompt } from "@/hooks/useInstallPrompt"
 import { useUserProfile } from "@/hooks/useUserProfile"
+import { usePersistProfileLocale } from "@/hooks/useProfileLocale"
 import { useBadgeStatus } from "@/hooks/useBadgeStatus"
 import { resolveAvatarUrl, resolveDisplayName } from "@/lib/userDisplay"
 import { rankColorText, resolveActiveTitle } from "@/lib/achievementUtils"
@@ -95,6 +96,7 @@ export function SideDrawer() {
   const { t, i18n } = useTranslation(["common", "settings", "account", "admin", "library", "achievements"])
   const [open, setOpen] = useAtom(drawerOpenAtom)
   const [locale, setLocale] = useAtom(localeAtom)
+  const persistProfileLocale = usePersistProfileLocale()
   const [weightUnit, setWeightUnit] = useAtom(weightUnitAtom)
   const user = useAtomValue(authAtom)
   const { data: profile } = useUserProfile()
@@ -138,6 +140,9 @@ export function SideDrawer() {
   function handleLocaleChange(v: "en" | "fr") {
     setLocale(v)
     i18n.changeLanguage(v)
+    // After the local switch, never before: the profile write is a best-effort
+    // sync for the user's other devices and must not gate the UI.
+    void persistProfileLocale(v)
   }
 
   const profileDisplayName = user

--- a/src/hooks/useCreateUserProfile.test.tsx
+++ b/src/hooks/useCreateUserProfile.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { act } from "@testing-library/react"
+
+import { renderHookWithProviders } from "@/test/utils"
+import { authAtom } from "@/store/atoms"
+import { useCreateUserProfile } from "./useCreateUserProfile"
+
+const single = vi.fn()
+const select = vi.fn(() => ({ single }))
+const upsert = vi.fn(() => ({ select }))
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: vi.fn(() => ({ upsert })) },
+}))
+
+const INPUT = {
+  gender: "male",
+  age: 30,
+  weight: 80,
+  goal: "strength",
+  experience: "intermediate",
+  equipment: "gym",
+  training_days_per_week: 4,
+  session_duration_minutes: 60,
+} as const
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  single.mockResolvedValue({ data: {}, error: null })
+})
+
+async function createProfileIn(locale: "en" | "fr") {
+  const { result, store } = renderHookWithProviders(
+    () => useCreateUserProfile(),
+    { locale },
+  )
+  act(() => {
+    store.set(authAtom, { id: "user-1", email: "a@b.c" } as never)
+  })
+
+  await act(async () => {
+    await result.current.mutateAsync(INPUT)
+  })
+
+  return vi.mocked(upsert).mock.calls[0][0] as Record<string, unknown>
+}
+
+describe("useCreateUserProfile", () => {
+  // Captured like `timezone`: the language they read the onboarding in is the
+  // best guess we will ever have for a device we have not met yet.
+  it.each(["en", "fr"] as const)(
+    "seeds the profile with the onboarding language (%s)",
+    async (locale) => {
+      expect(await createProfileIn(locale)).toMatchObject({ locale })
+    },
+  )
+
+  // The column's CHECK only accepts a base subtag, so an unnormalized
+  // "en-US" would fail the whole upsert — the profile, not just the language.
+  it("normalizes a regional tag before writing it", async () => {
+    const { result, store, i18nInstance } = renderHookWithProviders(() =>
+      useCreateUserProfile(),
+    )
+    await act(async () => {
+      await i18nInstance.changeLanguage("en-US")
+    })
+    act(() => {
+      store.set(authAtom, { id: "user-1", email: "a@b.c" } as never)
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync(INPUT)
+    })
+
+    expect(vi.mocked(upsert).mock.calls[0][0]).toMatchObject({ locale: "en" })
+  })
+})

--- a/src/hooks/useCreateUserProfile.test.tsx
+++ b/src/hooks/useCreateUserProfile.test.tsx
@@ -29,20 +29,23 @@ beforeEach(() => {
   single.mockResolvedValue({ data: {}, error: null })
 })
 
-async function createProfileIn(locale: "en" | "fr") {
-  const { result, store } = renderHookWithProviders(
-    () => useCreateUserProfile(),
-    { locale },
-  )
+async function createProfileIn(locale?: "en" | "fr") {
+  const harness = renderHookWithProviders(() => useCreateUserProfile(), {
+    locale,
+  })
   act(() => {
-    store.set(authAtom, { id: "user-1", email: "a@b.c" } as never)
+    harness.store.set(authAtom, { id: "user-1", email: "a@b.c" } as never)
   })
 
+  return harness
+}
+
+async function submitQuestionnaire(
+  harness: Awaited<ReturnType<typeof createProfileIn>>,
+) {
   await act(async () => {
-    await result.current.mutateAsync(INPUT)
+    await harness.result.current.mutateAsync(INPUT)
   })
-
-  return vi.mocked(upsert).mock.calls[0][0] as Record<string, unknown>
 }
 
 describe("useCreateUserProfile", () => {
@@ -51,27 +54,28 @@ describe("useCreateUserProfile", () => {
   it.each(["en", "fr"] as const)(
     "seeds the profile with the onboarding language (%s)",
     async (locale) => {
-      expect(await createProfileIn(locale)).toMatchObject({ locale })
+      await submitQuestionnaire(await createProfileIn(locale))
+
+      expect(upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ locale }),
+        expect.anything(),
+      )
     },
   )
 
   // The column's CHECK only accepts a base subtag, so an unnormalized
   // "en-US" would fail the whole upsert — the profile, not just the language.
   it("normalizes a regional tag before writing it", async () => {
-    const { result, store, i18nInstance } = renderHookWithProviders(() =>
-      useCreateUserProfile(),
+    const harness = await createProfileIn()
+    await act(async () => {
+      await harness.i18nInstance.changeLanguage("en-US")
+    })
+
+    await submitQuestionnaire(harness)
+
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: "en" }),
+      expect.anything(),
     )
-    await act(async () => {
-      await i18nInstance.changeLanguage("en-US")
-    })
-    act(() => {
-      store.set(authAtom, { id: "user-1", email: "a@b.c" } as never)
-    })
-
-    await act(async () => {
-      await result.current.mutateAsync(INPUT)
-    })
-
-    expect(vi.mocked(upsert).mock.calls[0][0]).toMatchObject({ locale: "en" })
   })
 })

--- a/src/hooks/useCreateUserProfile.ts
+++ b/src/hooks/useCreateUserProfile.ts
@@ -1,6 +1,8 @@
 import { useMutation } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
+import { useTranslation } from "react-i18next"
 import { supabase } from "@/lib/supabase"
+import { normalizeLocale } from "@/lib/persistedLocale"
 import { authAtom, weightUnitAtom } from "@/store/atoms"
 import { getResolvedIANATimeZone } from "@/lib/trainingActivityTimezone"
 import { AuthExpiredError, DisplayNameTakenError } from "@/hooks/profileErrors"
@@ -22,6 +24,7 @@ const LBS_TO_KG = 0.453592
 export function useCreateUserProfile() {
   const user = useAtomValue(authAtom)
   const weightUnit = useAtomValue(weightUnitAtom)
+  const { i18n } = useTranslation()
 
   return useMutation({
     mutationFn: async (input: ProfileInput) => {
@@ -35,6 +38,12 @@ export function useCreateUserProfile() {
       const emailDefault = user.email?.trim() || null
 
       const timezone = getResolvedIANATimeZone()
+
+      // Captured like `timezone`: whatever language they just read the
+      // onboarding in is the best guess we will ever have. Normalized because
+      // `i18n.language` can be "en-US" and the column's CHECK only accepts a
+      // base subtag — an unnormalized write would fail the whole upsert.
+      const locale = normalizeLocale(i18n.language)
 
       const { data, error } = await supabase
         .from("user_profiles")
@@ -51,6 +60,7 @@ export function useCreateUserProfile() {
             training_days_per_week: input.training_days_per_week,
             session_duration_minutes: input.session_duration_minutes,
             timezone,
+            locale,
           },
           { onConflict: "user_id" },
         )

--- a/src/hooks/useOnboardingEntry.test.ts
+++ b/src/hooks/useOnboardingEntry.test.ts
@@ -39,6 +39,7 @@ const PROFILE: UserProfile = {
   session_duration_minutes: 45,
   active_title_tier_id: null,
   timezone: "Europe/Paris",
+  locale: null,
   created_at: "2026-05-08T10:00:00Z",
   updated_at: "2026-05-08T10:00:00Z",
 }

--- a/src/hooks/useOnboardingResume.test.ts
+++ b/src/hooks/useOnboardingResume.test.ts
@@ -39,6 +39,7 @@ const PROFILE: UserProfile = {
   session_duration_minutes: 45,
   active_title_tier_id: null,
   timezone: "Europe/Paris",
+  locale: null,
   created_at: "2026-05-08T10:00:00Z",
   updated_at: "2026-05-08T10:00:00Z",
 }

--- a/src/hooks/useProfileLocale.test.tsx
+++ b/src/hooks/useProfileLocale.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { act, waitFor } from "@testing-library/react"
+
+import { renderHookWithProviders, mockQueryResult } from "@/test/utils"
+import { authAtom, localeAtom } from "@/store/atoms"
+import type { UserProfile } from "@/types/onboarding"
+import { useUserProfile } from "@/hooks/useUserProfile"
+import {
+  useHydrateLocaleFromProfile,
+  usePersistProfileLocale,
+} from "./useProfileLocale"
+
+const eq = vi.fn()
+const update = vi.fn(() => ({ eq }))
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: vi.fn(() => ({ update })) },
+}))
+
+vi.mock("@/hooks/useUserProfile", () => ({
+  useUserProfile: vi.fn(),
+}))
+
+const profile = (locale: UserProfile["locale"]) =>
+  mockQueryResult({ locale } as UserProfile)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  eq.mockResolvedValue({ error: null })
+  vi.mocked(useUserProfile).mockReturnValue(mockQueryResult(null))
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+describe("usePersistProfileLocale", () => {
+  it("writes the chosen language to the signed-in user's profile", async () => {
+    const { result, store } = renderHookWithProviders(() =>
+      usePersistProfileLocale(),
+    )
+    act(() => {
+      store.set(authAtom, { id: "user-1" } as never)
+    })
+
+    await act(async () => {
+      await result.current("fr")
+    })
+
+    expect(update).toHaveBeenCalledWith({ locale: "fr" })
+    expect(eq).toHaveBeenCalledWith("user_id", "user-1")
+  })
+
+  it("does nothing at all when nobody is signed in", async () => {
+    const { result } = renderHookWithProviders(() => usePersistProfileLocale())
+
+    await act(async () => {
+      await result.current("fr")
+    })
+
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  // The UI is already correct when this runs, so a failure has nothing to
+  // report: surfacing it would be noise about a preference, not a problem.
+  it("stays silent when the write fails", async () => {
+    eq.mockRejectedValue(new Error("network down"))
+    const { result, store } = renderHookWithProviders(() =>
+      usePersistProfileLocale(),
+    )
+    act(() => {
+      store.set(authAtom, { id: "user-1" } as never)
+    })
+
+    await expect(
+      act(async () => {
+        await result.current("fr")
+      }),
+    ).resolves.not.toThrow()
+  })
+})
+
+describe("useHydrateLocaleFromProfile", () => {
+  it("adopts the profile language on a device that has stored nothing", async () => {
+    vi.mocked(useUserProfile).mockReturnValue(profile("fr"))
+
+    const { store } = renderHookWithProviders(() =>
+      useHydrateLocaleFromProfile(),
+    )
+
+    await waitFor(() => {
+      expect(store.get(localeAtom)).toBe("fr")
+    })
+  })
+
+  it("leaves an explicit choice on this device alone", async () => {
+    localStorage.setItem("locale", '"en"')
+    vi.mocked(useUserProfile).mockReturnValue(profile("fr"))
+
+    const { store } = renderHookWithProviders(() =>
+      useHydrateLocaleFromProfile(),
+    )
+
+    await waitFor(() => {
+      expect(store.get(localeAtom)).toBe("en")
+    })
+    expect(localStorage.getItem("locale")).toBe('"en"')
+  })
+
+  // NULL means "never chose", which must not be read as "chose the default".
+  it("does nothing when the profile has no language", async () => {
+    vi.mocked(useUserProfile).mockReturnValue(profile(null))
+
+    renderHookWithProviders(() => useHydrateLocaleFromProfile())
+
+    await waitFor(() => {
+      expect(localStorage.getItem("locale")).toBeNull()
+    })
+  })
+
+  it("stores what it adopted so the next boot needs no round-trip", async () => {
+    vi.mocked(useUserProfile).mockReturnValue(profile("fr"))
+
+    renderHookWithProviders(() => useHydrateLocaleFromProfile())
+
+    await waitFor(() => {
+      expect(localStorage.getItem("locale")).toBe('"fr"')
+    })
+  })
+})

--- a/src/hooks/useProfileLocale.ts
+++ b/src/hooks/useProfileLocale.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect } from "react"
+import { useAtomValue, useSetAtom } from "jotai"
+
+import { supabase } from "@/lib/supabase"
+import {
+  readPersistedLocale,
+  type PersistedLocale,
+} from "@/lib/persistedLocale"
+import { authAtom, localeAtom } from "@/store/atoms"
+import { useUserProfile } from "@/hooks/useUserProfile"
+
+/**
+ * The cross-device half of the **Display Locale** (T152).
+ *
+ * `localStorage` stays authoritative at render: the profile is only readable
+ * once auth has resolved, so consulting it first would flash untranslated
+ * content on every load. The column exists to seed a device that has stored
+ * nothing — and to make server-side senders (emails, MCP) possible later.
+ */
+export function usePersistProfileLocale() {
+  const user = useAtomValue(authAtom)
+
+  return useCallback(
+    async (locale: PersistedLocale) => {
+      if (!user) return
+
+      // Deliberately silent. `localStorage` has already won, so the UI is
+      // correct and only cross-device sync is lost — no toast, no retry. A
+      // language preference is not training data.
+      try {
+        await supabase
+          .from("user_profiles")
+          .update({ locale })
+          .eq("user_id", user.id)
+      } catch {
+        // Same reasoning: a rejected request changes nothing the reader can see.
+      }
+    },
+    [user],
+  )
+}
+
+/**
+ * Adopts the profile's language on a device that has never stored one — the
+ * second install, where the browser would otherwise decide.
+ *
+ * Writing it to storage is the point rather than a side effect: the next boot
+ * then resolves synchronously and skips the one-time flash entirely.
+ */
+export function useHydrateLocaleFromProfile() {
+  const { data: profile } = useUserProfile()
+  const setLocale = useSetAtom(localeAtom)
+  const profileLocale = profile?.locale ?? null
+
+  useEffect(() => {
+    if (!profileLocale) return
+    // An explicit choice made on this device outranks the profile, always.
+    if (readPersistedLocale(window.localStorage)) return
+
+    setLocale(profileLocale)
+  }, [profileLocale, setLocale])
+}

--- a/src/lib/persistedLocale.test.ts
+++ b/src/lib/persistedLocale.test.ts
@@ -1,8 +1,43 @@
 import { afterEach, describe, expect, it } from "vitest"
-import { readPersistedLocale } from "./persistedLocale"
+import {
+  detectLocale,
+  normalizeLocale,
+  readPersistedLocale,
+} from "./persistedLocale"
 
 afterEach(() => {
   localStorage.clear()
+})
+
+describe("normalizeLocale", () => {
+  // `user_profiles.locale` has a CHECK on ('en','fr'): writing the raw
+  // `i18n.language` would be rejected for every browser that reports a region.
+  it.each(["en-US", "en-GB", "EN"])("strips the region from %s", (tag) => {
+    expect(normalizeLocale(tag)).toBe("en")
+  })
+
+  it("keeps a bare supported tag", () => {
+    expect(normalizeLocale("fr")).toBe("fr")
+  })
+
+  it.each(["es", "de-DE", "", null, undefined])(
+    "returns null for %s",
+    (tag) => {
+      expect(normalizeLocale(tag)).toBeNull()
+    },
+  )
+})
+
+describe("detectLocale", () => {
+  it("follows the browser when it speaks a supported language", () => {
+    expect(detectLocale("fr-CA")).toBe("fr")
+  })
+
+  // Matches `fallbackLng` in i18n.ts. The previous default was French, which
+  // contradicted it.
+  it("falls back to English, not French, for an unsupported language", () => {
+    expect(detectLocale("de-DE")).toBe("en")
+  })
 })
 
 describe("readPersistedLocale", () => {

--- a/src/lib/persistedLocale.ts
+++ b/src/lib/persistedLocale.ts
@@ -14,6 +14,31 @@ const SUPPORTED = new Set(["en", "fr"])
 
 export type PersistedLocale = "en" | "fr"
 
+/**
+ * Maps a BCP-47 language tag onto a supported locale, or `null`.
+ *
+ * Needed wherever a tag meets a narrower type: `i18n.language` carries a region
+ * ("en-US") when it comes from the browser detector, and `user_profiles.locale`
+ * has a CHECK constraint that only accepts the base subtag.
+ */
+export function normalizeLocale(
+  language: string | null | undefined,
+): PersistedLocale | null {
+  const base = language?.toLowerCase().split("-")[0]
+  return base && SUPPORTED.has(base) ? (base as PersistedLocale) : null
+}
+
+/**
+ * The **Display Locale** to use before any stored or profile preference is
+ * known: the browser's language when supported, English otherwise — the same
+ * order i18next's detector applies, so the two can't disagree.
+ */
+export function detectLocale(
+  language: string | null | undefined,
+): PersistedLocale {
+  return normalizeLocale(language) ?? "en"
+}
+
 export function readPersistedLocale(storage: Storage): PersistedLocale | null {
   let raw: string | null
   try {

--- a/src/lib/recommendTemplates.test.ts
+++ b/src/lib/recommendTemplates.test.ts
@@ -32,6 +32,7 @@ function makeProfile(overrides: Partial<UserProfile> = {}): UserProfile {
     session_duration_minutes: 60,
     active_title_tier_id: null,
     timezone: null,
+    locale: null,
     created_at: "",
     updated_at: "",
     ...overrides,

--- a/src/lib/userDisplay.test.ts
+++ b/src/lib/userDisplay.test.ts
@@ -37,6 +37,7 @@ const baseProfile: UserProfile = {
   session_duration_minutes: 60,
   active_title_tier_id: null,
   timezone: null,
+  locale: null,
   created_at: "",
   updated_at: "",
 }

--- a/src/pages/AccountPage.test.tsx
+++ b/src/pages/AccountPage.test.tsx
@@ -40,6 +40,7 @@ const mockProfile: UserProfile = {
   session_duration_minutes: 60,
   active_title_tier_id: null,
   timezone: "Europe/Paris",
+  locale: null,
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
 }

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -4,6 +4,7 @@ import { Dumbbell, Loader2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 import { getResolvedIANATimeZone } from "@/lib/trainingActivityTimezone"
+import { normalizeLocale } from "@/lib/persistedLocale"
 import { useCreateUserProfile } from "@/hooks/useCreateUserProfile"
 import { useGenerateProgram } from "@/hooks/useGenerateProgram"
 import { useTrackEvent } from "@/hooks/useTrackEvent"
@@ -166,6 +167,7 @@ export function OnboardingPage() {
       session_duration_minutes: data.session_duration_minutes,
       active_title_tier_id: null,
       timezone: getResolvedIANATimeZone(),
+      locale: normalizeLocale(i18n.language),
       created_at: "",
       updated_at: "",
     }

--- a/src/store/atoms.test.ts
+++ b/src/store/atoms.test.ts
@@ -265,4 +265,36 @@ describe("localeAtom default", () => {
 
     expect(createStore().get(localeAtom)).toBe("fr")
   })
+
+  // A bare "fr" predates jotai's JSON encoding but is a preference the user
+  // really expressed; jotai's default storage would read it as corrupt and use
+  // the detected default instead, silently flipping them to English.
+  it("honours a legacy raw value written by an older version", async () => {
+    vi.resetModules()
+    vi.stubGlobal("navigator", { language: "en-US" })
+    localStorage.setItem("locale", "fr")
+    const { localeAtom } = await import("./atoms")
+
+    expect(createStore().get(localeAtom)).toBe("fr")
+  })
+
+  it("upgrades the encoding as soon as the value is written", async () => {
+    vi.resetModules()
+    vi.stubGlobal("navigator", { language: "en-US" })
+    localStorage.setItem("locale", "fr")
+    const { localeAtom } = await import("./atoms")
+
+    createStore().set(localeAtom, "fr")
+
+    expect(localStorage.getItem("locale")).toBe('"fr"')
+  })
+
+  it("ignores an unsupported stored value and detects instead", async () => {
+    vi.resetModules()
+    vi.stubGlobal("navigator", { language: "fr-FR" })
+    localStorage.setItem("locale", '"es"')
+    const { localeAtom } = await import("./atoms")
+
+    expect(createStore().get(localeAtom)).toBe("fr")
+  })
 })

--- a/src/store/atoms.test.ts
+++ b/src/store/atoms.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach } from "vitest"
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest"
 import { createStore } from "jotai"
 import {
   sessionAtom,
@@ -224,5 +224,45 @@ describe("session PR atoms persist across reloads (regression #291)", () => {
     store.set(prFlagsAtom, {})
 
     expect(localStorage.getItem("prFlags")).toBe(JSON.stringify({}))
+  })
+})
+
+describe("localeAtom default", () => {
+  async function localeFor(language: string) {
+    localStorage.clear()
+    vi.resetModules()
+    vi.stubGlobal("navigator", { language })
+    const { localeAtom } = await import("./atoms")
+    return createStore().get(localeAtom)
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  // The atom used to default to "fr" whenever storage was empty, and the
+  // SideDrawer effect pushes that value onto i18n — so a fresh device with an
+  // English browser switched itself to French the moment the shell mounted,
+  // which is the very complaint that opened this epic (#415).
+  it("follows an English browser on a device that has stored nothing", async () => {
+    await expect(localeFor("en-US")).resolves.toBe("en")
+  })
+
+  it("follows a French browser just the same", async () => {
+    await expect(localeFor("fr-FR")).resolves.toBe("fr")
+  })
+
+  it("lands on English for a language the app does not speak", async () => {
+    await expect(localeFor("de-DE")).resolves.toBe("en")
+  })
+
+  it("still lets a stored choice win over the browser", async () => {
+    vi.resetModules()
+    vi.stubGlobal("navigator", { language: "en-US" })
+    localStorage.setItem("locale", '"fr"')
+    const { localeAtom } = await import("./atoms")
+
+    expect(createStore().get(localeAtom)).toBe("fr")
   })
 })

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -1,6 +1,10 @@
 import { atom } from "jotai"
 import { atomWithStorage } from "jotai/utils"
-import { detectLocale, type PersistedLocale } from "@/lib/persistedLocale"
+import {
+  detectLocale,
+  readPersistedLocale,
+  type PersistedLocale,
+} from "@/lib/persistedLocale"
 import type { User } from "@/types/auth"
 import type { SessionSetRow } from "@/lib/sessionSetRow"
 import type { UnlockedAchievement } from "@/types/achievements"
@@ -131,10 +135,48 @@ export const installPromptStateAtom = atomWithStorage<{ dismissed: boolean }>(
  * onto i18n, a fresh device with an English browser switched itself to French
  * as soon as the shell mounted.
  */
+/**
+ * Two encodings have always coexisted under `localStorage["locale"]`: jotai
+ * writes `'"fr"'`, while older versions and DevTools wrote a bare `fr`. Jotai's
+ * default JSON storage reads the bare form as corrupt and falls back to its
+ * initial value, which would drop a preference a user really had set.
+ *
+ * Decoding through `readPersistedLocale` — the same reader i18n boot uses —
+ * means the atom and i18next cannot disagree about a stored choice, whichever
+ * of them happens to be imported first.
+ */
+const localeStorage = {
+  getItem: (_key: string, initialValue: PersistedLocale): PersistedLocale =>
+    (typeof window === "undefined"
+      ? null
+      : readPersistedLocale(window.localStorage)) ?? initialValue,
+
+  setItem: (key: string, value: PersistedLocale): void =>
+    window.localStorage.setItem(key, JSON.stringify(value)),
+
+  removeItem: (key: string): void => window.localStorage.removeItem(key),
+
+  // Keeps the language in step across tabs, which the default storage did too.
+  subscribe: (
+    key: string,
+    callback: (value: PersistedLocale) => void,
+    initialValue: PersistedLocale,
+  ) => {
+    if (typeof window === "undefined") return undefined
+
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== key) return
+      callback(readPersistedLocale(window.localStorage) ?? initialValue)
+    }
+    window.addEventListener("storage", onStorage)
+    return () => window.removeEventListener("storage", onStorage)
+  },
+}
+
 export const localeAtom = atomWithStorage<PersistedLocale>(
   "locale",
   detectLocale(typeof navigator === "undefined" ? null : navigator.language),
-  undefined,
+  localeStorage,
   // `getOnInit`, like `sessionAtom`: this value decides the language of the
   // first paint, so it has to be the stored choice from the very first read
   // rather than a default that a later mount corrects.

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -1,5 +1,6 @@
 import { atom } from "jotai"
 import { atomWithStorage } from "jotai/utils"
+import { detectLocale, type PersistedLocale } from "@/lib/persistedLocale"
 import type { User } from "@/types/auth"
 import type { SessionSetRow } from "@/lib/sessionSetRow"
 import type { UnlockedAchievement } from "@/types/achievements"
@@ -119,7 +120,26 @@ export const installPromptStateAtom = atomWithStorage<{ dismissed: boolean }>(
   { dismissed: false },
 )
 
-export const localeAtom = atomWithStorage<"en" | "fr">("locale", "fr")
+/**
+ * **Display Locale**, in precedence order: this stored value (an explicit
+ * choice, and the only one that survives a reload synchronously), then
+ * `user_profiles.locale` (which seeds a device that has never stored one), then
+ * the browser, then English.
+ *
+ * The default is *detected* rather than hardcoded on purpose. It used to be
+ * "fr" while `fallbackLng` was "en", and since `SideDrawer` pushes this atom
+ * onto i18n, a fresh device with an English browser switched itself to French
+ * as soon as the shell mounted.
+ */
+export const localeAtom = atomWithStorage<PersistedLocale>(
+  "locale",
+  detectLocale(typeof navigator === "undefined" ? null : navigator.language),
+  undefined,
+  // `getOnInit`, like `sessionAtom`: this value decides the language of the
+  // first paint, so it has to be the stored choice from the very first read
+  // rather than a default that a later mount corrects.
+  { getOnInit: true },
+)
 
 export const weightUnitAtom = atomWithStorage<"kg" | "lbs">("weightUnit", "kg")
 

--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -1,3 +1,4 @@
+import type { PersistedLocale } from "@/lib/persistedLocale"
 import type { Exercise } from "./database"
 
 export type UserGoal = "strength" | "hypertrophy" | "endurance" | "general_fitness"
@@ -21,6 +22,8 @@ export interface UserProfile {
   session_duration_minutes: number
   active_title_tier_id: string | null
   timezone: string | null
+  /** `null` = never chose a language. `localStorage` still wins at render. */
+  locale: PersistedLocale | null
   created_at: string
   updated_at: string
 }

--- a/supabase/migrations/20260731180000_add_locale_to_user_profiles.sql
+++ b/supabase/migrations/20260731180000_add_locale_to_user_profiles.sql
@@ -1,0 +1,13 @@
+-- Seeds the Display Locale on a device that has never stored one (T152, #422).
+--
+-- Nullable with no default on purpose: NULL means "never expressed a choice",
+-- which is not the same as "chose French". A DEFAULT 'fr' would erase that
+-- distinction and flip English speakers who never asked for anything.
+--
+-- Inline CHECK mirrors `gender`; vocabulary matches `embedded_agent_threads.locale`.
+-- No RLS change needed — "Users manage own profile" is FOR ALL.
+ALTER TABLE user_profiles
+  ADD COLUMN locale text CHECK (locale IN ('en', 'fr'));
+
+COMMENT ON COLUMN user_profiles.locale IS
+  'Display Locale preference. NULL = never chosen. localStorage stays authoritative at render; this only seeds a new device.';


### PR DESCRIPTION
Part of #422.

## What

Adds a nullable `user_profiles.locale` so a second device starts in the user's language instead of the browser's. Today the language lives only in `localStorage`: install the PWA on a new phone and you're back to whatever the browser reports.

## The bug hiding behind "reconcile the two defaults"

The ticket asked to reconcile `localeAtom`'s default (`"fr"`) with `fallbackLng` (`"en"`), which reads like housekeeping. It isn't. `localeAtom` returns its default whenever storage is empty, and `SideDrawer` pushes that value onto i18n:

```ts
useEffect(() => {
  if (i18n.language !== locale) i18n.changeLanguage(locale)
}, [locale, i18n])
```

So on a fresh device with an English browser, i18next correctly detected `en` — and then the shell switched the app to French as soon as it mounted. That is the exact complaint that opened this epic (#415), caused by our own default rather than by missing translations. There is a test for it now:

```
AssertionError: expected 'fr' to be 'en'
```

The atom now *detects* its default instead of hardcoding one, and reads storage with `getOnInit: true`, like `sessionAtom` and `prFlagsAtom` already do — its value decides the language of the first paint, so it can't afford to be a default that a later mount corrects.

## Precedence, stated once

1. an explicit choice in `localStorage` — the only one that resolves synchronously, so it always wins at render
2. `user_profiles.locale` — seeds a device that has stored nothing, applied once auth resolves
3. the browser, when it speaks a supported language
4. English

Reading the profile any earlier would flash untranslated content on every load, since it isn't readable until auth resolves. Adopting it writes to storage, which is the point rather than a side effect: the next boot then resolves synchronously with no flash at all.

## Scope

- **Migration** — nullable, no default. `NULL` means "never expressed a choice", which is *not* "chose French"; a `DEFAULT 'fr'` would erase that distinction and flip English speakers who never asked for anything. Inline CHECK mirrors `gender`.
- **Write** — `SideDrawer` syncs after the local switch, never before, and fails silently by design: `localStorage` has already won, the UI is correct, and only cross-device sync is lost. No toast, no retry — a language preference is not training data.
- **Seed** — onboarding captures the language exactly like `timezone`, normalized. `i18n.language` can be `"en-US"`, which the CHECK rejects, and that would have failed the whole profile upsert rather than just the language.
- **Read** — `useHydrateLocaleFromProfile` in `AppShell`. No extra request: `useUserProfile` is already fetched for `SideDrawer` and react-query dedupes the key.

## Out of scope

Any server-side consumption (emails, MCP). The column is write-mostly in v1 — it exists so those become possible, not to deliver them.

## Deploying — migration first, then merge

**This PR must not be merged before the migration is applied to production.**

An earlier version of this description claimed merging first was safe because the profile write fails silently. That was wrong, and Copilot caught it: the `SideDrawer` sync does swallow its errors, but the onboarding `upsert` in `useCreateUserProfile` **throws**. With the column missing, Postgres returns `42703 undefined_column` and profile creation fails for every new user — onboarding, not just the language.

Order:

1. `supabase db push` (or apply `20260731180000_add_locale_to_user_profiles.sql` in the dashboard)
2. merge this PR, which deploys

Adding a `42703` fallback was considered and rejected: permanent defensive code to cover a one-time deploy window is worse than sequencing the deploy correctly. Nothing here is time-sensitive.

## Tests

- The regression above, plus browser detection and stored-choice precedence on `localeAtom`.
- `normalizeLocale` / `detectLocale`, including the regional tags the CHECK would reject.
- Hydration bracketed from both sides: storage empty → the profile wins; storage set → the profile is ignored and left alone; `NULL` → nothing happens.
- Language switch writes to both `localStorage` and the profile, and stays switched when the write fails.
- Onboarding seeds the current language, normalized.
- 1892 tests pass, `tsc -b` and lint clean.

Made with [Cursor](https://cursor.com)
