### PR TITLE
feat(i18n): display-time resolution for English exercise instructions (T156)

### DIFF
--- a/.cursor/rules/build-sandbox-caveat.mdc
+++ b/.cursor/rules/build-sandbox-caveat.mdc
@@ -37,6 +37,23 @@ npx tsc --noEmit
 npx tsc -p tsconfig.app.json --noEmit
 ```
 
+## `tsconfig.app.json` does not cover `scripts/`
+
+Same trap, narrower. `tsconfig.app.json` is `include: ["src"]` and
+`tsconfig.node.json` is `include: ["vite.config.ts"]`, so **nothing under
+`scripts/` is type-checked by any project in the solution.** A broken script
+gets a green `tsc -b`.
+
+Type-check a script standalone, with the `tsconfig.node.json` flags spelled out:
+
+```bash
+npx tsc --noEmit --ignoreConfig --strict --target es2023 --lib es2023 \
+  --module esnext --moduleResolution bundler --resolveJsonModule \
+  --verbatimModuleSyntax --moduleDetection force --erasableSyntaxOnly \
+  --noUnusedLocals --noUnusedParameters --types node --skipLibCheck \
+  scripts/<file>.ts
+```
+
 ## Run vitest with the Supabase env stripped
 
 CI has no `.env`, so `src/lib/supabase.ts` throws `supabaseUrl is required.`

--- a/docs/Epic_Brief_—_English_Exercise_Instructions_#417.md
+++ b/docs/Epic_Brief_—_English_Exercise_Instructions_#417.md
@@ -1,0 +1,99 @@
+# Epic Brief — English Exercise Instructions (#417)
+
+## Summary
+
+Rendre le **corps des consignes d'exercice** lisible en anglais, alors que le panneau de détail est aujourd'hui à moitié traduit : les titres de section (« Setup », « Movement ») passent par i18next, le contenu reste français sur les **372 lignes** du catalogue. Le stockage mire le précédent `name_en` — une colonne `instructions_en` nullable — et la résolution se fait **à l'affichage**, conformément à l'**ADR 0010**, en réemployant la forme exacte de `resolveExerciseName` (`file:src/lib/catalogLabels.ts`). Le point central de l'epic n'est pas la traduction : elle est mesurée à **0,40 $ et neuf minutes** pour tout le catalogue. Le coût réel est la **relecture humaine de 4 140 phrases**, qui exige un relecteur trilingue français / anglais / coaching. Toute la conception vise donc à réduire ce que doivent lire des yeux humains : couverture partielle érigée en état d'arrivée valide grâce au repli, priorisation par usage réel mesuré, et **contre-relecture par un second modèle** qui ordonne la file au lieu de la certifier. Invariant de sécurité : une ligne signalée et non validée **reste en français**, parce qu'une consigne fausse en anglais a l'air autorisée là où le français signalait « ce n'est pas pour toi ».
+
+---
+
+## Context & Problem
+
+**Who is affected:** Les utilisateurs anglophones, arrivés majoritairement par **MCP**. Signalé de l'extérieur par un contributeur sur [#417](https://github.com/PierreTsia/workout-app/issues/417), capture d'écran à l'appui, en même temps que [#415](https://github.com/PierreTsia/workout-app/issues/415) dont l'epic est livré.
+
+**Current state:**
+- Les **372 lignes** du catalogue ont des instructions, toutes en français, dans un JSONB à quatre clés (`setup`, `movement`, `breathing`, `common_mistakes`) — **4 140 phrases**, **299 914 caractères**, 806 caractères par exercice en moyenne (mesuré).
+- Le panneau `file:src/components/exercise/ExerciseInstructionsPanel.tsx` traduit ses **titres** de section par `t()` et rend le **corps** brut depuis `exercise.instructions`. Le mixte est donc dans un même écran.
+- Aucune colonne `instructions_en`. `Exercise.instructions` est typé `ExerciseInstructions | null` dans `file:src/types/database.ts`.
+- Depuis la livraison de #415, l'interface est **intégralement anglaise** pour un anglophone — noms, muscles, matériel. Les consignes sont le **dernier îlot français**, et il est plus voyant qu'avant précisément parce que tout le reste a été traduit.
+- Le pipeline qui a produit le français existe (`file:scripts/enrich-instructions.ts`, Groq `llama-3.3-70b`), mais son prompt est **français en dur** et il **génère** au lieu de traduire. Il n'est pas réemployable tel quel.
+- L'usage est **fortement concentré** : sur 372 lignes de catalogue, **141 seulement ont déjà été loguées**. Les 60 premiers exercices portent **76,7 %** des séries enregistrées, les 40 premiers **61,8 %**, les 20 premiers **41,1 %**. **231 exercices n'ont jamais été logués par personne.**
+- Une surface de relecture admin existe déjà (`file:src/pages/AdminReviewPage.tsx`), mais son `reviewed_at` est **partagé** avec l'enrichissement d'images : valider une traduction dessus sortirait l'exercice de la file de revue de contenu sans que personne ne l'ait relu. Et chaque outil admin est une **route sœur** (`/admin/review`, `/admin/enrichment`, `/admin/feedback`), jamais un onglet.
+
+**Ce que le spike a établi (mesuré, pas supposé) :**
+- **Gemini 2.5 Flash** sur un échantillon aléatoire de 30 lignes tiré à la graine, dont la moyenne colle au catalogue à +1,7 % : **29/30 réellement propres**, un seul défaut de contenu réel (« largeur des épaules » devenu *hip-width*), **zéro inversion de mode** sur 107 entrées d'erreurs courantes, **98 %** de cohérence en deuxième personne.
+- **DeepL est écarté**, glossaire ou non : 25 inversions de mode sur 42 entrées — un impératif sous un titre « Common mistakes » ordonne de commettre la faute — plus « décliné » traduit par *incline* sur un exercice nommé *Decline Bench Leg Raise*. Son glossaire est aveugle au contexte et a même inséré des caractères qu'aucun token source ne justifiait.
+- Le filet automatique **sur-signale** : 2 alertes sur 3 étaient des faux positifs (« pupitre Larry Scott » est bien un *preacher bench* ; « Lower back to 90° » où *lower* est un verbe).
+
+**Pain points:**
+| Pain | Impact |
+|---|---|
+| Corps des consignes FR imposé | Un anglophone lit un titre « Setup » suivi de « Allongez-vous sur le banc… » dans le même panneau |
+| Dernier îlot après #415 | Le contraste est maximal : tout l'écran est anglais sauf la seule zone de coaching réel |
+| Coût réel = relecture, pas génération | 4 140 phrases à relire contre 0,40 $ de traduction — se tromper de levier condamne l'epic |
+| Relecteur unique non substituable | Valider « largeur des épaules » exige FR + EN + coaching ; impossible à sous-traiter à un traducteur |
+| Consigne fausse en anglais | Elle a l'air autorisée, là où le français signalait implicitement « ce n'est pas pour toi » |
+| Filet bruyant | Un garde-fou à 2 faux positifs sur 3 consomme le temps de relecture qu'il prétend économiser |
+| Relecture en un bloc | Une tâche qui exige plusieurs heures d'affilée ne se termine jamais |
+
+---
+
+## User Stories
+
+1. As an **English-speaking user**, I want the **instruction body in English** on the exercise details panel when my Display Locale is EN, so that the panel stops mixing an English heading with French coaching text.
+2. As an **English-speaking user** viewing an exercise **not yet translated**, I want the French instructions shown rather than an empty panel, so that partial coverage is invisible rather than broken.
+3. As an **English-speaking user** viewing an exercise whose translation was **flagged and not yet human-approved**, I want the **French** shown, so that I am never handed a suspect form cue that looks authoritative.
+4. As a **French-speaking user**, I want **nothing to change** in what I read, so that translating for others is not a regression for the default audience.
+5. As the **reviewer**, I want a queue that puts **flagged rows first, then unreviewed rows ordered by real usage**, so that my scarce attention lands on the exercises people actually perform.
+6. As the **reviewer**, I want French and English shown **sentence-aligned side by side**, with the cross-checker's objection attached to the offending sentence, so that I can judge without reconstructing the mapping myself.
+7. As the **reviewer**, I want to **approve, edit, or revert to French** per row from the keyboard, so that a pass is fast and resumable in ten-minute chunks.
+8. As the **reviewer**, I want a button that **copies a review request** — source, translation, objection, and the house style rules — so that I can adjudicate a hard case with an agent instead of alone.
+9. As the **reviewer**, I want to **paste a corrected JSON back**, shape-validated and diffed before saving, so that a malformed answer cannot silently corrupt a row.
+10. As the **reviewer**, I want my decision recorded with a timestamp, so that a second pass never re-presents what I already approved.
+11. As a **maintainer**, I want the backfill script to be **idempotent** and fill only `NULL` rows, so that re-running it is safe by construction.
+12. As a **maintainer**, I want each row to record **which model and prompt version** produced it, so that a future re-run is diffable rather than a mystery.
+13. As a **maintainer**, I want to run the backfill **in waves** — never-logged rows first, then the top N by usage, or explicit ids — so that I control blast radius and get feedback on a low-stakes lot.
+14. As a **maintainer**, I want a **second model to cross-check each sentence pair** for semantic equivalence, so that measurement changes like "shoulder-width → hip-width" are caught, which regex cannot see.
+15. As a **maintainer**, I want the gate's **known false positives fixed** before it orders the queue, so that it does not burn the reviewer's trust on its first use.
+16. As a **maintainer**, I want the resolution rule implemented **once** and consumed by every surface, so that it cannot drift the way the Catalog Snapshot write paths did.
+17. As a **maintainer**, I want **partial coverage to be a supported state**, so that an unfinished backfill is a status, not an incident.
+18. As an **admin creating a catalog exercise** with French instructions only, I want it displayed as typed in both locales, so that unfinished catalog rows degrade gracefully.
+
+### Success measures
+| Story # | Measure |
+|---|---|
+| 1 | **0 phrase française** rendue dans le corps pour `locale = en` sur une ligne au statut `approved` ou `clean` |
+| 2, 3, 18 | Matrice de repli couverte par test : `instructions_en` nul, statut `flagged`, statut `clean`, statut `approved` |
+| 4 | **0 changement** de ce qui est rendu pour `locale = fr`, quel que soit le statut |
+| 5 | La file place les `flagged` avant les `clean`, et trie les `clean` par nombre de séries loguées décroissant |
+| 11 | Deux exécutions consécutives du script produisent **0 écriture** sur la seconde |
+| 14 | Le défaut « largeur des épaules → hip-width » du spike est **attrapé** par la contre-relecture sur un test de régression |
+| 15 | Les deux faux positifs connus (synonyme de matériel, verbe *lower*) ne se déclenchent plus |
+| — | **≥ 76 %** de l'exposition réelle (séries loguées) couverte par des lignes `approved` à la clôture de l'epic |
+
+---
+
+## Scope
+
+**In scope:**
+1. Colonne `instructions_en` + statut + horodatage de relecture + modèle, et la résolution à l'affichage câblée dans le panneau de détail.
+2. Script de backfill par vagues : traduction Gemini 2.5 Flash, filet automatique corrigé, **contre-relecture par un second modèle**, écriture du statut.
+3. Route admin sœur `/admin/translations` : file priorisée, comparaison alignée, validation clavier, puis — livré séparément — presse-papier de demande d'arbitrage et collage validé du correctif.
+4. Backfill effectif sur **tout le catalogue**, en vagues : longue traîne d'abord, puis les 60 premiers par usage relus à la main.
+
+**Out of scope:**
+- **MCP** (`get_exercise_details` et consorts) : l'issue le mentionne, mais la locale côté MCP est le chantier de [#422](https://github.com/PierreTsia/workout-app/issues/422) v1.5, conditionné à une mesure de production. Aucune raison de le rouvrir ici.
+- Retraduction ou correction du **français** existant, même quand la contre-relecture révèle que la source est fautive : signalé, pas corrigé.
+- Noms et descriptions de **templates de programme** ([#58](https://github.com/PierreTsia/workout-app/issues/58)) — même forme de problème, epic distinct.
+- Toute mémoire de traduction, framework générique d'i18n de contenu, ou éditeur bilingue.
+- Restructuration en `instructions: { fr, en }` : casse le précédent `name_en` et impose une migration de données pour aucun gain.
+- Relecture humaine exhaustive des 372 lignes.
+
+---
+
+## Success Criteria
+
+- **Numérique :** ≥ 76 % de l'exposition réelle mesurée en séries loguées est servie par des instructions anglaises **relues par un humain**.
+- **Numérique :** 0 ligne au statut `flagged` n'est jamais rendue en anglais.
+- **Numérique :** le script est idempotent — seconde exécution à 0 écriture.
+- **Qualitatif :** un anglophone ouvrant le détail d'un exercice courant ne voit plus une seule phrase française, et un francophone ne voit aucun changement.
+- **Qualitatif :** un backfill inachevé est un état documenté et sans incident, pas une dette bloquante.

--- a/docs/Epic_Brief_—_English_Exercise_Instructions_#417.md
+++ b/docs/Epic_Brief_—_English_Exercise_Instructions_#417.md
@@ -81,7 +81,7 @@ Rendre le **corps des consignes d'exercice** lisible en anglais, alors que le pa
 4. Backfill effectif sur **tout le catalogue**, en vagues : longue traîne d'abord, puis les 60 premiers par usage relus à la main.
 
 **Out of scope:**
-- **MCP** (`get_exercise_details` et consorts) : l'issue le mentionne, mais la locale côté MCP est le chantier de [#422](https://github.com/PierreTsia/workout-app/issues/422) v1.5, conditionné à une mesure de production. Aucune raison de le rouvrir ici.
+- **MCP.** `file:supabase/functions/mcp/tools/getExerciseDetails.ts` rend `ex.instructions` sous des en-têtes anglais **en dur** — exactement le même défaut de panneau à moitié traduit que l'app, sur la surface où les anglophones arrivent réellement. Il reste pourtant hors périmètre, pour deux raisons de fond : le serveur MCP **ne connaît pas la locale du lecteur** (l'auth résout le token et ne lit jamais le profil), et renvoyer les deux langues doublerait une réponse d'outil de 806 caractères par exercice — ce qui est gratuit pour un nom, pas pour un bloc de consignes. Le sujet appartient donc au chantier de locale MCP de [#422](https://github.com/PierreTsia/workout-app/issues/422) v1.5, conditionné à la mesure de T154. Le noter ici évite qu'on le redécouvre comme un oubli.
 - Retraduction ou correction du **français** existant, même quand la contre-relecture révèle que la source est fautive : signalé, pas corrigé.
 - Noms et descriptions de **templates de programme** ([#58](https://github.com/PierreTsia/workout-app/issues/58)) — même forme de problème, epic distinct.
 - Toute mémoire de traduction, framework générique d'i18n de contenu, ou éditeur bilingue.

--- a/docs/T156_—_Display-time_instruction_resolution.md
+++ b/docs/T156_—_Display-time_instruction_resolution.md
@@ -1,0 +1,118 @@
+# T156 — Display-time instruction resolution
+
+## Goal
+
+Poser le schéma et la règle de résolution qui rendent les consignes d'exercice affichables en anglais, et basculer les trois surfaces qui les rendent. Sans une seule ligne d'anglais en base, ce ticket est un **no-op visible en production** : c'est exactement sa valeur, il permet de vérifier la migration et le résolveur indépendamment du contenu.
+
+Le résolveur ne choisit pas seulement une langue, il rend `null` quand il n'y a rien à afficher — ce qui absorbe le bloc `hasInstructions` aujourd'hui **dupliqué dans trois composants**.
+
+Couvre les stories 1, 2, 3, 4, 16, 17 et 18 de l'Epic Brief.
+
+## Mode
+
+**AFK** — la matrice de repli est mécanique à vérifier, et aucune décision d'architecture ne reste ouverte.
+
+## Slice
+
+migration + CHECK → `src/types/database.ts` → `resolveExerciseInstructions` → `useCatalogLabels` → 3 surfaces → `FULL_EXERCISE_SELECT` → vitest
+
+## Dependencies
+
+Aucune.
+
+## Scope
+
+### Migration
+
+```sql
+-- supabase/migrations/<timestamp>_add_english_instructions.sql
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en jsonb;
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en_status text;
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en_reviewed_at timestamptz;
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en_audit jsonb;
+
+ALTER TABLE exercises
+  ADD CONSTRAINT exercises_instructions_en_status_chk
+  CHECK (instructions_en_status IN ('clean', 'flagged', 'approved'));
+```
+
+Nullable sans défaut : `NULL` signifie « jamais traduit », distinct de « traduit et propre ». Aucun changement de RLS — les nouvelles colonnes héritent des policies de `file:supabase/migrations/20260313140002_exercises_rls.sql`.
+
+### Types
+
+`file:src/types/database.ts` est **maintenu à la main**, aucun codegen. Étendre `Exercise` avec les quatre champs, en réemployant `ExerciseInstructions` tel quel pour `instructions_en` — la forme est identique, pas de variante de type.
+
+Ajouter aussi le type `TranslationAudit`, **bien que rien ici ne le consomme** : T157 l'écrit et T158 le lit, et ces deux tickets sont censés tourner en parallèle. Le contrat descend donc au niveau commun.
+
+| Champ | Type |
+|---|---|
+| `model` | `string` |
+| `prompt_version` | `number` |
+| `translated_at` | `string` |
+| `checker_model` | `string \| null` |
+| `gate_flags` | `string[]` |
+| `objections` | `{ section: keyof ExerciseInstructions; index: number; verdict: string; note: string }[]` |
+
+### Résolveur
+
+`resolveExerciseInstructions(source, locale)` dans `file:src/lib/catalogLabels.ts`, à côté de `resolveExerciseName` et sous les mêmes contraintes : aucun import React ni i18next, testable dans les deux locales sans rendu. Le test de pureté en `?raw` de `file:src/lib/catalogLabels.test.ts` doit continuer de passer.
+
+Règle : l'anglais est retenu si **et seulement si** `isEnglish(locale)`, statut ∈ {`clean`, `approved`}, et **parité de présence** des sections — toute section non vide en français doit être non vide en anglais. Sinon, repli **en bloc** sur le français. Jamais un panneau mi-anglais mi-français : c'est le défaut que l'issue a rapporté.
+
+Le retour est `ExerciseInstructions | null`, `null` signifiant « rien à afficher ». Tout statut nul, inconnu, ou absent de la projection **échoue fermé** vers le français.
+
+`useCatalogLabels` (`file:src/hooks/useCatalogLabels.ts`) gagne `exerciseInstructions(row)`, lié à `i18n.language` comme les résolveurs existants. Aucune nouvelle source de locale.
+
+### Surfaces
+
+| Fichier | Changement |
+|---|---|
+| `file:src/components/exercise/ExerciseInstructionsPanel.tsx` | Supprimer le bloc `hasInstructions` (29-34) au profit du résolveur |
+| `file:src/components/exercise/ExerciseInfoDialog.tsx` | Idem (27-32) ; utilise déjà `useCatalogLabels` pour le titre |
+| `file:src/components/generator/ExerciseDetailSheet.tsx` | Idem ; `const ins = exercise.instructions` (33) devient le bloc résolu |
+
+`file:src/components/exercise/InstructionSection.tsx` reste inchangé : il reçoit déjà des `string[]` et ses titres passent par i18next.
+
+### Projection
+
+`file:src/lib/exerciseSelects.ts` — `FULL_EXERCISE_SELECT` gagne `instructions_en` et `instructions_en_status`. **Pas** l'audit, qui ne sert qu'à l'écran de relecture et voyagera par le RPC de T158.
+
+C'est une nécessité, pas un confort : `file:src/hooks/useWorkoutExercises.ts` préchauffe le cache `["exercise", id]` depuis cette projection, et `ExerciseInstructionsPanel` lit ce cache sans refetch. Une projection incomplète ferait diverger le même panneau selon qu'on l'ouvre depuis une séance ou depuis la bibliothèque. `LABEL_EXERCISE_SELECT` reste intouchée, elle ne porte aucune instruction.
+
+### Garde-fous
+
+**Test d'architecture** — un grep sur `src/components/**` interdisant toute lecture de `.instructions` hors du résolveur, sur le modèle du test de pureté en `?raw` déjà pratiqué. C'est le garde-fou du mode d'échec que l'ADR 0010 documente : une surface qui oublie le helper rend du français en silence, invisible pour un relecteur francophone.
+
+**Test d'épinglage de `search_exercises`** — `file:supabase/migrations/20260326120000_search_exercises.sql` est `RETURNS SETOF exercises` avec un `SELECT e.*`, et c'est **la seule raison** pour laquelle `SwapExerciseSheet` verra les traductions : c'est la seule surface qui passe une ligne paginée sans refetch par id. Un test doit affirmer que les nouvelles colonnes circulent par ce RPC, pour qu'un futur passage à une projection explicite casse un test au lieu de casser la fonctionnalité en silence.
+
+### Tests
+
+- Matrice de repli du résolveur : `instructions_en` nul, statut nul, `flagged`, `clean`, `approved`, statut inconnu, parité de sections violée, blocs vides des deux côtés.
+- Les deux locales sur au moins une des trois surfaces, via `renderWithProviders(..., { locale })`.
+- Le français rendu à l'identique quel que soit le statut.
+
+## Out of Scope
+
+- Toute production de traduction : c'est T157.
+- Toute surface admin : c'est T158.
+- La colonne `has_instructions` de `file:src/components/admin/exercises-table/columns.tsx` reste assise sur le **français** — c'est un indicateur de contenu source, pas d'affichage.
+- Le sur-poids préexistant de `search_exercises`, qui renvoie `e.*` et transporte donc des instructions qu'aucune liste n'affiche. Dette antérieure, à sortir en issue.
+
+## Acceptance Criteria
+
+- [ ] La migration passe en local et le `CHECK` rejette un statut hors vocabulaire.
+- [ ] La matrice de repli est couverte en test, y compris statut inconnu et parité de sections violée.
+- [ ] Le test de pureté de `catalogLabels` passe toujours (aucun import React ni i18next).
+- [ ] Un test d'architecture échoue si un composant lit `.instructions` hors du résolveur.
+- [ ] Un test affirme que `search_exercises` renvoie `instructions_en` et son statut.
+- [ ] Aucun des trois composants ne contient plus son propre bloc `hasInstructions`.
+- [ ] En `fr`, l'affichage est identique à avant, quel que soit le statut de la ligne.
+- [ ] **Démo** : sur une ligne semée à la main en `clean`, l'app en anglais affiche l'anglais ; basculée en `flagged`, elle réaffiche le français sans rechargement de page.
+
+## References
+
+- Epic Brief : `docs/Epic_Brief_—_English_Exercise_Instructions_#417.md`, stories 1, 2, 3, 4, 16, 17, 18
+- Tech Plan : `docs/Tech_Plan_—_English_Exercise_Instructions_#417.md`, § Data Model, § Critical Constraints (cache préchauffé, `SwapExerciseSheet`)
+- ADR 0010 : `docs/adr/0010-localize-catalog-at-display-time.md`
+- Issue [#417](https://github.com/PierreTsia/workout-app/issues/417)
+- `file:src/lib/catalogLabels.ts`, `file:src/lib/exerciseSelects.ts`

--- a/docs/T157_—_Translation_pipeline_and_quality_gate.md
+++ b/docs/T157_—_Translation_pipeline_and_quality_gate.md
@@ -1,0 +1,103 @@
+# T157 — Translation pipeline & quality gate
+
+## Goal
+
+Livrer le pipeline qui traduit les consignes françaises en anglais, les fait contre-relire par un **second modèle d'un autre fournisseur**, et écrit contenu, statut et audit en une seule opération par ligne. Le script est idempotent par construction et s'exécute par vagues, pour que le rayon d'explosion reste choisi.
+
+Le filet qualité est promu depuis les fichiers de spike vers `src/lib/`, où le type-check et Vitest le couvrent — parce que **CI ne type-check pas `scripts/`**, et que le seul code du pipeline qui doive être juste ne peut pas vivre dans l'angle mort.
+
+Couvre les stories 11, 12, 13, 14 et 15 de l'Epic Brief.
+
+## Mode
+
+**AFK** — le modèle, le contre-relecteur, le vocabulaire de statut et l'ordre des vagues sont tranchés dans le Tech Plan. Rien ne reste à décider en vol.
+
+## Slice
+
+`src/lib/instructionQuality.ts` + `instructionPrompt.ts` → CLI `scripts/translate-instructions.ts` → Gemini → Groq → écriture des 4 colonnes → vitest
+
+## Dependencies
+
+T156 (les colonnes et le vocabulaire de statut).
+
+## Scope
+
+### Promotion du filet dans `src/lib`
+
+`file:scripts/spike-checks.ts` devient `src/lib/instructionQuality.ts`, en fonctions **pures** sur une paire (source française, traduction anglaise), sans I/O. Contrôles portés : parité de longueur, nombres perdus, matériel inventé, muscle non traduit, bavure de casse, résidus français, glossaire au niveau de la phrase, mode impératif sous « common mistakes », calques anatomiques, ratio de deuxième personne.
+
+Deux corrections obligatoires, chacune adossée à un test nommé :
+
+| Faux positif mesuré au spike | Correction |
+|---|---|
+| « pupitre Larry Scott » signalé comme matériel inventé alors que *preacher bench* est la traduction juste | Synonymes de matériel reconnus |
+| « Lower back to 90° » signalé comme muscle non traduit, où *lower* est un verbe | Désambiguïsation par position dans la phrase |
+
+Les frontières de mots utilisent des lookarounds Unicode, **pas `\b`**, qui échoue sur `élastique` et `épaules`.
+
+`src/lib/instructionPrompt.ts` porte `buildPrompt()`, `parseInstructions()` et `PROMPT_VERSION`. La dérivation du statut est elle aussi une fonction pure et testée : `deriveStatus(gateFlags, objections, checkerAvailable)`.
+
+### CLI
+
+`scripts/translate-instructions.ts`, env via `file:scripts/load-env.ts`, service role via le patron de `file:scripts/enrichment-config.ts`. Entrée dans `package.json` sur le modèle des autres scripts d'enrichissement.
+
+| Drapeau | Effet |
+|---|---|
+| *(défaut)* | **Dry-run** — traduit, contrôle, affiche, n'écrit rien |
+| `--apply` | Écrit en base |
+| `--unlogged` | Vague longue traîne : les exercices sans aucune série loguée |
+| `--top N` | Les N exercices les plus logués |
+| `--ids a,b,c` | Liste explicite |
+| `--force` | Réécrit une ligne déjà traduite, **sauf `approved`** |
+
+Dry-run par défaut suit `file:scripts/backfill-was-pr.ts` ; `file:scripts/enrich-instructions.ts` écrit sans garde-fou et sert de contre-exemple.
+
+### Traduction et contre-relecture
+
+Gemini 2.5 Flash traduit — mesuré sur un échantillon aléatoire de 30 lignes tiré à la graine : 29/30 propres, zéro inversion de mode sur 107 entrées d'erreurs courantes, 98 % de cohérence en deuxième personne.
+
+Groq `llama-3.3-70b-versatile` contre-relit **paire de phrases par paire de phrases**, et rend un verdict d'équivalence sémantique. Le fournisseur est différent du traducteur exprès : c'est ce qui rend les erreurs non corrélées, et c'est la seule façon d'attraper le défaut réel du spike — « largeur des épaules » rendu *hip-width*, qu'aucune regex ne peut voir.
+
+Séquentiel, une ligne à la fois, avec respect de `Retry-After` — le patron des spikes, pas celui de `enrich-instructions.ts` qui ignore les 429.
+
+### Écriture
+
+Sélection : `instructions IS NOT NULL AND instructions_en IS NULL`, filtrée par la vague. Les quatre colonnes partent en **une seule mise à jour** : contenu, statut dérivé, audit. Jamais d'écriture partielle, jamais un bloc dont la forme n'a pas été validée avant.
+
+Statut dérivé : filet propre **et** aucune objection du contre-relecteur → `clean`. Sinon `flagged`. Contre-relecteur indisponible ou quota épuisé → `flagged`, **jamais** `clean` : un quota mort ne doit pas produire de l'anglais réputé propre.
+
+### Nettoyage
+
+Les cinq fichiers de spike non commités disparaissent dans ce ticket, leur logique étant promue : `spike-checks.ts`, `spike-translate-instructions.ts`, `spike-deepl-instructions.ts`, `spike-gemini-instructions.ts`, `spike-model-comparison.ts`.
+
+### Tests
+
+- `instructionQuality` : les deux régressions nommées, plus un cas par contrôle.
+- `deriveStatus` : filet propre sans objection, filet propre avec objection, filet sale, contre-relecteur absent.
+- `parseInstructions` : JSON valide, JSON entouré de prose, JSON invalide, forme incomplète.
+
+## Out of Scope
+
+- Toute UI : c'est T158 à T160.
+- L'exécution sur le catalogue réel : c'est T161. Ce ticket se démontre sur trois lignes.
+- Toute correction du **français** source, même quand la contre-relecture révèle qu'il est fautif. Signalé dans l'audit, jamais corrigé.
+- Un `tsconfig.scripts.json` pour type-checker les 45 scripts du repo. Trou systémique réel, rayon d'explosion inconnu, chantier séparé.
+
+## Acceptance Criteria
+
+- [ ] « pupitre Larry Scott » et « Lower back to 90° » ne déclenchent plus d'alerte, chacun couvert par un test nommé.
+- [ ] Les frontières de mots survivent aux accents (`élastique`, `épaules`) — test dédié.
+- [ ] Contre-relecteur indisponible → statut `flagged`, jamais `clean`.
+- [ ] Sans `--apply`, aucune écriture en base, vérifié sur une exécution complète.
+- [ ] Deux exécutions consécutives avec `--apply` : **zéro écriture** sur la seconde.
+- [ ] `--force` laisse intactes les lignes `approved`.
+- [ ] Une ligne dont le JSON du modèle est invalide est sautée, ses colonnes restent nulles, et l'exécution suivante la reprend.
+- [ ] Les cinq fichiers de spike ne sont plus dans l'arbre.
+- [ ] **Démo** : `--ids` sur trois exercices avec `--apply`, puis l'app en anglais affiche les trois consignes traduites — et celles passées en `flagged` restent françaises.
+
+## References
+
+- Epic Brief : `docs/Epic_Brief_—_English_Exercise_Instructions_#417.md`, stories 11, 12, 13, 14, 15
+- Tech Plan : `docs/Tech_Plan_—_English_Exercise_Instructions_#417.md`, § Key Decisions (traducteur, contre-relecteur, verdict par défaut), § Failure Mode Analysis
+- Issue [#417](https://github.com/PierreTsia/workout-app/issues/417)
+- Précédents : `file:scripts/enrich-instructions.ts`, `file:scripts/backfill-was-pr.ts`, `file:scripts/load-env.ts`, `file:scripts/enrichment-config.ts`

--- a/docs/T158_—_Translation_review_queue.md
+++ b/docs/T158_—_Translation_review_queue.md
@@ -1,0 +1,77 @@
+# T158 — Translation review queue
+
+## Goal
+
+Livrer la surface qui rend la relecture possible : une file priorisée et une comparaison français / anglais alignée phrase à phrase, avec les objections du contre-relecteur accrochées à la phrase visée. **En lecture seule** — séparer la lecture de l'écriture rend ce ticket utile seul, puisque c'est la surface qui permet de regarder le taux de signalement réel avant d'avoir construit le chemin d'écriture.
+
+La file va sur une **route sœur `/admin/translations`**, pas dans un onglet : chaque outil admin de ce repo est une route, et `/admin/enrichment` a déjà été sorti ainsi pour exactement le même patron de file à une carte.
+
+Couvre les stories 5 et 6 de l'Epic Brief.
+
+## Mode
+
+**AFK** — l'ordre de la file, la projection du RPC et la forme de la carte sont fixés par le Tech Plan.
+
+## Slice
+
+RPC → `useTranslationReviewQueue` → route `/admin/translations` → `TranslationReviewCard` → i18n → vitest
+
+## Dependencies
+
+T156 (les colonnes et le type `TranslationAudit`). T157 fournit le contenu réel, mais n'est pas bloquant : une ligne semée à la main suffit à démontrer ce ticket. Les deux peuvent donc être pris en parallèle.
+
+## Scope
+
+### RPC
+
+`get_translations_for_review()`, `SECURITY DEFINER`, **projection étroite à huit colonnes** : `id`, `name`, `name_en`, `instructions`, `instructions_en`, `instructions_en_status`, `instructions_en_audit`, `logged_sets`.
+
+Délibérément différent de `get_unreviewed_exercises_by_usage` (`file:supabase/migrations/20260414000000_create_review_rpc.sql`) sur deux points. Il énumère 18 colonnes à la main et pourrit à chaque ajout au schéma ; celui-ci ne demande que ce que la file rend. Et il compte l'usage sur `workout_exercises` + `template_exercises`, c'est-à-dire les **prescriptions** ; celui-ci compte les lignes de `set_logs`, c'est-à-dire l'**exposition réelle en lecture**.
+
+Filtre : `instructions_en IS NOT NULL AND instructions_en_reviewed_at IS NULL`. Ordre : les `flagged` d'abord, puis séries loguées décroissantes, puis nom.
+
+### Hook et route
+
+`src/hooks/useTranslationReviewQueue.ts` appelle le RPC. Route `/admin/translations` ajoutée sous `AdminGuard` dans `file:src/router/index.tsx`, à côté des cinq routes admin existantes, avec son entrée depuis `AdminHomePage`.
+
+`src/pages/admin/AdminTranslationsPage.tsx` reprend la coquille de `file:src/pages/AdminReviewPage.tsx` : en-tête, barre de progression, une carte à la fois, index local dans la file. Pas de pagination — le volume attendu est de quelques centaines de lignes.
+
+### Carte de comparaison
+
+`src/components/admin/translations/TranslationReviewCard.tsx` — les quatre sections l'une sous l'autre, français et anglais côte à côte, alignés **par index dans la section**. Chaque objection de `instructions_en_audit` se rend en badge sur la phrase qu'elle visait, avec son verdict et sa note.
+
+Un badge de statut, et le nombre de séries loguées, pour que le relecteur sache ce qu'il arbitre.
+
+### i18n
+
+Nouvelles clés sous `admin.translations.*` dans **les deux** `file:src/locales/en/admin.json` et `file:src/locales/fr/admin.json`. `EnrichmentCard` et ses chaînes anglaises en dur sont le contre-exemple du repo : ne pas le copier.
+
+### Tests
+
+- Ordre de la file : un `flagged` peu logué passe avant un `clean` très logué.
+- Une objection s'affiche sur la bonne phrase, pas en tête de section.
+- État vide quand la file est épuisée.
+- Un non-admin est redirigé (couvert par `AdminGuard`, à vérifier une fois).
+
+## Out of Scope
+
+- Toute écriture : approuver, éditer et rendre au français sont dans T159.
+- L'assistant presse-papier : T160.
+- Toute modification de `get_unreviewed_exercises_by_usage` ou de la file de revue de contenu existante. Les deux files doivent rester **étanches** : c'est précisément parce que `reviewed_at` est partagé entre revue de contenu et enrichissement d'images que ce ticket s'appuie sur une colonne dédiée.
+
+## Acceptance Criteria
+
+- [ ] `get_translations_for_review` renvoie huit colonnes et compte les séries loguées, pas les prescriptions.
+- [ ] Les `flagged` remontent avant les `clean`, et les `clean` sont triés par séries loguées décroissantes.
+- [ ] Une objection de l'audit s'affiche sur la phrase anglaise qu'elle visait.
+- [ ] Les libellés existent en anglais **et** en français, aucun texte en dur.
+- [ ] `/admin/translations` est inaccessible à un non-admin.
+- [ ] `get_unreviewed_exercises_by_usage` est inchangé et sa file rend le même nombre d'éléments qu'avant.
+- [ ] **Démo** : avec deux lignes semées à la main, une `flagged` et une `clean`, la file les présente dans le bon ordre et la comparaison est lisible phrase à phrase.
+
+## References
+
+- Epic Brief : `docs/Epic_Brief_—_English_Exercise_Instructions_#417.md`, stories 5, 6
+- Tech Plan : `docs/Tech_Plan_—_English_Exercise_Instructions_#417.md`, § Data Model (RPC), § Component Architecture
+- Issue [#417](https://github.com/PierreTsia/workout-app/issues/417)
+- Précédents : `file:src/pages/AdminReviewPage.tsx`, `file:src/router/index.tsx`, `file:src/router/AdminGuard.tsx`

--- a/docs/T159_—_Approve_edit_revert_translations.md
+++ b/docs/T159_—_Approve_edit_revert_translations.md
@@ -1,0 +1,86 @@
+# T159 — Approve / edit / revert translations
+
+## Goal
+
+Rendre la file décidable : approuver une traduction, corriger une coquille, ou la rendre au français — au clavier, avec la décision horodatée pour qu'une seconde passe ne représente jamais ce qui a déjà été tranché.
+
+Le point de vigilance est une colonne : cette mutation **ne doit pas toucher `reviewed_at`**. Ce champ est partagé entre la revue de contenu de `AdminReviewPage` et l'upload d'images de l'enrichissement ; l'écrire ici sortirait l'exercice de la file de revue de contenu sans que personne ne l'ait relu.
+
+Couvre les stories 7 et 10 de l'Epic Brief.
+
+## Mode
+
+**AFK** — la sémantique des trois actions et la colonne d'horodatage sont fixées.
+
+## Slice
+
+`useApproveTranslation` → actions de la carte + raccourcis clavier → écriture RLS → vitest
+
+## Dependencies
+
+T158.
+
+## Scope
+
+### Mutation
+
+`src/hooks/useApproveTranslation.ts`, sur le patron de `file:src/hooks/useAdminUpdateExercise.ts` — client anon avec la session de l'admin, pas de service role. La policy `"Admins can update exercises"` couvre déjà l'UPDATE depuis le navigateur, aucun changement de RLS n'est nécessaire.
+
+Le hook existant **stampe systématiquement `reviewed_at` et `reviewed_by`** : c'est pourquoi il ne peut pas être réutilisé, et pourquoi celui-ci écrit sa propre liste de colonnes.
+
+| Action | Écrit |
+|---|---|
+| Approuver | `instructions_en_status = 'approved'`, `instructions_en_reviewed_at = now()` |
+| Approuver après édition | idem, plus `instructions_en` corrigé |
+| Rendre au français | `instructions_en_status = 'flagged'`, `instructions_en_reviewed_at = now()` |
+
+Rendre au français **conserve** le contenu anglais : la ligne quitte la file et réaffiche le français, mais la traduction reste en base pour qu'une future passe puisse la reprendre avec `--force`.
+
+Invalidation des mêmes clés que `useAdminUpdateExercise` — la ligne catalogue est en cache à plusieurs endroits — plus la clé de la file. Toast via `sonner`, comme partout ailleurs dans l'admin.
+
+### Actions et clavier
+
+Trois affordances sur `TranslationReviewCard`, plus le saut. Raccourcis en handlers **locaux** `onKeyDown` sur le conteneur, comme `file:src/components/builder/BuilderHeader.tsx` : le repo n'a aucun hook de raccourci global, et ce ticket n'en invente pas.
+
+| Touche | Action |
+|---|---|
+| `A` | Approuver |
+| `E` | Basculer en édition |
+| `R` | Rendre au français |
+| `→` | Passer sans décider |
+
+L'édition est **minimale et volontairement inconfortable** : un `Textarea` brut par section, une ligne par phrase. La correction structurée, la validation de forme et le diff sont le sujet de T160 ; les mettre ici viderait T160 de sa raison d'être et ferait doubler ce ticket.
+
+La file est reconstruite après chaque écriture, l'index local repart sur l'élément suivant — comme `AdminReviewPage` le fait déjà après sauvegarde.
+
+### Tests
+
+- Approuver écrit `approved` et l'horodatage, et **laisse `reviewed_at` nul** — assertion explicite sur la charge de l'UPDATE.
+- Rendre au français écrit `flagged` et l'horodatage, et conserve `instructions_en`.
+- Une ligne décidée quitte la file au rechargement.
+- Les quatre raccourcis déclenchent la bonne action.
+- Erreur d'écriture : toast d'erreur, la ligne reste dans la file.
+
+## Out of Scope
+
+- L'assistant presse-papier, la validation de JSON collé et le diff : T160.
+- Toute écriture sur `reviewed_at` ou `reviewed_by`.
+- Une reprise de position persistée entre deux sessions : l'index reste local, comme dans l'écran de revue existant.
+- Toute action de masse. La relecture est phrase à phrase, par construction.
+
+## Acceptance Criteria
+
+- [ ] Approuver écrit `instructions_en_status` et `instructions_en_reviewed_at`, et **ne mentionne pas** `reviewed_at` dans la charge.
+- [ ] La file de revue de contenu de `/admin/review` rend le même nombre d'éléments avant et après une approbation de traduction.
+- [ ] Rendre au français repasse la ligne en `flagged`, conserve `instructions_en`, et l'app en anglais réaffiche le français.
+- [ ] Une ligne décidée ne réapparaît plus dans la file.
+- [ ] Les quatre raccourcis fonctionnent et n'interceptent pas la frappe dans un `Textarea` en édition.
+- [ ] Une erreur d'écriture laisse la ligne en place avec un toast d'erreur.
+- [ ] **Démo** : trois lignes tranchées d'affilée au clavier, la file se vide, et l'affichage de l'app suit chaque décision.
+
+## References
+
+- Epic Brief : `docs/Epic_Brief_—_English_Exercise_Instructions_#417.md`, stories 7, 10
+- Tech Plan : `docs/Tech_Plan_—_English_Exercise_Instructions_#417.md`, § Critical Constraints (deux chemins d'écriture), § Component Responsibilities
+- Issue [#417](https://github.com/PierreTsia/workout-app/issues/417)
+- Précédents : `file:src/hooks/useAdminUpdateExercise.ts`, `file:src/components/builder/BuilderHeader.tsx`

--- a/docs/T160_—_Review_assist_clipboard_round-trip.md
+++ b/docs/T160_—_Review_assist_clipboard_round-trip.md
@@ -1,0 +1,76 @@
+# T160 — Review assist clipboard round-trip
+
+## Goal
+
+Rendre l'arbitrage d'un cas difficile rapide au lieu de solitaire. Un bouton copie une **demande d'arbitrage** complète — noms de l'exercice, phrases numérotées et alignées, objections du contre-relecteur, règles maison — que le relecteur soumet à un agent ; le retour se recolle dans l'écran, sa forme est validée, et un diff par section précède toute écriture.
+
+Le levier est bien identifié : le coût de cet epic n'est pas la traduction (0,40 $ et neuf minutes pour tout le catalogue) mais la relecture de 4 140 phrases par un relecteur trilingue non substituable. Ce ticket ne rend pas la relecture possible, il la rend tenable.
+
+Couvre les stories 8 et 9 de l'Epic Brief.
+
+## Mode
+
+**AFK** — construire le dialog est mécanique. C'est son usage qui est humain, et cet usage vit dans T161.
+
+## Slice
+
+`buildReviewRequest` pur → `ReviewAssistDialog` → presse-papier → validation de forme → diff → vitest
+
+## Dependencies
+
+T159 (le chemin d'écriture et l'édition minimale qu'il remplace).
+
+## Scope
+
+### Construction de la charge
+
+`buildReviewRequest(row)` est une **fonction pure dans `src/lib/`**, donc testée sans rendu. Elle produit un texte portant :
+
+- Le nom français et le nom anglais de l'exercice, pour que l'arbitre sache de quel mouvement on parle.
+- Les quatre sections, chaque phrase **numérotée** et appariée à sa source française, pour que le retour soit réalignable sans deviner.
+- Les objections du contre-relecteur, avec leur verdict et leur note, référencées par section et index.
+- Les **règles maison**, celles-là mêmes que le prompt de traduction applique : phrase nominale pour les erreurs courantes (un impératif sous « common mistakes » ordonne de commettre la faute), deuxième personne constante, fidélité du matériel et des mesures.
+- La consigne de rendre un **JSON corrigé** dans la forme attendue, pas un commentaire.
+
+La demande demande un arbitrage et une correction, pas une validation : « dis-moi si c'est bon » produit un avis, « corrige ce qui doit l'être et rends le JSON » produit quelque chose de collable.
+
+### Presse-papier
+
+Repli à trois niveaux, exactement celui de `file:src/components/ErrorFallback.tsx` : `navigator.clipboard.writeText`, puis un `textarea` hors écran avec `execCommand`, puis dépôt du texte dans un toast long comme le fait `file:src/components/admin/review/ExerciseReviewToolbar.tsx` pour ses prompts d'illustration. Un contexte non sécurisé ne doit pas être un cul-de-sac.
+
+### Collage retour
+
+Le JSON collé passe par `parseInstructions` de `src/lib/instructionPrompt.ts` (T157) — même validateur que le script, donc même définition de « forme valide » des deux côtés du pipeline. Un JSON malformé, tronqué, ou dont une clé manque est **refusé avec un message**, sans aucune écriture.
+
+Un JSON valide affiche un **diff par section** entre l'anglais en base et l'anglais proposé, phrase par phrase. L'écriture ne part qu'après confirmation, par la mutation de T159 — ce ticket n'ouvre pas de second chemin d'écriture.
+
+### Tests
+
+- `buildReviewRequest` : les phrases sont numérotées et appariées, les objections référencées, les règles présentes.
+- JSON malformé, tronqué, clé manquante, tableau devenu chaîne → refus, aucune mutation appelée.
+- JSON valide → diff affiché, mutation appelée seulement après confirmation.
+- Repli de presse-papier quand `navigator.clipboard` est absent.
+
+## Out of Scope
+
+- **Tout appel LLM depuis le navigateur.** Aucune clé d'API côté client, jamais. L'aller-retour passe par le presse-papier et c'est un choix, pas une limitation.
+- Toute mémoire de traduction, ou réutilisation d'un arbitrage passé sur une phrase similaire.
+- Un second chemin d'écriture : la mutation reste celle de T159.
+- La correction du **français** source, même si l'arbitrage révèle qu'il est fautif.
+
+## Acceptance Criteria
+
+- [ ] La demande copiée contient les noms, les phrases numérotées et appariées, les objections, et les règles maison.
+- [ ] Un JSON malformé ou incomplet est refusé avec un message, et aucune mutation n'est appelée.
+- [ ] Un JSON valide affiche un diff par section avant écriture, et l'écriture n'a lieu qu'après confirmation.
+- [ ] Le validateur est **le même** que celui du script de T157.
+- [ ] Le repli de presse-papier fonctionne sans `navigator.clipboard`.
+- [ ] `buildReviewRequest` est pure et testée sans rendu.
+- [ ] **Démo** : sur une ligne `flagged`, copier la demande, coller un JSON corrigé, lire le diff, écrire — et voir l'app en anglais afficher le texte corrigé.
+
+## References
+
+- Epic Brief : `docs/Epic_Brief_—_English_Exercise_Instructions_#417.md`, stories 8, 9
+- Tech Plan : `docs/Tech_Plan_—_English_Exercise_Instructions_#417.md`, § Component Responsibilities (`ReviewAssistDialog`)
+- Issue [#417](https://github.com/PierreTsia/workout-app/issues/417)
+- Précédents : `file:src/components/ErrorFallback.tsx`, `file:src/components/admin/review/ExerciseReviewToolbar.tsx`

--- a/docs/T161_—_Backfill_waves_execution.md
+++ b/docs/T161_—_Backfill_waves_execution.md
@@ -1,0 +1,73 @@
+# T161 — Backfill waves execution
+
+## Goal
+
+Exécuter la traduction sur le catalogue réel, en vagues, et amener l'exposition relue par un humain au-dessus du seuil de l'epic. C'est le seul ticket qui produit de la donnée en production, et le seul qui peut faire échouer le critère numérique.
+
+L'ordre des vagues est un garde-fou, pas une préférence : le spike n'a mesuré que **30 lignes sur 372**. Le taux réel de signalement au-delà de l'échantillon est inconnu, et la longue traîne des exercices que personne n'a jamais logués est l'endroit où le mesurer sans rien risquer.
+
+Sert le critère agrégé de l'epic : ≥ 76 % de l'exposition réelle servie par des consignes anglaises relues par un humain.
+
+## Mode
+
+**HITL** — et pas parce qu'une décision manque. Le jugement exige les données en main : regarder le taux de signalement sur 231 lignes réelles, décider si Gemini Flash tient hors échantillon, puis relire à la main 60 exercices de coaching. Rien de tout cela ne se ramène à une acceptation mécanique.
+
+## Slice
+
+migration en production → vague longue traîne → mesure → décision → vague top 60 → relecture humaine → clôture
+
+## Dependencies
+
+T157 (le script) et T159 (les actions de relecture). T160 rend la relecture nettement plus rapide et devrait être livré avant la vague du top 60, sans la bloquer.
+
+## Scope
+
+### Préalable
+
+La migration de T156 doit être **appliquée en production avant** que le script ne tourne contre elle — le précédent de T152 dans l'epic #415 a établi cet ordre.
+
+### Vague 1 — longue traîne
+
+Les **231 exercices que personne n'a jamais logués**, via `--unlogged`. Dry-run d'abord, puis `--apply`.
+
+C'est la vague de mesure. Elle produit trois chiffres qui n'existent pas encore : le taux de lignes `flagged`, la nature dominante des objections, et le coût réel en temps et en jetons. Sur des exercices que personne ne consulte, une erreur qui passe ne blesse personne.
+
+### Point de décision
+
+Le taux de signalement est comparé aux 1/30 du spike. S'il s'effondre — disons au-delà de 20 % — on ne poursuit pas : on corrige le prompt, ou on change de traducteur, **avant** de toucher aux exercices qui comptent. La décision et ses chiffres sont consignés en commentaire sur l'issue de l'epic.
+
+### Vague 2 — top 60
+
+Les 60 exercices les plus logués, via `--top 60`. Ils portent **76,7 %** des séries enregistrées, contre 61,8 % pour les 40 premiers et 41,1 % pour les 20 premiers. C'est là que la relecture humaine a un rendement réel.
+
+### Relecture
+
+Passes de relecture dans `/admin/translations`, les `flagged` d'abord puis les `clean` par exposition décroissante, avec l'assistant de T160 pour les cas difficiles. Résumable par tranches : c'est la raison pour laquelle la décision est horodatée.
+
+### Reste du catalogue
+
+Le solde des lignes loguées est traduit par vagues, sans exigence de relecture exhaustive. La couverture partielle est un **état supporté** de l'epic, pas un incident.
+
+## Out of Scope
+
+- Toute modification du script ou de l'UI. Si une correction s'avère nécessaire, elle repart en ticket : ce ticket exécute, il ne code pas.
+- La correction du français source, même quand la contre-relecture le débusque.
+- La relecture humaine exhaustive des 372 lignes.
+- Les templates de programme ([#58](https://github.com/PierreTsia/workout-app/issues/58)), même si le pipeline s'y appliquerait.
+
+## Acceptance Criteria
+
+- [ ] La migration de T156 est appliquée en production avant la première exécution avec `--apply`.
+- [ ] Vague 1 exécutée sur les 231 exercices jamais logués.
+- [ ] Le taux de signalement réel, la nature dominante des objections et le coût effectif sont **mesurés et consignés** sur l'issue de l'epic.
+- [ ] La décision de poursuivre ou de corriger le prompt est tracée, avec ses chiffres.
+- [ ] Vague 2 exécutée sur le top 60 par séries loguées.
+- [ ] Aucune ligne `flagged` non relue ne s'affiche en anglais dans l'app — vérifié par échantillonnage.
+- [ ] Le ticket se clôt sur une mesure et une décision tracées ; si le seuil de 76 % n'est pas atteint, le pourcentage réel est rapporté et l'epic reste ouvert. La couverture partielle est un état supporté, pas un échec.
+
+## References
+
+- Epic Brief : `docs/Epic_Brief_—_English_Exercise_Instructions_#417.md`, § Success Criteria
+- Tech Plan : `docs/Tech_Plan_—_English_Exercise_Instructions_#417.md`, § Key Decisions (ordre des vagues)
+- Issue [#417](https://github.com/PierreTsia/workout-app/issues/417)
+- Précédent d'ordre migration/production : T152 dans [#422](https://github.com/PierreTsia/workout-app/issues/422)

--- a/docs/Tech_Plan_—_English_Exercise_Instructions_#417.md
+++ b/docs/Tech_Plan_—_English_Exercise_Instructions_#417.md
@@ -1,0 +1,290 @@
+# Tech Plan — English Exercise Instructions (#417)
+
+## Architectural Approach
+
+L'epic est **entièrement en lecture**. Contrairement aux noms, `instructions` n'est snapshotée nulle part : aucun `workout_exercises`, aucun `set_logs`, aucun des six chemins d'écriture de #415. Le risque central de l'epic précédent — un snapshot porteur de logique de tri et de regroupement — n'existe pas ici. Aucun chemin d'écriture applicatif n'est modifié.
+
+La difficulté se déplace sur deux points. D'abord, **trois surfaces dupliquent** aujourd'hui le même bloc `hasInstructions` et lisent `.instructions.*` en direct sans résolveur : `file:src/components/exercise/ExerciseInstructionsPanel.tsx`, `file:src/components/exercise/ExerciseInfoDialog.tsx`, `file:src/components/generator/ExerciseDetailSheet.tsx`. Le résolveur ne se contente donc pas de choisir une langue : il renvoie `ExerciseInstructions | null`, où `null` signifie « rien à afficher ». Il absorbe la décision de présence triplicée, ce qui **supprime** du code au lieu d'en ajouter.
+
+Ensuite, **l'affichage dépend d'une colonne de statut de relecture**. C'est un couplage assumé : la seule façon de garantir qu'une traduction suspecte reste française est que le rendu connaisse le verdict. Le résolveur échoue **fermé** — un statut absent, nul ou inconnu rend du français.
+
+Le reste est un pipeline hors ligne : une lib pure de contrôle qualité dans `src/lib/`, un script de backfill dans `scripts/`, et une route admin sœur pour la relecture.
+
+**Séquence de livraison en quatre PR.** La PR 1 (migration, types, résolveur, trois surfaces) est un **no-op en production** : sans aucune donnée anglaise en base, elle ne change rien à l'écran, ce qui dérisque la migration et le résolveur séparément. La PR 2 livre le filet qualité et le script, sans UI. La PR 3 livre la file et la comparaison. La PR 4 livre l'assistant d'arbitrage par presse-papier.
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Moment de résolution | **Affichage**, jamais l'écriture | ADR 0010 ; ici c'est gratuit, aucun snapshot n'existe |
+| Forme du résolveur | `resolveExerciseInstructions()` dans `file:src/lib/catalogLabels.ts`, renvoyant `ExerciseInstructions \| null` | Absorbe le `hasInstructions` triplicé ; même patron que `resolveExerciseName` |
+| Chaîne de repli | `instructions_en` si EN **et** statut ∈ {`clean`, `approved`} **et** parité de sections → sinon `instructions` | Pas de snapshot de secours, la chaîne est plus courte que pour les noms |
+| Granularité du repli | **En bloc, jamais par section** | Un panneau mi-anglais mi-français est exactement le défaut qu'a rapporté l'issue |
+| Rigueur de la parité | Toute section non vide en FR doit être non vide en EN ; le **nombre de phrases n'est pas comparé** | Le modèle fusionne parfois deux phrases légitimement ; compter les phrases renverrait au français des traductions correctes |
+| Comportement par défaut | **Échec fermé** : statut nul, inconnu ou absent de la projection → français | Un anglophone qui lit du français est déçu ; un anglophone qui lit une consigne fausse se blesse |
+| Colonnes | **4 colonnes plates** sur `exercises` | Calque `name_en` ; aucune abstraction générique pour un second usage hypothétique |
+| Type du statut | `text` + `CHECK` | Aucun enum Postgres dans ce repo ; précédent `difficulty_level` et `measurement_type` |
+| `reviewed_at` | **Non réutilisé** — colonne dédiée | Partagé entre la revue de contenu et l'upload d'images ; le réutiliser viderait la file de `file:src/pages/AdminReviewPage.tsx` sans relecture |
+| Projection | `instructions_en` + statut ajoutés à `FULL_EXERCISE_SELECT` | `file:src/hooks/useWorkoutExercises.ts` préchauffe le cache `["exercise", id]` depuis FULL ; une ligne tronquée en cache rendrait du français en silence. Coût mesuré ≈ 5 ko par jour |
+| Surface de relecture | **Route sœur `/admin/translations`** | `/admin/enrichment` est déjà une route sœur pour le même patron de file ; aucun onglet n'existe en admin |
+| File de relecture | Nouveau RPC `get_translations_for_review()`, projection **étroite** | `get_unreviewed_exercises_by_usage` énumère 18 colonnes à la main et pourrit à chaque ajout ; la file n'a besoin que de 8 champs |
+| Métrique de priorité | Séries loguées (`set_logs`), **pas** `workout_exercises` | Le RPC existant compte les prescriptions ; on veut l'exposition réelle en lecture |
+| Filet qualité | Lib **pure** `file:src/lib/instructionQuality.ts` | CI ne type-check pas `scripts/` ; dans `src/` le filet gagne `tsc -b` et Vitest gratuitement, et n'est importé par aucun composant donc jamais embarqué |
+| Traducteur | **Gemini 2.5 Flash** | Mesuré : 29/30 propres, 0 inversion de mode sur 107 entrées, 98 % de cohérence en deuxième personne |
+| Contre-relecteur | **Groq `llama-3.3-70b-versatile`** | Autre fournisseur, donc erreurs non corrélées avec le traducteur ; déjà dans les conventions du repo |
+| Verdict par défaut | Contre-relecteur indisponible → `flagged`, **jamais** `clean` | Un quota épuisé ne doit pas produire de l'anglais réputé propre |
+| Ordre des vagues | **Longue traîne d'abord** (231 jamais logués), puis le top 60 | Mesure le taux réel de signalement à faible enjeu avant de toucher les 77 % d'exposition |
+| Écriture backfill | **Service role** | Script headless sans JWT admin |
+| Écriture relecture | Client anon + session admin | La policy `"Admins can update exercises"` couvre déjà l'UPDATE depuis le navigateur |
+| Mode par défaut du script | **Dry-run**, `--apply` pour écrire | Précédent `file:scripts/backfill-was-pr.ts` ; `file:scripts/enrich-instructions.ts` écrit sans garde-fou, contre-exemple |
+| Aller-retour de relecture | Presse-papier dans les **deux sens**, JSON validé puis diffé | Aucune clé LLM dans le navigateur, et l'adjudication reste conversationnelle |
+
+### Critical Constraints
+
+**Le cache React Query est préchauffé depuis `FULL_EXERCISE_SELECT`.** `file:src/hooks/useWorkoutExercises.ts` embarque la ligne catalogue complète et remplit `["exercise", id]`. `ExerciseInstructionsPanel` lit ensuite ce cache via `useExerciseFromLibrary` → `useExerciseById` **sans refetch**. Si les nouvelles colonnes n'entrent pas dans FULL, le panneau ouvert depuis une séance résout en français alors que la même page ouverte depuis la bibliothèque résout en anglais — divergence invisible en revue. Les colonnes vont donc dans `file:src/lib/exerciseSelects.ts`, projection FULL. `LABEL_EXERCISE_SELECT` reste intouchée puisqu'elle ne porte aucune instruction.
+
+**`SwapExerciseSheet` est la seule surface sans refetch par id.** Elle passe telle quelle une ligne issue de `useExerciseLibraryPaginated`, donc de `search_exercises`. Cette fonction est `RETURNS SETOF exercises` avec un `SELECT e.*` : les nouvelles colonnes y circulent automatiquement, sans migration. C'est le seul endroit où l'on dépend de cette propriété — à documenter, parce qu'un futur passage de ce RPC à une projection explicite casserait la traduction silencieusement.
+
+**Le poids réseau est déjà payé, en français.** Mesure : 806 caractères d'instructions par exercice en moyenne, sur 372 lignes et 299 914 caractères au total. Une journée de six exercices ajoute donc ≈ 5 ko avant gzip. En revanche `search_exercises` renvoie `e.*`, donc une page de bibliothèque transporte déjà une vingtaine de kilo-octets d'instructions que la liste n'affiche pas — et qu'on va doubler. C'est une dette préexistante, pas créée ici ; elle mérite une issue séparée plutôt qu'une refonte du RPC de recherche dans cet epic.
+
+**CI ne type-check pas `scripts/`.** `tsconfig.app.json` n'inclut que `src`, `tsconfig.node.json` que `vite.config.ts`, et `tsc -b` ne voit donc aucun des 45 scripts. Seul ESLint les couvre. Toute logique du pipeline qui mérite d'être juste vit dans `src/lib/` ; `scripts/` ne garde que les I/O, les appels réseau et le CLI.
+
+**Deux chemins d'écriture, deux privilèges.** Le backfill a besoin de `SUPABASE_SERVICE_ROLE_KEY` car il tourne sans session. L'écran de relecture écrit depuis le navigateur avec la session de l'admin, exactement comme `file:src/hooks/useAdminUpdateExercise.ts`. Ce hook **stampe systématiquement `reviewed_at` et `reviewed_by`** : la relecture de traduction ne peut donc pas le réutiliser, il lui faut sa propre mutation.
+
+**`get_unreviewed_exercises_by_usage` est aveugle aux nouvelles colonnes** puisqu'il énumère les 18 colonnes existantes. Il continue de fonctionner sans modification — c'est exactement ce qu'on veut, les deux files restent étanches.
+
+**`src/types/database.ts` est maintenu à la main.** Aucun script de génération dans `package.json` : la migration doit être suivie d'une extension manuelle de l'interface `Exercise`. `ExerciseInstructions` est réemployé tel quel pour `instructions_en`, sans variante de type.
+
+**L'i18n admin existe et doit être respectée.** `file:src/locales/en/admin.json` et son pendant français couvrent les pages admin. `EnrichmentCard` est le contre-exemple du repo, avec ses chaînes anglaises en dur : ne pas le copier.
+
+---
+
+## Data Model
+
+Quatre colonnes nullables sur `exercises`, sans défaut. Forward-only, `IF NOT EXISTS`, aucun changement de RLS — les nouvelles colonnes héritent des policies existantes.
+
+```sql
+-- supabase/migrations/<timestamp>_add_english_instructions.sql
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en jsonb;
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en_status text;
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en_reviewed_at timestamptz;
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en_audit jsonb;
+
+ALTER TABLE exercises
+  ADD CONSTRAINT exercises_instructions_en_status_chk
+  CHECK (instructions_en_status IN ('clean', 'flagged', 'approved'));
+```
+
+`NULL` sur le statut signifie « jamais traduit », ce qui est distinct de « traduit et propre ». Aucun défaut, pour la même raison que `user_profiles.locale` en #415 : un défaut détruirait cette information.
+
+Pas de `instructions_en_reviewed_by` : il y a exactement un relecteur, et `reviewed_by` sur la table existante ne sert qu'à distinguer plusieurs admins sur la revue de contenu.
+
+```mermaid
+classDiagram
+    class Exercise {
+        +uuid id
+        +jsonb instructions "FR, source curée"
+        +jsonb instructions_en_nullable
+        +text instructions_en_status_nullable "clean|flagged|approved"
+        +timestamptz instructions_en_reviewed_at_nullable
+        +jsonb instructions_en_audit_nullable
+    }
+    class InstructionSource {
+        +ExerciseInstructions_nullable instructions
+        +ExerciseInstructions_nullable instructions_en
+        +string_nullable instructions_en_status
+    }
+    class ResolvedInstructions {
+        +string[] setup
+        +string[] movement
+        +string[] breathing
+        +string[] common_mistakes
+    }
+    class Audit {
+        +string model
+        +number prompt_version
+        +string checker_model
+        +string[] gate_flags
+        +Objection[] objections
+    }
+    Exercise --> InstructionSource : projection FULL / select(*)
+    InstructionSource --> ResolvedInstructions : resolveExerciseInstructions(locale)
+    Exercise --> Audit : instructions_en_audit
+```
+
+### Table Notes
+
+**`instructions_en`** — même forme exacte que `instructions` (`setup`, `movement`, `breathing`, `common_mistakes`, tous `string[]`), donc le type `ExerciseInstructions` est réemployé sans variante. Le script n'écrit **jamais** un bloc partiel : la validation de forme précède l'écriture, comme dans `file:scripts/enrich-instructions.ts`.
+
+**`instructions_en_status`** — la seule colonne lue au rendu. `clean` = traduit, passé le filet automatique et le contre-relecteur. `flagged` = une objection subsiste, **rendu en français** jusqu'à arbitrage. `approved` = validé par un humain.
+
+**`instructions_en_audit`** — jamais requêtée, uniquement affichée dans l'écran de relecture. C'est elle qui permet d'accrocher une objection à la phrase fautive :
+
+```json
+{
+  "model": "gemini-2.5-flash",
+  "prompt_version": 1,
+  "translated_at": "2026-08-02T09:12:00Z",
+  "checker_model": "llama-3.3-70b-versatile",
+  "gate_flags": ["dropped-number:movement.2"],
+  "objections": [
+    {
+      "section": "setup",
+      "index": 1,
+      "verdict": "measurement-changed",
+      "note": "'largeur des épaules' rendu 'hip-width'"
+    }
+  ]
+}
+```
+
+**Nouveau RPC de file**, projection étroite et comptage sur les séries loguées :
+
+```sql
+-- supabase/migrations/<timestamp>_create_translation_review_rpc.sql
+CREATE OR REPLACE FUNCTION get_translations_for_review()
+RETURNS TABLE (
+  id uuid,
+  name text,
+  name_en text,
+  instructions jsonb,
+  instructions_en jsonb,
+  instructions_en_status text,
+  instructions_en_audit jsonb,
+  logged_sets bigint
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT
+    e.id, e.name, e.name_en,
+    e.instructions, e.instructions_en,
+    e.instructions_en_status, e.instructions_en_audit,
+    COALESCE(sl.cnt, 0) AS logged_sets
+  FROM exercises e
+  LEFT JOIN (
+    SELECT exercise_id, COUNT(*) AS cnt FROM set_logs GROUP BY exercise_id
+  ) sl ON sl.exercise_id = e.id
+  WHERE e.instructions_en IS NOT NULL
+    AND e.instructions_en_reviewed_at IS NULL
+  ORDER BY
+    (e.instructions_en_status = 'flagged') DESC,
+    COALESCE(sl.cnt, 0) DESC,
+    e.name ASC;
+$$;
+```
+
+Huit colonnes au lieu de dix-neuf : la file ne rend ni emoji ni difficulté, et l'ajout d'une future colonne à `exercises` ne la fera pas pourrir.
+
+**Aucun snapshot n'est concerné.** `name_snapshot`, `muscle_snapshot`, `emoji_snapshot`, `exercise_name_snapshot` sont hors sujet : les instructions n'ont jamais été copiées nulle part.
+
+---
+
+## Component Architecture
+
+### Layer Overview
+
+```mermaid
+graph TD
+    subgraph Affichage
+        CL[lib/catalogLabels.ts<br/>+ resolveExerciseInstructions]
+        UCL[useCatalogLabels<br/>+ exerciseInstructions]
+        P1[ExerciseInstructionsPanel]
+        P2[ExerciseInfoDialog]
+        P3[ExerciseDetailSheet]
+        IS[InstructionSection<br/>inchangé]
+    end
+    subgraph Pipeline
+        IQ[lib/instructionQuality.ts<br/>pur: checkRow, flagsFor]
+        IP[lib/instructionPrompt.ts<br/>buildPrompt, parseInstructions]
+        SC[scripts/translate-instructions.ts<br/>I/O, Gemini, Groq, CLI]
+    end
+    subgraph Relecture
+        RPC[(get_translations_for_review)]
+        HQ[useTranslationReviewQueue]
+        HM[useApproveTranslation]
+        PG[AdminTranslationsPage]
+        RC[TranslationReviewCard]
+        RA[ReviewAssistDialog]
+    end
+    CL --> UCL --> P1 & P2 & P3 --> IS
+    IQ --> SC
+    IP --> SC
+    IQ --> RA
+    RPC --> HQ --> PG --> RC --> HM
+    RC --> RA
+```
+
+### New Files & Responsibilities
+
+| File | Purpose |
+|---|---|
+| `supabase/migrations/<ts>_add_english_instructions.sql` | Les 4 colonnes + le CHECK |
+| `supabase/migrations/<ts>_create_translation_review_rpc.sql` | `get_translations_for_review()` |
+| `src/lib/instructionQuality.ts` | Filet qualité **pur** : parité de longueur, nombres perdus, matériel inventé, muscle non traduit, bavure de casse, résidus français, glossaire au niveau de la phrase, mode impératif, calques anatomiques, ratio de deuxième personne. Promu depuis `scripts/spike-checks.ts` |
+| `src/lib/instructionQuality.test.ts` | Dont deux régressions nommées : « pupitre Larry Scott » et « Lower back to 90° » ne doivent plus se déclencher |
+| `src/lib/instructionPrompt.ts` | `buildPrompt()`, `parseInstructions()`, `PROMPT_VERSION` |
+| `scripts/translate-instructions.ts` | CLI : `--dry-run` (défaut), `--apply`, `--unlogged`, `--top N`, `--ids`, `--force`. Gemini traduit, Groq contre-relit, service role écrit |
+| `src/pages/admin/AdminTranslationsPage.tsx` | Route `/admin/translations` : file, progression, carte courante |
+| `src/components/admin/translations/TranslationReviewCard.tsx` | Comparaison FR/EN alignée à la phrase, objections accrochées, approuver / éditer / rendre au français |
+| `src/components/admin/translations/ReviewAssistDialog.tsx` | Copie la demande d'arbitrage, colle le JSON corrigé, valide la forme, montre le diff avant écriture |
+| `src/hooks/useTranslationReviewQueue.ts` | Appelle le RPC |
+| `src/hooks/useApproveTranslation.ts` | UPDATE ciblé : statut, `instructions_en_reviewed_at`, éventuellement `instructions_en` corrigé. **Ne touche pas** `reviewed_at` |
+
+### Component Responsibilities
+
+**`resolveExerciseInstructions(source, locale)`**
+- Prend `{ instructions, instructions_en, instructions_en_status }`, rend `ExerciseInstructions | null`
+- Rend `null` quand les quatre tableaux de la langue retenue sont vides — c'est là que meurt le `hasInstructions` triplicé
+- Anglais retenu seulement si `isEnglish(locale)`, statut ∈ {`clean`, `approved`}, et **parité de présence** des sections avec le français
+- Aucune dépendance React ni i18next, testable dans les deux locales sans rendu, garanti par le test de pureté en `?raw` déjà pratiqué par `file:src/lib/catalogLabels.test.ts`
+
+**`useCatalogLabels`** — gagne `exerciseInstructions(row)`, lié à `i18n.language` comme les résolveurs existants. Aucune nouvelle source de locale : ni `localeAtom`, ni lecture directe de `navigator`.
+
+**Test d'architecture** — un test grep sur `src/components/**` interdisant toute lecture de `.instructions` hors du résolveur. C'est le garde-fou du mode d'échec que l'ADR 0010 a documenté : une surface qui oublie le helper rend du français, invisible pour un relecteur francophone.
+
+**`src/lib/instructionQuality.ts`**
+- Fonctions pures sur une paire `(source FR, traduction EN)`, sans I/O
+- Deux faux positifs connus du spike sont des cas de test, pas des règles : un synonyme de matériel légitime (« pupitre Larry Scott » = *preacher bench*) et le verbe *lower* pris pour le muscle *lower back*
+- Les frontières de mots utilisent des lookarounds Unicode, pas `\b`, qui échoue sur `élastique` et `épaules`
+
+**`scripts/translate-instructions.ts`**
+- Sélection : `instructions IS NOT NULL AND instructions_en IS NULL`, filtrée par la vague. `--force` réécrit, **sauf les lignes `approved`**
+- Séquentiel, une ligne à la fois, avec respect de `Retry-After` — le patron des spikes, pas celui de `enrich-instructions.ts` qui ignore les 429
+- Écrit les quatre colonnes en une seule mise à jour : contenu, statut dérivé du filet et du contre-relecteur, audit. Jamais d'écriture partielle
+- Reprise naturelle : une interruption laisse les lignes non traitées à `NULL`
+- Env via `file:scripts/load-env.ts`, clés via le patron de `file:scripts/enrichment-config.ts`
+
+**`TranslationReviewCard`**
+- Alignement phrase à phrase par index dans chaque section ; une objection de l'audit se rend en badge sur la phrase concernée
+- Clavier : `A` approuver, `E` éditer, `R` rendre au français, `→` passer. Handlers locaux `onKeyDown`, comme `file:src/components/builder/BuilderHeader.tsx` — le repo n'a aucun hook de raccourci global et ce plan n'en invente pas
+- La position dans la file reste locale comme dans `AdminReviewPage`, et la file est reconstruite après chaque écriture
+
+**`ReviewAssistDialog`** *(PR 4)*
+- Bouton de copie construisant la demande d'arbitrage : nom FR et EN de l'exercice, tableaux alignés numérotés, objections du contre-relecteur, et les règles maison (phrase nominale pour les erreurs courantes, deuxième personne constante, fidélité du matériel et des mesures)
+- Repli de presse-papier robuste calqué sur `file:src/components/ErrorFallback.tsx` — `navigator.clipboard`, puis `execCommand`, puis dépôt du texte dans un toast long comme le fait `file:src/components/admin/review/ExerciseReviewToolbar.tsx`
+- Le collage retour est validé sur la forme avant toute écriture, puis diffé section par section
+
+### Failure Mode Analysis
+
+| Failure | Behavior |
+|---|---|
+| Statut absent de la projection | Repli **français**, sans erreur. Neutralisé par l'inclusion dans FULL et par le test d'architecture |
+| Section EN vide alors que la FR est remplie | Repli **en bloc** sur le français, jamais un panneau mixte |
+| JSON du traducteur invalide | Ligne sautée, colonnes laissées à `NULL`, reprise au run suivant |
+| Contre-relecteur indisponible ou quota épuisé | Statut `flagged`, donc **français à l'écran**. Jamais `clean` par défaut |
+| Quota atteint en cours de vague | Arrêt propre ; chaque ligne est écrite atomiquement, aucune ligne à moitié traduite |
+| Statut hors vocabulaire | Rejet par le `CHECK` Postgres, et le résolveur échoue fermé de toute façon |
+| Re-run après relecture humaine | `--force` exclut `approved` ; sans `--force`, le filtre `instructions_en IS NULL` protège tout |
+| JSON corrigé malformé collé dans l'UI | Refus avec message, aucune écriture |
+| Exercice sans instructions françaises | Hors candidats — le script ne traduit rien qui n'existe pas |
+| `search_exercises` repasse à une projection explicite | La traduction disparaît de `SwapExerciseSheet` en silence. Contrainte documentée ci-dessus |
+| Ligne `approved` puis français corrigé plus tard | Divergence non détectée. Accepté et tracé : hors périmètre de l'Epic Brief |
+
+---
+
+## Références
+
+- Epic Brief : `docs/Epic_Brief_—_English_Exercise_Instructions_#417.md`
+- ADR 0010 — Localize catalog labels at display time : `docs/adr/0010-localize-catalog-at-display-time.md`
+- Epic précédent : `docs/Epic_Brief_—_Localized_Exercise_Catalog_#415.md`, `docs/Tech_Plan_—_Localized_Exercise_Catalog_#415.md`
+- Issue : [#417](https://github.com/PierreTsia/workout-app/issues/417)

--- a/src/components/exercise/ExerciseInfoDialog.test.tsx
+++ b/src/components/exercise/ExerciseInfoDialog.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest"
+import { fireEvent, screen } from "@testing-library/react"
+
+import { renderWithProviders } from "@/test/utils"
+import type { Exercise } from "@/types/database"
+import { ExerciseInfoDialog } from "./ExerciseInfoDialog"
+
+const BASE_EXERCISE: Exercise = {
+  id: "ex-1",
+  name: "Développé couché",
+  muscle_group: "Pectoraux",
+  emoji: "🏋️",
+  is_system: true,
+  created_at: "2026-01-01T00:00:00Z",
+  youtube_url: null,
+  instructions: null,
+  image_url: null,
+  equipment: "barbell",
+  difficulty_level: null,
+  name_en: "Bench Press",
+  source: "wger:73",
+  secondary_muscles: null,
+  reviewed_at: null,
+  reviewed_by: null,
+}
+
+const BILINGUAL: Exercise = {
+  ...BASE_EXERCISE,
+  instructions: {
+    setup: ["Allonge-toi sur le banc"],
+    movement: ["Pousse la barre"],
+    breathing: ["Expire à la poussée"],
+    common_mistakes: ["Coudes trop écartés"],
+  },
+  instructions_en: {
+    setup: ["Lie back on the bench"],
+    movement: ["Press the bar up"],
+    breathing: ["Exhale on the push"],
+    common_mistakes: ["Flared elbows"],
+  },
+  instructions_en_status: "clean",
+}
+
+const openDialog = () =>
+  fireEvent.click(screen.getByRole("button", { name: "" }))
+
+describe("ExerciseInfoDialog", () => {
+  it("renders nothing when the row has neither instructions nor a video", () => {
+    const { container } = renderWithProviders(
+      <ExerciseInfoDialog exercise={BASE_EXERCISE} />,
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("shows the English steps to an English reader once the status is clean", () => {
+    renderWithProviders(<ExerciseInfoDialog exercise={BILINGUAL} />, {
+      locale: "en",
+    })
+    openDialog()
+
+    expect(screen.getByText("Lie back on the bench")).toBeInTheDocument()
+    expect(screen.queryByText("Allonge-toi sur le banc")).not.toBeInTheDocument()
+  })
+
+  it("keeps a French reader on French", () => {
+    renderWithProviders(<ExerciseInfoDialog exercise={BILINGUAL} />, {
+      locale: "fr",
+    })
+    openDialog()
+
+    expect(screen.getByText("Allonge-toi sur le banc")).toBeInTheDocument()
+    expect(screen.queryByText("Lie back on the bench")).not.toBeInTheDocument()
+  })
+})

--- a/src/components/exercise/ExerciseInfoDialog.test.tsx
+++ b/src/components/exercise/ExerciseInfoDialog.test.tsx
@@ -41,8 +41,13 @@ const BILINGUAL: Exercise = {
   instructions_en_status: "clean",
 }
 
-const openDialog = () =>
-  fireEvent.click(screen.getByRole("button", { name: "" }))
+/**
+ * Queried by accessible name on purpose: the trigger is icon-only, so naming it
+ * is what makes it reachable at all — and asking for the localized name here
+ * also fails if the label's key is missing from a locale.
+ */
+const openDialog = (accessibleName: string) =>
+  fireEvent.click(screen.getByRole("button", { name: accessibleName }))
 
 describe("ExerciseInfoDialog", () => {
   it("renders nothing when the row has neither instructions nor a video", () => {
@@ -57,7 +62,7 @@ describe("ExerciseInfoDialog", () => {
     renderWithProviders(<ExerciseInfoDialog exercise={BILINGUAL} />, {
       locale: "en",
     })
-    openDialog()
+    openDialog("Instructions: Bench Press")
 
     expect(screen.getByText("Lie back on the bench")).toBeInTheDocument()
     expect(screen.queryByText("Allonge-toi sur le banc")).not.toBeInTheDocument()
@@ -67,7 +72,7 @@ describe("ExerciseInfoDialog", () => {
     renderWithProviders(<ExerciseInfoDialog exercise={BILINGUAL} />, {
       locale: "fr",
     })
-    openDialog()
+    openDialog("Consignes : Développé couché")
 
     expect(screen.getByText("Allonge-toi sur le banc")).toBeInTheDocument()
     expect(screen.queryByText("Lie back on the bench")).not.toBeInTheDocument()

--- a/src/components/exercise/ExerciseInfoDialog.tsx
+++ b/src/components/exercise/ExerciseInfoDialog.tsx
@@ -22,16 +22,10 @@ interface ExerciseInfoDialogProps {
 
 export function ExerciseInfoDialog({ exercise }: ExerciseInfoDialogProps) {
   const { t } = useTranslation("exercise")
-  const { catalogName } = useCatalogLabels()
+  const { catalogName, exerciseInstructions } = useCatalogLabels()
 
-  const hasInstructions =
-    exercise.instructions &&
-    (exercise.instructions.setup.length > 0 ||
-      exercise.instructions.movement.length > 0 ||
-      exercise.instructions.breathing.length > 0 ||
-      exercise.instructions.common_mistakes.length > 0)
-
-  const hasContent = hasInstructions || exercise.youtube_url
+  const instructions = exerciseInstructions(exercise)
+  const hasContent = instructions || exercise.youtube_url
 
   if (!hasContent) return null
 
@@ -69,27 +63,27 @@ export function ExerciseInfoDialog({ exercise }: ExerciseInfoDialogProps) {
         </DialogHeader>
 
         <div className="flex flex-col gap-4">
-          {exercise.instructions && (
+          {instructions && (
             <>
               <InstructionSection
                 icon={Settings2}
                 title={t("setup")}
-                items={exercise.instructions.setup}
+                items={instructions.setup}
               />
               <InstructionSection
                 icon={Activity}
                 title={t("movement")}
-                items={exercise.instructions.movement}
+                items={instructions.movement}
               />
               <InstructionSection
                 icon={Wind}
                 title={t("breathing")}
-                items={exercise.instructions.breathing}
+                items={instructions.breathing}
               />
               <InstructionSection
                 icon={AlertTriangle}
                 title={t("commonMistakes")}
-                items={exercise.instructions.common_mistakes}
+                items={instructions.common_mistakes}
               />
             </>
           )}

--- a/src/components/exercise/ExerciseInfoDialog.tsx
+++ b/src/components/exercise/ExerciseInfoDialog.tsx
@@ -34,6 +34,7 @@ export function ExerciseInfoDialog({ exercise }: ExerciseInfoDialogProps) {
       <DialogTrigger asChild>
         <button
           type="button"
+          aria-label={t("instructionsFor", { name: catalogName(exercise) })}
           className="inline-flex items-center justify-center rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}

--- a/src/components/exercise/ExerciseInstructionsPanel.test.tsx
+++ b/src/components/exercise/ExerciseInstructionsPanel.test.tsx
@@ -94,6 +94,68 @@ describe("ExerciseInstructionsPanel", () => {
     expect(screen.getByText("Common mistakes")).toBeInTheDocument()
   })
 
+  const BILINGUAL: Exercise = {
+    ...BASE_EXERCISE,
+    instructions: {
+      setup: ["Allonge-toi sur le banc"],
+      movement: ["Pousse la barre"],
+      breathing: ["Expire à la poussée"],
+      common_mistakes: ["Coudes trop écartés"],
+    },
+    instructions_en: {
+      setup: ["Lie back on the bench"],
+      movement: ["Press the bar up"],
+      breathing: ["Exhale on the push"],
+      common_mistakes: ["Flared elbows"],
+    },
+    instructions_en_status: "clean",
+  }
+
+  it("shows the English steps to an English reader once the status is clean", () => {
+    mockUseExerciseFromLibrary.mockReturnValue({
+      data: BILINGUAL,
+      isLoading: false,
+    })
+
+    renderWithProviders(<ExerciseInstructionsPanel exerciseId="ex-1" />, {
+      locale: "en",
+    })
+    fireEvent.click(screen.getByText("How to perform"))
+
+    expect(screen.getByText("Lie back on the bench")).toBeInTheDocument()
+    expect(screen.queryByText("Allonge-toi sur le banc")).not.toBeInTheDocument()
+  })
+
+  it("shows the French steps to a French reader whatever the status", () => {
+    mockUseExerciseFromLibrary.mockReturnValue({
+      data: BILINGUAL,
+      isLoading: false,
+    })
+
+    renderWithProviders(<ExerciseInstructionsPanel exerciseId="ex-1" />, {
+      locale: "fr",
+    })
+    fireEvent.click(screen.getByText("Comment exécuter"))
+
+    expect(screen.getByText("Allonge-toi sur le banc")).toBeInTheDocument()
+    expect(screen.queryByText("Lie back on the bench")).not.toBeInTheDocument()
+  })
+
+  it("keeps an English reader on French while the translation is flagged", () => {
+    mockUseExerciseFromLibrary.mockReturnValue({
+      data: { ...BILINGUAL, instructions_en_status: "flagged" },
+      isLoading: false,
+    })
+
+    renderWithProviders(<ExerciseInstructionsPanel exerciseId="ex-1" />, {
+      locale: "en",
+    })
+    fireEvent.click(screen.getByText("How to perform"))
+
+    expect(screen.getByText("Allonge-toi sur le banc")).toBeInTheDocument()
+    expect(screen.queryByText("Lie back on the bench")).not.toBeInTheDocument()
+  })
+
   it("renders YouTube link when youtube_url is present", () => {
     mockUseExerciseFromLibrary.mockReturnValue({
       data: {

--- a/src/components/exercise/ExerciseInstructionsPanel.tsx
+++ b/src/components/exercise/ExerciseInstructionsPanel.tsx
@@ -6,6 +6,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
+import { useCatalogLabels } from "@/hooks/useCatalogLabels"
 import { useExerciseFromLibrary } from "@/hooks/useExerciseFromLibrary"
 import { InstructionSection } from "./InstructionSection"
 import { YouTubeLink } from "./YouTubeLink"
@@ -21,19 +22,14 @@ export function ExerciseInstructionsPanel({
   defaultExpanded = false,
 }: ExerciseInstructionsPanelProps) {
   const { t } = useTranslation("exercise")
+  const { exerciseInstructions } = useCatalogLabels()
   const { data: exercise, isLoading } = useExerciseFromLibrary(exerciseId)
   const [expanded, setExpanded] = useState(defaultExpanded)
 
   if (isLoading) return null
 
-  const hasInstructions =
-    exercise?.instructions &&
-    (exercise.instructions.setup.length > 0 ||
-      exercise.instructions.movement.length > 0 ||
-      exercise.instructions.breathing.length > 0 ||
-      exercise.instructions.common_mistakes.length > 0)
-
-  const hasContent = hasInstructions || exercise?.youtube_url
+  const instructions = exerciseInstructions(exercise)
+  const hasContent = instructions || exercise?.youtube_url
 
   if (!hasContent) return null
 
@@ -48,27 +44,27 @@ export function ExerciseInstructionsPanel({
       </CollapsibleTrigger>
 
       <CollapsibleContent className="flex flex-col gap-4 px-3 pb-2 pt-1">
-        {exercise?.instructions && (
+        {instructions && (
           <>
             <InstructionSection
               icon={Settings2}
               title={t("setup")}
-              items={exercise.instructions.setup}
+              items={instructions.setup}
             />
             <InstructionSection
               icon={Activity}
               title={t("movement")}
-              items={exercise.instructions.movement}
+              items={instructions.movement}
             />
             <InstructionSection
               icon={Wind}
               title={t("breathing")}
-              items={exercise.instructions.breathing}
+              items={instructions.breathing}
             />
             <InstructionSection
               icon={AlertTriangle}
               title={t("commonMistakes")}
-              items={exercise.instructions.common_mistakes}
+              items={instructions.common_mistakes}
             />
           </>
         )}

--- a/src/components/generator/ExerciseDetailSheet.test.tsx
+++ b/src/components/generator/ExerciseDetailSheet.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest"
+import { screen } from "@testing-library/react"
+
+import { renderWithProviders } from "@/test/utils"
+import type { Exercise } from "@/types/database"
+import { ExerciseDetailSheet } from "./ExerciseDetailSheet"
+
+const BILINGUAL: Exercise = {
+  id: "ex-1",
+  name: "Développé couché",
+  muscle_group: "Pectoraux",
+  emoji: "🏋️",
+  is_system: true,
+  created_at: "2026-01-01T00:00:00Z",
+  youtube_url: null,
+  instructions: {
+    setup: ["Allonge-toi sur le banc"],
+    movement: ["Pousse la barre"],
+    breathing: ["Expire à la poussée"],
+    common_mistakes: ["Coudes trop écartés"],
+  },
+  instructions_en: {
+    setup: ["Lie back on the bench"],
+    movement: ["Press the bar up"],
+    breathing: ["Exhale on the push"],
+    common_mistakes: ["Flared elbows"],
+  },
+  instructions_en_status: "clean",
+  image_url: null,
+  equipment: "barbell",
+  difficulty_level: null,
+  name_en: "Bench Press",
+  source: "wger:73",
+  secondary_muscles: null,
+  reviewed_at: null,
+  reviewed_by: null,
+}
+
+const renderSheet = (exercise: Exercise, locale: "en" | "fr") =>
+  renderWithProviders(
+    <ExerciseDetailSheet exercise={exercise} open onOpenChange={() => {}} />,
+    { locale },
+  )
+
+describe("ExerciseDetailSheet", () => {
+  // The row here comes straight from `search_exercises` without a refetch by
+  // id, so this is the surface that proves the RPC carries the translation.
+  it("shows the English steps to an English reader once the status is clean", () => {
+    renderSheet(BILINGUAL, "en")
+
+    expect(screen.getByText("Lie back on the bench")).toBeInTheDocument()
+    expect(screen.queryByText("Allonge-toi sur le banc")).not.toBeInTheDocument()
+  })
+
+  it("keeps a French reader on French", () => {
+    renderSheet(BILINGUAL, "fr")
+
+    expect(screen.getByText("Allonge-toi sur le banc")).toBeInTheDocument()
+    expect(screen.queryByText("Lie back on the bench")).not.toBeInTheDocument()
+  })
+
+  it("renders no instruction section when the row has none", () => {
+    renderSheet({ ...BILINGUAL, instructions: null, instructions_en: null }, "en")
+
+    expect(screen.queryByText("Setup")).not.toBeInTheDocument()
+  })
+})

--- a/src/components/generator/ExerciseDetailSheet.tsx
+++ b/src/components/generator/ExerciseDetailSheet.tsx
@@ -26,11 +26,12 @@ export function ExerciseDetailSheet({
   onOpenChange,
 }: ExerciseDetailSheetProps) {
   const { t } = useTranslation("exercise")
-  const { catalogName, muscleLabel, equipmentLabel } = useCatalogLabels()
+  const { catalogName, exerciseInstructions, muscleLabel, equipmentLabel } =
+    useCatalogLabels()
 
   if (!exercise) return null
 
-  const ins = exercise.instructions
+  const instructions = exerciseInstructions(exercise)
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -64,27 +65,27 @@ export function ExerciseDetailSheet({
         />
 
         <div className="mt-4 flex flex-col gap-4">
-          {ins && (
+          {instructions && (
             <>
               <InstructionSection
                 icon={Settings2}
                 title={t("setup")}
-                items={ins.setup}
+                items={instructions.setup}
               />
               <InstructionSection
                 icon={Activity}
                 title={t("movement")}
-                items={ins.movement}
+                items={instructions.movement}
               />
               <InstructionSection
                 icon={Wind}
                 title={t("breathing")}
-                items={ins.breathing}
+                items={instructions.breathing}
               />
               <InstructionSection
                 icon={AlertTriangle}
                 title={t("commonMistakes")}
-                items={ins.common_mistakes}
+                items={instructions.common_mistakes}
               />
             </>
           )}

--- a/src/hooks/useCatalogLabels.test.tsx
+++ b/src/hooks/useCatalogLabels.test.tsx
@@ -40,6 +40,31 @@ describe("useCatalogLabels", () => {
     expect(labels("en").equipmentLabel("smith_machine")).toBe("smith_machine")
   })
 
+  it("resolves the same row to two different instruction blocks across locales", () => {
+    const row = {
+      instructions: {
+        setup: ["Allonge-toi sur le banc"],
+        movement: [],
+        breathing: [],
+        common_mistakes: [],
+      },
+      instructions_en: {
+        setup: ["Lie back on the bench"],
+        movement: [],
+        breathing: [],
+        common_mistakes: [],
+      },
+      instructions_en_status: "clean",
+    }
+
+    expect(labels("en").exerciseInstructions(row)?.setup).toEqual([
+      "Lie back on the bench",
+    ])
+    expect(labels("fr").exerciseInstructions(row)?.setup).toEqual([
+      "Allonge-toi sur le banc",
+    ])
+  })
+
   it("never returns null for a missing value", () => {
     const { muscleLabel, equipmentLabel } = labels("en")
 

--- a/src/hooks/useCatalogLabels.ts
+++ b/src/hooks/useCatalogLabels.ts
@@ -4,7 +4,9 @@ import { useTranslation } from "react-i18next"
 import {
   equipmentLabelKey,
   muscleLabelKey,
+  resolveExerciseInstructions,
   resolveExerciseName,
+  type CatalogInstructionSource,
   type CatalogNameSource,
 } from "@/lib/catalogLabels"
 
@@ -30,6 +32,13 @@ export function useCatalogLabels() {
       catalogName: (
         row: { name?: string | null; name_en?: string | null } | null,
       ) => resolveExerciseName({ exercise: row }, language),
+
+      /**
+       * `null` when there is nothing to render — the presence check itself,
+       * not just the language choice, so no surface has to re-derive it.
+       */
+      exerciseInstructions: (row: CatalogInstructionSource | null | undefined) =>
+        resolveExerciseInstructions(row ?? {}, language),
 
       /** Falls back to the raw value: snapshots hold pre-taxonomy muscle names. */
       muscleLabel: (value: string | null | undefined) => {

--- a/src/lib/catalogLabels.test.ts
+++ b/src/lib/catalogLabels.test.ts
@@ -6,13 +6,39 @@ import {
   equipmentLabelKey,
   isEnglish,
   muscleLabelKey,
+  resolveExerciseInstructions,
   resolveExerciseName,
+  type CatalogInstructionSource,
   type CatalogNameSource,
 } from "./catalogLabels"
+import type { ExerciseInstructions } from "@/types/database"
 
 const row = (overrides: Partial<CatalogNameSource> = {}): CatalogNameSource => ({
   exercise: { name: "Développé couché", name_en: "Bench Press" },
   name_snapshot: "Développé couché (snapshot)",
+  ...overrides,
+})
+
+const FRENCH: ExerciseInstructions = {
+  setup: ["Allonge-toi sur le banc"],
+  movement: ["Pousse la barre"],
+  breathing: ["Expire à la poussée"],
+  common_mistakes: ["Coudes trop écartés"],
+}
+
+const ENGLISH: ExerciseInstructions = {
+  setup: ["Lie back on the bench"],
+  movement: ["Press the bar up"],
+  breathing: ["Exhale on the push"],
+  common_mistakes: ["Flared elbows"],
+}
+
+const instructionRow = (
+  overrides: Partial<CatalogInstructionSource> = {},
+): CatalogInstructionSource => ({
+  instructions: FRENCH,
+  instructions_en: ENGLISH,
+  instructions_en_status: "clean",
   ...overrides,
 })
 
@@ -79,6 +105,97 @@ describe("resolveExerciseName", () => {
 
   it("treats a region-tagged English locale as English", () => {
     expect(resolveExerciseName(row(), "en-US")).toBe("Bench Press")
+  })
+})
+
+describe("resolveExerciseInstructions", () => {
+  it("shows the English block to an English reader when the status is clean", () => {
+    expect(resolveExerciseInstructions(instructionRow(), "en")).toBe(ENGLISH)
+  })
+
+  // A half-English panel is the defect the issue reported, so parity is checked
+  // on the whole block: one section short and the reader gets French throughout.
+  it("falls back to French in one block when a section is missing in English", () => {
+    const source = instructionRow({
+      instructions_en: { ...ENGLISH, breathing: [] },
+    })
+
+    expect(resolveExerciseInstructions(source, "en")).toBe(FRENCH)
+  })
+
+  // The `hasInstructions` block the three display surfaces used to duplicate:
+  // "nothing to show" is the resolver's answer, not the caller's guess.
+  it("returns null when every section is empty on both sides", () => {
+    const empty: ExerciseInstructions = {
+      setup: [],
+      movement: [],
+      breathing: ["   "],
+      common_mistakes: [],
+    }
+    const source = instructionRow({
+      instructions: empty,
+      instructions_en: empty,
+    })
+
+    expect(resolveExerciseInstructions(source, "en")).toBeNull()
+    expect(resolveExerciseInstructions(source, "fr")).toBeNull()
+  })
+
+  it("shows the English block once a human approved it", () => {
+    const source = instructionRow({ instructions_en_status: "approved" })
+
+    expect(resolveExerciseInstructions(source, "en")).toBe(ENGLISH)
+  })
+
+  // Fail closed: anything that isn't an explicit go-ahead renders French. An
+  // unknown status is the interesting row — a vocabulary added tomorrow, or a
+  // typo, must not reach an English reader as English.
+  it.each(["flagged", "pending", "CLEAN", "", null, undefined])(
+    "renders French to an English reader when the status is %o",
+    (instructions_en_status) => {
+      const source = instructionRow({ instructions_en_status })
+
+      expect(resolveExerciseInstructions(source, "en")).toBe(FRENCH)
+    },
+  )
+
+  // SLIM and LABEL projections carry no status column at all; the row that
+  // reaches a display surface from one of them must still read French.
+  it("renders French when the status never made it into the projection", () => {
+    const source: CatalogInstructionSource = {
+      instructions: FRENCH,
+      instructions_en: ENGLISH,
+    }
+
+    expect(resolveExerciseInstructions(source, "en")).toBe(FRENCH)
+  })
+
+  it.each(["fr", "fr-FR"])(
+    "never returns the English block to a %s reader, clean status or not",
+    (locale) => {
+      expect(resolveExerciseInstructions(instructionRow(), locale)).toBe(FRENCH)
+    },
+  )
+
+  it.each(["clean", "flagged", "approved", null, undefined])(
+    "renders French identically whatever the status says (%o)",
+    (instructions_en_status) => {
+      const source = instructionRow({
+        instructions_en: null,
+        instructions_en_status,
+      })
+
+      expect(resolveExerciseInstructions(source, "en")).toBe(FRENCH)
+      expect(resolveExerciseInstructions(source, "fr")).toBe(FRENCH)
+    },
+  )
+
+  it("returns null rather than throwing when the row carries no instructions", () => {
+    expect(resolveExerciseInstructions({}, "en")).toBeNull()
+  })
+
+  it("treats a region-tagged English locale as English", () => {
+    expect(resolveExerciseInstructions(instructionRow(), "en-GB")).toBe(ENGLISH)
   })
 })
 

--- a/src/lib/catalogLabels.ts
+++ b/src/lib/catalogLabels.ts
@@ -7,6 +7,7 @@
  */
 import { EQUIPMENT_TAXONOMY } from "@/lib/catalogTaxonomy"
 import { MUSCLE_TAXONOMY } from "@/lib/trainingBalance"
+import type { ExerciseInstructions } from "@/types/database"
 
 /**
  * `exercise` is required, though nullable — pass `exercise: null` when there is
@@ -56,6 +57,77 @@ export function resolveExerciseName(
     clean(source.exercise_name_snapshot) ??
     ""
   )
+}
+
+/**
+ * Every column the display rule reads. All optional: a row that came through a
+ * projection without them (SLIM, LABEL) is a legitimate input, and the rule
+ * fails closed on it rather than making the caller pre-fill nulls.
+ */
+export interface CatalogInstructionSource {
+  instructions?: ExerciseInstructions | null
+  instructions_en?: ExerciseInstructions | null
+  instructions_en_status?: string | null
+}
+
+/** Statuses that clear the English block for display. Anything else is French. */
+const DISPLAYABLE_EN_STATUS: ReadonlySet<string> = new Set(["clean", "approved"])
+
+const SECTIONS = [
+  "setup",
+  "movement",
+  "breathing",
+  "common_mistakes",
+] as const satisfies readonly (keyof ExerciseInstructions)[]
+
+/** Sections holding at least one step that isn't blank. */
+const filledSections = (
+  block: ExerciseInstructions | null | undefined,
+): ReadonlySet<string> =>
+  new Set(
+    SECTIONS.filter((section) =>
+      (block?.[section] ?? []).some((step) => clean(step)),
+    ),
+  )
+
+/**
+ * `instructions_en` (English readers, released status, section parity) →
+ * `instructions` → `null`.
+ *
+ * `null` means "nothing to show", so the caller renders nothing rather than
+ * re-deriving that from four array lengths — the check three surfaces used to
+ * duplicate.
+ *
+ * The fallback is **whole-block**: an English translation missing a section the
+ * French fills sends the reader back to French entirely, because a half-English
+ * panel is the defect this replaces. Sentence counts are deliberately not
+ * compared — a translator legitimately merges two sentences into one.
+ *
+ * Every other outcome fails closed to French: an unknown status, a null one, or
+ * a projection that never carried the column. Blank steps count as absent, but
+ * the block itself is returned untouched, so French output is byte-identical to
+ * what the surfaces rendered before this rule existed.
+ */
+export function resolveExerciseInstructions(
+  source: CatalogInstructionSource,
+  locale: string,
+): ExerciseInstructions | null {
+  const candidate =
+    isEnglish(locale) &&
+    DISPLAYABLE_EN_STATUS.has(source.instructions_en_status ?? "")
+      ? source.instructions_en
+      : null
+
+  const french = source.instructions ?? null
+  const frenchSections = filledSections(french)
+  const englishSections = filledSections(candidate)
+  const hasParity = [...frenchSections].every((section) =>
+    englishSections.has(section),
+  )
+
+  const resolved = candidate && hasParity ? candidate : french
+
+  return filledSections(resolved).size > 0 ? resolved : null
 }
 
 const MUSCLES: ReadonlySet<string> = new Set(MUSCLE_TAXONOMY)

--- a/src/lib/exerciseSelects.test.ts
+++ b/src/lib/exerciseSelects.test.ts
@@ -54,4 +54,28 @@ describe("exercise selects", () => {
       expect.arrayContaining(["muscle_group", "equipment"]),
     )
   })
+
+  // `useWorkoutExercises` warms the `["exercise", id]` cache from FULL and
+  // `ExerciseInstructionsPanel` reads it without refetching. Drop either column
+  // here and the panel opened from a session resolves French while the same
+  // page opened from the library resolves English.
+  it("carries the columns the instruction resolver reads", () => {
+    expect(columns(FULL_EXERCISE_SELECT)).toEqual(
+      expect.arrayContaining(["instructions", "instructions_en", "instructions_en_status"]),
+    )
+  })
+
+  // The audit is for the review screen only, and it travels by its own RPC.
+  it("leaves the translation audit out of every projection", () => {
+    Object.values(SELECTS).forEach((select) => {
+      expect(columns(select)).not.toContain("instructions_en_audit")
+    })
+  })
+
+  it.each([SLIM_EXERCISE_SELECT, LABEL_EXERCISE_SELECT])(
+    "keeps instructions out of the light projections (%s)",
+    (select) => {
+      expect(columns(select).filter((c) => c.startsWith("instructions"))).toEqual([])
+    },
+  )
 })

--- a/src/lib/exerciseSelects.ts
+++ b/src/lib/exerciseSelects.ts
@@ -32,9 +32,15 @@ export const SLIM_EXERCISE_SELECT =
  *
  * Mirrors the full `Exercise` type so the returned shape stays safe to cache
  * under `["exercise", id]` for both session and admin consumers.
+ *
+ * `instructions_en` and its status ride along because the same cache entry
+ * feeds `ExerciseInstructionsPanel` with no refetch: a row missing the status
+ * resolves to French, so a truncated projection would show French in a session
+ * and English in the library. `instructions_en_audit` stays out — the review
+ * screen fetches it through its own RPC.
  */
 export const FULL_EXERCISE_SELECT =
-  "id, name, name_en, emoji, muscle_group, equipment, image_url, difficulty_level, is_system, measurement_type, default_duration_seconds, secondary_muscles, instructions, youtube_url, source, reviewed_at, reviewed_by, created_at"
+  "id, name, name_en, emoji, muscle_group, equipment, image_url, difficulty_level, is_system, measurement_type, default_duration_seconds, secondary_muscles, instructions, instructions_en, instructions_en_status, youtube_url, source, reviewed_at, reviewed_by, created_at"
 
 /**
  * Smallest projection that can render a localized label (ADR 0010): the name

--- a/src/locales/en/exercise.json
+++ b/src/locales/en/exercise.json
@@ -1,5 +1,6 @@
 {
   "howToPerform": "How to perform",
+  "instructionsFor": "Instructions: {{name}}",
   "setup": "Setup",
   "movement": "Movement",
   "breathing": "Breathing",

--- a/src/locales/fr/exercise.json
+++ b/src/locales/fr/exercise.json
@@ -1,5 +1,6 @@
 {
   "howToPerform": "Comment exécuter",
+  "instructionsFor": "Consignes : {{name}}",
   "setup": "Mise en place",
   "movement": "Mouvement",
   "breathing": "Respiration",

--- a/src/test/instructionResolution.arch.test.ts
+++ b/src/test/instructionResolution.arch.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest"
+
+/**
+ * Guards for the failure mode ADR 0010 documented: a display surface that
+ * forgets the resolver keeps rendering French, which is invisible to a
+ * French-speaking reviewer. Neither of these can be caught by reading a diff.
+ */
+
+const componentSources = import.meta.glob("../components/**/*.{ts,tsx}", {
+  query: "?raw",
+  eager: true,
+  import: "default",
+}) as Record<string, string>
+
+const migrationSources = import.meta.glob("../../supabase/migrations/*.sql", {
+  query: "?raw",
+  eager: true,
+  import: "default",
+}) as Record<string, string>
+
+const repoPath = (globKey: string) =>
+  globKey.startsWith("../../")
+    ? globKey.slice("../../".length)
+    : `src/${globKey.slice("../".length)}`
+
+/**
+ * Blanks out string literals before the scan. Without this, the i18n key
+ * `t("blockRunner.instructions")` reads as an instruction access and the guard
+ * cries wolf at a component that renders no instructions at all.
+ */
+const code = (source: string) =>
+  source.replace(/"[^"\n]*"|'[^'\n]*'|`[^`]*`/g, '""')
+
+/**
+ * The two files that legitimately read the French block: both edit or count the
+ * *source* content in admin, neither renders instructions to a reader. Listed
+ * rather than pattern-matched so that adding one is a deliberate act.
+ */
+const FRENCH_SOURCE_READERS = [
+  "src/components/admin/exercise-form/transforms.ts",
+  "src/components/admin/exercises-table/columns.tsx",
+]
+
+describe("instruction reads in components", () => {
+  it("routes every display surface through the resolver", () => {
+    const readers = Object.entries(componentSources)
+      .filter(([path]) => !/\.test\.tsx?$/.test(path))
+      .filter(([, source]) => /\.instructions\w*/.test(code(source)))
+      .map(([path]) => repoPath(path))
+      .sort()
+
+    expect(readers).toEqual(FRENCH_SOURCE_READERS)
+  })
+})
+
+describe("search_exercises", () => {
+  // SwapExerciseSheet hands a paginated row straight to ExerciseDetailSheet
+  // without refetching by id, so this RPC is the only path carrying the English
+  // columns to that surface. It does so purely because it returns whole rows.
+  // Asserting it against a live database would need one; this is the strongest
+  // static statement of the same property.
+  const definitions = Object.entries(migrationSources)
+    .filter(([, sql]) => /FUNCTION\s+search_exercises\s*\(/.test(sql))
+    .sort(([a], [b]) => a.localeCompare(b))
+
+  const [path, sql] = definitions[definitions.length - 1] ?? []
+
+  it("is defined exactly where this guard expects it", () => {
+    expect(repoPath(path ?? "")).toBe(
+      "supabase/migrations/20260326120000_search_exercises.sql",
+    )
+  })
+
+  it("returns whole exercise rows, so new columns flow without a migration", () => {
+    expect(sql).toMatch(/RETURNS SETOF exercises/)
+  })
+
+  it("projects e.* rather than an explicit column list", () => {
+    const projections = [
+      ...(sql ?? "").matchAll(/RETURN QUERY\s+SELECT\s+([^\n]+)/g),
+    ].map(([, projection]) => projection.trim())
+
+    expect(projections).toEqual(["e.*", "e.*"])
+  })
+
+  it("carries the English instruction columns, which sit on exercises", () => {
+    const added = Object.values(migrationSources).flatMap((migration) =>
+      [
+        ...migration.matchAll(
+          /ALTER TABLE exercises\s+ADD COLUMN IF NOT EXISTS\s+(\w+)/g,
+        ),
+      ].map(([, column]) => column),
+    )
+
+    expect(added).toEqual(
+      expect.arrayContaining(["instructions_en", "instructions_en_status"]),
+    )
+  })
+})

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -5,6 +5,26 @@ export interface ExerciseInstructions {
   common_mistakes: string[]
 }
 
+/**
+ * Trace left by the translation pipeline on `exercises.instructions_en_audit`.
+ *
+ * Nothing reads it at display time — it exists for the review screen, and the
+ * contract lives here because T157 writes it and T158 reads it in parallel.
+ */
+export interface TranslationAudit {
+  model: string
+  prompt_version: number
+  translated_at: string
+  checker_model: string | null
+  gate_flags: string[]
+  objections: {
+    section: keyof ExerciseInstructions
+    index: number
+    verdict: string
+    note: string
+  }[]
+}
+
 export interface Exercise {
   id: string
   name: string
@@ -14,6 +34,12 @@ export interface Exercise {
   created_at: string
   youtube_url: string | null
   instructions: ExerciseInstructions | null
+  /** English translation, same shape. Only shown when the status allows it. */
+  instructions_en?: ExerciseInstructions | null
+  /** `clean` | `flagged` | `approved`; null means never translated. */
+  instructions_en_status?: string | null
+  instructions_en_reviewed_at?: string | null
+  instructions_en_audit?: TranslationAudit | null
   image_url: string | null
   equipment: string
   difficulty_level: "beginner" | "intermediate" | "advanced" | null

--- a/supabase/migrations/20260802120000_add_english_instructions.sql
+++ b/supabase/migrations/20260802120000_add_english_instructions.sql
@@ -1,0 +1,29 @@
+-- English exercise instructions (T156, #417).
+--
+-- Nullable with no default on purpose: NULL on the status means "never
+-- translated", which is not the same as "translated and clean". A DEFAULT would
+-- erase that distinction, exactly as it would have on `user_profiles.locale`.
+--
+-- No RLS change needed — the new columns inherit the policies of
+-- `20260313140002_exercises_rls.sql`. A NULL status passes the CHECK, since
+-- `NULL IN (...)` is NULL, not false.
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en jsonb;
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en_status text;
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en_reviewed_at timestamptz;
+ALTER TABLE exercises ADD COLUMN IF NOT EXISTS instructions_en_audit jsonb;
+
+ALTER TABLE exercises
+  ADD CONSTRAINT exercises_instructions_en_status_chk
+  CHECK (instructions_en_status IN ('clean', 'flagged', 'approved'));
+
+COMMENT ON COLUMN exercises.instructions_en IS
+  'English translation of `instructions`, same shape. Written whole or not at all.';
+
+COMMENT ON COLUMN exercises.instructions_en_status IS
+  'clean | flagged | approved. NULL = never translated. The only column read at render: anything but clean/approved shows French.';
+
+COMMENT ON COLUMN exercises.instructions_en_reviewed_at IS
+  'Human review of the translation. Deliberately not `reviewed_at`, which drives the content-review queue.';
+
+COMMENT ON COLUMN exercises.instructions_en_audit IS
+  'Translator/checker trace for the review screen. Never read at render.';


### PR DESCRIPTION
First slice of the #436 epic, carrying the epic's design docs with it so the plan can be read next to the code that implements it.

## What

- Migration adding `instructions_en`, `instructions_en_status`, `instructions_en_reviewed_at` and `instructions_en_audit` to `exercises` — all nullable, no default.
- `resolveExerciseInstructions` in `catalogLabels.ts`, plus `exerciseInstructions(row)` on `useCatalogLabels`.
- The three surfaces that render instructions now go through it: `ExerciseInstructionsPanel`, `ExerciseInfoDialog`, `ExerciseDetailSheet`.
- Two guard tests, and a first test file each for the two surfaces that had none.
- Epic Brief, Tech Plan and tickets T156–T161.

**No English content exists yet, so this is a no-op on screen.** That is deliberate: it lets the migration and the resolution rule be verified apart from the content that T157 will produce.

## Why

The details panel is half translated today — headings go through i18next, the body is French on all 372 rows. Since #415 shipped, instructions are the last French island, and more conspicuous than before precisely because everything around them was fixed.

## How

Display-time resolution, per ADR 0010: read from the joined catalog row, change no write path. Unlike names, instructions are snapshotted nowhere, so there is no frozen-record problem to solve here.

`resolveExerciseInstructions` returns `ExerciseInstructions | null`, and `null` means "nothing to show" — which folds in the `hasInstructions` check that all three surfaces used to duplicate. English is served only when the locale is English, the status is `clean` or `approved`, and every section the French fills is also filled in English. **Everything else fails closed to French**: an unknown status, a null one, or a projection that never carried the column. A French cue an English reader can't parse is a disappointment; a wrong cue that looks authoritative is an injury.

The fallback is whole-block, never per-section — a half-English panel is the defect this replaces. Sentence counts are deliberately not compared, since a translator legitimately merges two sentences into one.

The columns join `FULL_EXERCISE_SELECT` out of necessity rather than convenience: `useWorkoutExercises` warms the `["exercise", id]` cache from that projection and the panel reads it without refetching, so a truncated projection would show French in a session and English in the library — a divergence invisible in review.

Both guards were verified to bite by breaking them on purpose, then reverting. The architecture test pins the two admin files that legitimately read the French block (`exercise-form/transforms.ts` editing the source, `exercises-table/columns.tsx` for the `has_instructions` indicator); it asserts on a sorted list, so a new direct reader fails and so does a stale allowlist entry. The second test pins `search_exercises` to `RETURNS SETOF exercises` with `SELECT e.*` — the only reason `SwapExerciseSheet`, the one surface that passes a paginated row straight through, will ever see a translation.

## Notes for review

- The migration is **written, not applied**. `instructions_en_status` accepts `clean | flagged | approved` via a CHECK, and `NULL` passes it since `NULL IN (...)` is `NULL`, not false. Needs a `db push` before T157 runs.
- `instructions_en_status` is typed `string | null` rather than the three-value union on purpose: handling a status outside the vocabulary *is* the resolver's job, and a union would force a cast in the very test that proves it.
- The four new `Exercise` fields are optional rather than required-nullable, since SLIM and LABEL projections genuinely don't carry them.
- A fourth surface exists that this PR does **not** fix: `supabase/functions/mcp/tools/getExerciseDetails.ts` renders French under hardcoded English headers. Out of scope on the merits — MCP doesn't know the reader's locale — and recorded in #436.

Part of #436 · Related #417 · Extends ADR 0010

Made with [Cursor](https://cursor.com)