### PR TITLE
feat(i18n): translation pipeline & quality gate (T157)

### DIFF
--- a/docs/T157_—_Translation_pipeline_and_quality_gate.md
+++ b/docs/T157_—_Translation_pipeline_and_quality_gate.md
@@ -31,7 +31,7 @@ Deux corrections obligatoires, chacune adossée à un test nommé :
 | Faux positif mesuré au spike | Correction |
 |---|---|
 | « pupitre Larry Scott » signalé comme matériel inventé alors que *preacher bench* est la traduction juste | Synonymes de matériel reconnus |
-| « Lower back to 90° » signalé comme muscle non traduit, où *lower* est un verbe | Désambiguïsation par position dans la phrase |
+| « Lower back to 90° » signalé par la **bavure de casse** : *Lower back* est le libellé anglais des lombaires, et le filet analysait le bloc entier concaténé, si bien que toute phrase sauf la première perdait l'exemption d'ouverture de phrase | Bavure de casse évaluée phrase par phrase |
 
 Les frontières de mots utilisent des lookarounds Unicode, **pas `\b`**, qui échoue sur `élastique` et `épaules`.
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "dedup-exercises": "tsx scripts/dedup-exercises.ts",
     "audit-muscles": "tsx scripts/audit-muscle-tags.ts",
     "seed:history": "tsx scripts/seed-local-history.ts",
-    "backfill:was-pr": "tsx scripts/backfill-was-pr.ts"
+    "backfill:was-pr": "tsx scripts/backfill-was-pr.ts",
+    "translate-instructions": "tsx --tsconfig tsconfig.app.json scripts/translate-instructions.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/translate-instructions.ts
+++ b/scripts/translate-instructions.ts
@@ -399,6 +399,22 @@ interface RowResult {
 
 const QUOTA_STRIKES = 2
 
+/**
+ * The `approved` guard, restated in the UPDATE clause so the database enforces
+ * it. `isTranslationCandidate` reads a snapshot taken at selection time; a row
+ * approved in the review UI while the wave is running would otherwise be
+ * overwritten under the reviewer, and `approved` is the one verdict this
+ * pipeline must never touch.
+ *
+ * `.neq("instructions_en_status", "approved")` is the obvious spelling and is
+ * wrong: the column is NULL on every never-translated row, and `NULL <>
+ * 'approved'` is NULL rather than true in SQL. That filter would match no
+ * untranslated row at all, so the pipeline would write nothing and report every
+ * row as written.
+ */
+const NOT_APPROVED =
+  "instructions_en_status.is.null,instructions_en_status.neq.approved"
+
 const describe = (result: RowResult): string => {
   const objections = (result.objections ?? []).map(
     ({ section, index, verdict, note }) => `${section}.${index} ${verdict}: ${note}`,
@@ -444,8 +460,26 @@ const translateRow = async (row: ExerciseRow): Promise<RowResult> => {
     }
   }
 
-  const { error } = await supabase.from("exercises").update(update).eq("id", row.id)
+  const { data: touched, error } = await supabase
+    .from("exercises")
+    .update(update)
+    .eq("id", row.id)
+    .or(NOT_APPROVED)
+    .select("id")
   if (error) throw new Error(`writing ${row.id}: ${error.message}`)
+
+  // Asking for the affected rows back is what makes the guard legible. Without
+  // it, "approved a second ago" and "written" produce the same silence, and a
+  // script that reports a write it did not perform is worse than one that errors.
+  if ((touched ?? []).length === 0) {
+    return {
+      row,
+      state: "skipped",
+      flags,
+      objections,
+      reason: "approved while the run was in flight; left untouched",
+    }
+  }
 
   return {
     row,

--- a/scripts/translate-instructions.ts
+++ b/scripts/translate-instructions.ts
@@ -144,19 +144,38 @@ const ROW_COLUMNS =
 
 const PAGE_SIZE = 1000
 
+/**
+ * PostgREST truncates a response at `max_rows` — 1000, in
+ * `supabase/config.toml` — and says nothing when it does. The catalog holds 372
+ * rows today, so this is headroom rather than a bug; the point is that the day
+ * it crosses the cap, the rows past it would simply never be translated and no
+ * output would mention them.
+ *
+ * `name` orders the wave, `id` makes that order total: two exercises sharing a
+ * name would otherwise be free to swap places between pages.
+ */
 const fetchCandidates = async (): Promise<ExerciseRow[]> => {
-  const query = supabase
-    .from("exercises")
-    .select(ROW_COLUMNS)
-    .not("instructions", "is", null)
-    .order("name", { ascending: true })
+  const rows: ExerciseRow[] = []
 
-  const { data, error } = await (wave.kind === "ids"
-    ? query.in("id", wave.ids)
-    : query)
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const query = supabase
+      .from("exercises")
+      .select(ROW_COLUMNS)
+      .not("instructions", "is", null)
+      .order("name", { ascending: true })
+      .order("id", { ascending: true })
+      .range(from, from + PAGE_SIZE - 1)
 
-  if (error) throw new Error(`fetching exercises: ${error.message}`)
-  return (data ?? []) as ExerciseRow[]
+    const { data, error } = await (wave.kind === "ids"
+      ? query.in("id", wave.ids)
+      : query)
+    if (error) throw new Error(`fetching exercises: ${error.message}`)
+
+    const page = (data ?? []) as ExerciseRow[]
+    rows.push(...page)
+
+    if (page.length < PAGE_SIZE) return rows
+  }
 }
 
 /**

--- a/scripts/translate-instructions.ts
+++ b/scripts/translate-instructions.ts
@@ -175,6 +175,11 @@ const fetchLoggedSets = async (): Promise<Map<string, number>> => {
     const { data, error } = await supabase
       .from("set_logs")
       .select("exercise_id")
+      // Offset paging over an unordered select is not paging. Postgres owes no
+      // row order without ORDER BY, so page 2 can repeat a row from page 1 and
+      // omit another — and these counts are what order the waves. `id` is
+      // unique, so the order it imposes is total.
+      .order("id", { ascending: true })
       .range(from, from + PAGE_SIZE - 1)
     if (error) throw new Error(`counting set_logs: ${error.message}`)
 
@@ -190,6 +195,11 @@ const applyWave = async (rows: readonly ExerciseRow[]): Promise<ExerciseRow[]> =
 
   const logged = await fetchLoggedSets()
   const countOf = (row: ExerciseRow) => logged.get(row.id) ?? 0
+
+  // The tally decides the wave, so it is worth being able to see it: a paging
+  // bug shows up here as a total that does not match `select count(*)`.
+  const total = [...logged.values()].reduce((sum, count) => sum + count, 0)
+  console.log(`counted ${total} logged sets across ${logged.size} exercises`)
 
   return wave.kind === "unlogged"
     ? rows.filter((row) => countOf(row) === 0)

--- a/scripts/translate-instructions.ts
+++ b/scripts/translate-instructions.ts
@@ -159,9 +159,19 @@ const fetchCandidates = async (): Promise<ExerciseRow[]> => {
   return (data ?? []) as ExerciseRow[]
 }
 
-/** Logged sets per exercise, the metric the waves are ordered on. */
+/**
+ * Logged sets per exercise, the metric the waves are ordered on.
+ *
+ * Each page is folded into the tally as it arrives and then dropped, so the
+ * footprint is one entry per distinct exercise — a few hundred — rather than
+ * one string per logged set, which is a table that only ever grows.
+ */
 const fetchLoggedSets = async (): Promise<Map<string, number>> => {
-  const page = async (from: number, acc: string[]): Promise<string[]> => {
+  const counts = new Map<string, number>()
+
+  // The cursor is the loop's own state: "keep paging until a short page" is the
+  // early-exit that no `.map` or `.reduce` over a known list can express.
+  for (let from = 0; ; from += PAGE_SIZE) {
     const { data, error } = await supabase
       .from("set_logs")
       .select("exercise_id")
@@ -169,14 +179,10 @@ const fetchLoggedSets = async (): Promise<Map<string, number>> => {
     if (error) throw new Error(`counting set_logs: ${error.message}`)
 
     const ids = (data ?? []).map((row) => row.exercise_id as string)
-    const total = [...acc, ...ids]
-    return ids.length < PAGE_SIZE ? total : page(from + PAGE_SIZE, total)
-  }
+    ids.reduce((tally, id) => tally.set(id, (tally.get(id) ?? 0) + 1), counts)
 
-  return (await page(0, [])).reduce(
-    (counts, id) => counts.set(id, (counts.get(id) ?? 0) + 1),
-    new Map<string, number>(),
-  )
+    if (ids.length < PAGE_SIZE) return counts
+  }
 }
 
 const applyWave = async (rows: readonly ExerciseRow[]): Promise<ExerciseRow[]> => {

--- a/scripts/translate-instructions.ts
+++ b/scripts/translate-instructions.ts
@@ -1,0 +1,479 @@
+/**
+ * Translate `exercises.instructions` (French) into `exercises.instructions_en`
+ * (English), cross-check the result with a second model from another provider,
+ * and write content, status and audit in a single update per row (#417, T157).
+ *
+ * Dry-run by default. Nothing reaches the database without `--apply`.
+ *
+ *   npm run translate-instructions                       # every candidate, dry-run
+ *   npm run translate-instructions -- --ids a,b,c        # explicit rows
+ *   npm run translate-instructions -- --unlogged         # never-logged long tail
+ *   npm run translate-instructions -- --top 60           # 60 most-logged rows
+ *   npm run translate-instructions -- --ids a,b,c --apply
+ *   npm run translate-instructions -- --top 60 --force --apply
+ *
+ * Flags: `--apply` writes, `--force` retranslates rows that already have
+ * English (never `approved` ones), `--verbose` prints the produced block.
+ *
+ * Run it through the npm script, or pass `--tsconfig tsconfig.app.json` to tsx
+ * yourself: the `@/*` alias the shared libs use is only declared there.
+ *
+ * Requires VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY and GEMINI_API_KEY in
+ * `.env` / `.env.local`. GROQ_API_KEY is optional by design — without a
+ * cross-checker every row lands on `flagged`, which renders French, and that is
+ * the correct outcome rather than a reason to stop.
+ */
+import "./load-env.js"
+import { createClient } from "@supabase/supabase-js"
+
+import { checkTranslation, gateFlags } from "../src/lib/instructionQuality"
+import {
+  buildPrompt,
+  buildReviewPrompt,
+  parseInstructions,
+  parseObjections,
+  type Prompt,
+  type TranslationObjection,
+} from "../src/lib/instructionPrompt"
+import {
+  buildTranslationUpdate,
+  isTranslationCandidate,
+  type PipelineStatus,
+} from "../src/lib/translationPipeline"
+import type { ExerciseInstructions } from "../src/types/database"
+
+// ---------- CLI ----------
+
+const argv = process.argv.slice(2)
+const hasFlag = (flag: string) => argv.includes(flag)
+
+/** Accepts both `--top 60` and `--top=60`. */
+const optionValue = (flag: string): string | undefined => {
+  const inline = argv.find((arg) => arg.startsWith(`${flag}=`))
+  if (inline) return inline.slice(flag.length + 1)
+  const index = argv.indexOf(flag)
+  return index === -1 ? undefined : argv[index + 1]
+}
+
+const APPLY = hasFlag("--apply")
+const FORCE = hasFlag("--force")
+const VERBOSE = hasFlag("--verbose")
+
+type Wave =
+  | { kind: "ids"; ids: string[] }
+  | { kind: "unlogged" }
+  | { kind: "top"; count: number }
+  | { kind: "all" }
+
+const wave = ((): Wave => {
+  const ids = optionValue("--ids")
+  if (ids !== undefined) {
+    return {
+      kind: "ids",
+      ids: ids
+        .split(",")
+        .map((id) => id.trim())
+        .filter((id) => id !== ""),
+    }
+  }
+  if (hasFlag("--unlogged")) return { kind: "unlogged" }
+  const top = optionValue("--top")
+  if (top !== undefined) return { kind: "top", count: Number(top) }
+  return { kind: "all" }
+})()
+
+if (wave.kind === "ids" && wave.ids.length === 0) {
+  console.error("--ids needs a comma-separated list of exercise ids")
+  process.exit(1)
+}
+if (wave.kind === "top" && (!Number.isInteger(wave.count) || wave.count <= 0)) {
+  console.error("--top needs a positive integer")
+  process.exit(1)
+}
+
+// ---------- Env ----------
+
+/**
+ * An exported-but-empty shell variable shadows the `.env` value, because dotenv
+ * never overrides an already-defined name. Blanking the Supabase variables is
+ * the documented way to reproduce CI locally, so an empty string has to count
+ * as absent rather than as a key.
+ */
+const envValue = (name: string): string | undefined => {
+  const value = process.env[name]?.trim()
+  return value === "" ? undefined : value
+}
+
+const SUPABASE_URL = envValue("VITE_SUPABASE_URL")
+const SERVICE_ROLE_KEY = envValue("SUPABASE_SERVICE_ROLE_KEY")
+const GEMINI_API_KEY = envValue("GEMINI_API_KEY")
+const GROQ_API_KEY = envValue("GROQ_API_KEY")
+
+const GEMINI_MODEL = envValue("TRANSLATION_GEMINI_MODEL") ?? "gemini-2.5-flash"
+const GROQ_MODEL =
+  envValue("TRANSLATION_GROQ_MODEL") ??
+  envValue("ENRICHMENT_GROQ_MODEL") ??
+  "llama-3.3-70b-versatile"
+
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY || !GEMINI_API_KEY) {
+  console.error(
+    "Missing env. Need VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY and GEMINI_API_KEY.",
+  )
+  process.exit(1)
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: { persistSession: false },
+})
+
+// ---------- Rows ----------
+
+interface ExerciseRow {
+  id: string
+  name: string
+  name_en: string | null
+  muscle_group: string
+  equipment: string
+  instructions: ExerciseInstructions | null
+  instructions_en: ExerciseInstructions | null
+  instructions_en_status: string | null
+}
+
+const ROW_COLUMNS =
+  "id, name, name_en, muscle_group, equipment, instructions, instructions_en, instructions_en_status"
+
+const PAGE_SIZE = 1000
+
+const fetchCandidates = async (): Promise<ExerciseRow[]> => {
+  const query = supabase
+    .from("exercises")
+    .select(ROW_COLUMNS)
+    .not("instructions", "is", null)
+    .order("name", { ascending: true })
+
+  const { data, error } = await (wave.kind === "ids"
+    ? query.in("id", wave.ids)
+    : query)
+
+  if (error) throw new Error(`fetching exercises: ${error.message}`)
+  return (data ?? []) as ExerciseRow[]
+}
+
+/** Logged sets per exercise, the metric the waves are ordered on. */
+const fetchLoggedSets = async (): Promise<Map<string, number>> => {
+  const page = async (from: number, acc: string[]): Promise<string[]> => {
+    const { data, error } = await supabase
+      .from("set_logs")
+      .select("exercise_id")
+      .range(from, from + PAGE_SIZE - 1)
+    if (error) throw new Error(`counting set_logs: ${error.message}`)
+
+    const ids = (data ?? []).map((row) => row.exercise_id as string)
+    const total = [...acc, ...ids]
+    return ids.length < PAGE_SIZE ? total : page(from + PAGE_SIZE, total)
+  }
+
+  return (await page(0, [])).reduce(
+    (counts, id) => counts.set(id, (counts.get(id) ?? 0) + 1),
+    new Map<string, number>(),
+  )
+}
+
+const applyWave = async (rows: readonly ExerciseRow[]): Promise<ExerciseRow[]> => {
+  if (wave.kind === "ids" || wave.kind === "all") return [...rows]
+
+  const logged = await fetchLoggedSets()
+  const countOf = (row: ExerciseRow) => logged.get(row.id) ?? 0
+
+  return wave.kind === "unlogged"
+    ? rows.filter((row) => countOf(row) === 0)
+    : [...rows].sort((a, b) => countOf(b) - countOf(a)).slice(0, wave.count)
+}
+
+// ---------- Providers ----------
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Groq answers an exhausted daily quota with a 43-minute `Retry-After`. Waiting
+ * it out would turn a wave into an afternoon, so a backoff longer than this
+ * counts as "provider unavailable" and the run moves on — flagging the row,
+ * which is the safe direction.
+ */
+const MAX_BACKOFF_MS = 120_000
+
+class ProviderUnavailableError extends Error {}
+
+const backoffMs = (response: Response, attempt: number): number => {
+  const retryAfter = Number(response.headers.get("retry-after"))
+  return Number.isFinite(retryAfter) && retryAfter > 0
+    ? retryAfter * 1000
+    : attempt * 15_000
+}
+
+/**
+ * Retries on 429 and 5xx, honouring the server's own `Retry-After` — the spike
+ * pattern, not `enrich-instructions.ts`, which ignores 429 and burns the quota
+ * answering nothing.
+ */
+const withRetry = async (
+  label: string,
+  send: () => Promise<Response>,
+  attempt = 1,
+): Promise<Response> => {
+  const response = await send()
+  if (response.status !== 429 && response.status < 500) return response
+  if (attempt > 4) return response
+
+  const waitMs = backoffMs(response, attempt)
+  if (waitMs > MAX_BACKOFF_MS) {
+    throw new ProviderUnavailableError(
+      `${label} asked for ${Math.round(waitMs / 1000)}s of backoff (HTTP ${response.status})`,
+    )
+  }
+  console.log(`   ${label}: HTTP ${response.status}, waiting ${Math.round(waitMs / 1000)}s`)
+  await sleep(waitMs)
+  return withRetry(label, send, attempt + 1)
+}
+
+interface GeminiResponse {
+  candidates?: Array<{
+    content?: { parts?: Array<{ text?: string; thought?: boolean }> }
+    finishReason?: string
+  }>
+  promptFeedback?: { blockReason?: string }
+}
+
+/**
+ * Thinking is switched off explicitly: thoughts are drawn from the output
+ * budget, and with it on the model spends the budget reasoning and returns an
+ * empty candidate.
+ */
+const callGemini = async (prompt: Prompt): Promise<string> => {
+  const response = await withRetry("gemini", () =>
+    fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-goog-api-key": GEMINI_API_KEY,
+        },
+        body: JSON.stringify({
+          systemInstruction: { parts: [{ text: prompt.system }] },
+          contents: [{ role: "user", parts: [{ text: prompt.user }] }],
+          generationConfig: {
+            temperature: 0.2,
+            maxOutputTokens: 8000,
+            responseMimeType: "application/json",
+            thinkingConfig: { thinkingBudget: 0 },
+          },
+        }),
+      },
+    ),
+  )
+
+  if (!response.ok) {
+    throw new Error(`gemini HTTP ${response.status}: ${(await response.text()).slice(0, 200)}`)
+  }
+
+  const data = (await response.json()) as GeminiResponse
+  const candidate = data.candidates?.[0]
+  const text = (candidate?.content?.parts ?? [])
+    .filter((part) => part.thought !== true)
+    .map((part) => part.text ?? "")
+    .join("")
+
+  if (!text) {
+    // Keep the reason: an empty candidate is either a safety block or a budget
+    // exhausted by thinking, and the two are fixed differently.
+    const why = data.promptFeedback?.blockReason ?? candidate?.finishReason ?? "empty candidate"
+    throw new Error(`gemini returned no text (${why})`)
+  }
+  return text
+}
+
+const callGroq = async (prompt: Prompt): Promise<string> => {
+  const response = await withRetry("groq", () =>
+    fetch("https://api.groq.com/openai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${GROQ_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: GROQ_MODEL,
+        messages: [
+          { role: "system", content: prompt.system },
+          { role: "user", content: prompt.user },
+        ],
+        max_tokens: 1200,
+        temperature: 0.1,
+        response_format: { type: "json_object" },
+      }),
+    }),
+  )
+
+  if (!response.ok) {
+    throw new Error(`groq HTTP ${response.status}: ${(await response.text()).slice(0, 200)}`)
+  }
+  const data = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>
+  }
+  return data.choices?.[0]?.message?.content ?? ""
+}
+
+/** Candidates always carry French instructions; the predicate guarantees it. */
+const promptSubject = (row: ExerciseRow) => ({
+  name: row.name,
+  name_en: row.name_en,
+  muscle_group: row.muscle_group,
+  equipment: row.equipment,
+  instructions: row.instructions as ExerciseInstructions,
+})
+
+/**
+ * `null` means "no second opinion", never "no objection". Every failure mode of
+ * the cross-checker collapses into it: no key, dead quota, HTTP error,
+ * unparseable verdict.
+ */
+const crossCheck = async (
+  row: ExerciseRow,
+  translation: ExerciseInstructions,
+): Promise<TranslationObjection[] | null> => {
+  if (!GROQ_API_KEY) return null
+  try {
+    const raw = await callGroq(buildReviewPrompt(promptSubject(row), translation))
+    return parseObjections(raw, translation)
+  } catch (error) {
+    console.log(`   cross-check unavailable: ${(error as Error).message}`)
+    return null
+  }
+}
+
+// ---------- Run ----------
+
+interface RowResult {
+  row: ExerciseRow
+  state: "written" | "previewed" | "skipped" | "halted"
+  status?: PipelineStatus
+  flags: string[]
+  objections: TranslationObjection[] | null
+  reason?: string
+}
+
+const QUOTA_STRIKES = 2
+
+const describe = (result: RowResult): string => {
+  const objections = (result.objections ?? []).map(
+    ({ section, index, verdict, note }) => `${section}.${index} ${verdict}: ${note}`,
+  )
+  const parts = [...result.flags, ...objections]
+  return parts.length === 0 ? "" : ` — ${parts.join("; ")}`
+}
+
+const translateRow = async (row: ExerciseRow): Promise<RowResult> => {
+  const subject = promptSubject(row)
+  const raw = await callGemini(buildPrompt(subject))
+  const translation = parseInstructions(raw)
+
+  if (!translation) {
+    // Skipped, columns untouched: the next run picks the row up again.
+    return {
+      row,
+      state: "skipped",
+      flags: [],
+      objections: null,
+      reason: `unparseable model answer (${raw.length} chars)`,
+    }
+  }
+
+  const flags = gateFlags(checkTranslation(subject, translation))
+  const objections = await crossCheck(row, translation)
+  const update = buildTranslationUpdate({
+    translation,
+    gateFlags: flags,
+    objections,
+    model: GEMINI_MODEL,
+    checkerModel: GROQ_MODEL,
+    translatedAt: new Date().toISOString(),
+  })
+
+  if (!APPLY) {
+    return {
+      row,
+      state: "previewed",
+      status: update.instructions_en_status,
+      flags,
+      objections,
+    }
+  }
+
+  const { error } = await supabase.from("exercises").update(update).eq("id", row.id)
+  if (error) throw new Error(`writing ${row.id}: ${error.message}`)
+
+  return {
+    row,
+    state: "written",
+    status: update.instructions_en_status,
+    flags,
+    objections,
+  }
+}
+
+const quotaExhausted = (results: readonly RowResult[]): boolean =>
+  results.length >= QUOTA_STRIKES &&
+  results.slice(-QUOTA_STRIKES).every((result) => result.reason?.startsWith("provider") === true)
+
+const candidates = (await fetchCandidates()).filter((row) =>
+  isTranslationCandidate(row, { force: FORCE }),
+)
+const rows = await applyWave(candidates)
+
+console.log(
+  `${APPLY ? "APPLY" : "DRY RUN"} · wave ${wave.kind}${FORCE ? " · force" : ""} · ` +
+    `${rows.length} row${rows.length === 1 ? "" : "s"} · ${GEMINI_MODEL} + ${GROQ_MODEL}\n`,
+)
+
+/**
+ * Sequential on purpose: both free tiers rate-limit per minute, and each row is
+ * written atomically, so an interruption leaves untouched rows at NULL and the
+ * next run resumes exactly where this one stopped.
+ */
+const results = await rows.reduce<Promise<RowResult[]>>(async (previous, row) => {
+  const done = await previous
+  const label = row.name_en ?? row.name
+
+  if (quotaExhausted(done)) {
+    return [...done, { row, state: "halted", flags: [], objections: null }]
+  }
+
+  try {
+    const result = await translateRow(row)
+    const icon = result.state === "skipped" ? "✗" : result.status === "clean" ? "✓" : "⚠"
+    console.log(`${icon} ${label}${result.reason ? ` — ${result.reason}` : describe(result)}`)
+    if (VERBOSE && result.state !== "skipped") {
+      console.log(JSON.stringify(result, null, 2))
+    }
+    return [...done, result]
+  } catch (error) {
+    const message = (error as Error).message
+    const reason =
+      error instanceof ProviderUnavailableError ? `provider unavailable: ${message}` : message
+    console.log(`✗ ${label} — ${reason}`)
+    return [...done, { row, state: "skipped", flags: [], objections: null, reason }]
+  }
+}, Promise.resolve([]))
+
+const count = (predicate: (result: RowResult) => boolean) => results.filter(predicate).length
+
+console.log(
+  `\n${count((r) => r.status === "clean")} clean · ` +
+    `${count((r) => r.status === "flagged")} flagged · ` +
+    `${count((r) => r.state === "skipped")} skipped · ` +
+    `${count((r) => r.state === "halted")} not attempted`,
+)
+
+if (!APPLY) {
+  console.log("Nothing was written. Pass --apply to persist.")
+}

--- a/src/lib/instructionPrompt.test.ts
+++ b/src/lib/instructionPrompt.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest"
+
+import source from "./instructionPrompt.ts?raw"
+import { importsOf } from "@/test/imports"
+import {
+  PROMPT_VERSION,
+  buildPrompt,
+  buildReviewPrompt,
+  parseInstructions,
+  parseObjections,
+  type PromptSubject,
+} from "./instructionPrompt"
+import type { ExerciseInstructions } from "@/types/database"
+
+const FRENCH: ExerciseInstructions = {
+  setup: ["Allonge-toi sur le banc"],
+  movement: ["Pousse la barre vers le haut"],
+  breathing: ["Expire à la poussée"],
+  common_mistakes: ["Arrondir le dos"],
+}
+
+const ENGLISH: ExerciseInstructions = {
+  setup: ["Lie back on the bench"],
+  movement: ["Press the bar up"],
+  breathing: ["Exhale on the push"],
+  common_mistakes: ["Rounding your back"],
+}
+
+const SUBJECT: PromptSubject = {
+  name: "Développé couché",
+  name_en: "Bench Press",
+  muscle_group: "Pectoraux",
+  equipment: "barbell",
+  instructions: FRENCH,
+}
+
+describe("purity", () => {
+  it.each(["react", "i18next", "@/lib/supabase", "@supabase"])(
+    "does not import %s",
+    (module) => {
+      expect(importsOf(source, module)).toEqual([])
+    },
+  )
+})
+
+describe("buildPrompt", () => {
+  it("stamps a version the audit can be diffed against", () => {
+    expect(PROMPT_VERSION).toBeGreaterThan(0)
+  })
+
+  it("passes the canonical labels in lowercase", () => {
+    const { system, user } = buildPrompt(SUBJECT)
+
+    // Title Case in the prompt is what taught the model to write "Chest" in the
+    // middle of a sentence, which the gate then flags as casing bleed.
+    expect(system).toContain('The target muscle is "chest"')
+    expect(system).toContain('This exercise\'s equipment is "barbell"')
+    expect(user).toContain("Muscle group: Pectoraux (English: Chest)")
+  })
+
+  it("names the exercise in English and carries the source block", () => {
+    const { system, user } = buildPrompt(SUBJECT)
+
+    expect(system).toContain('Refer to the exercise as "Bench Press"')
+    expect(user).toContain("Allonge-toi sur le banc")
+  })
+
+  it("falls back to the French name when there is no English one", () => {
+    const { system } = buildPrompt({ ...SUBJECT, name_en: null })
+
+    expect(system).toContain('Refer to the exercise as "Développé couché"')
+  })
+})
+
+describe("parseInstructions", () => {
+  it("reads a valid block", () => {
+    expect(parseInstructions(JSON.stringify(ENGLISH))).toEqual(ENGLISH)
+  })
+
+  it("reads a block wrapped in prose", () => {
+    const raw = `Sure! Here is the translation:\n\`\`\`json\n${JSON.stringify(ENGLISH)}\n\`\`\`\nHope this helps.`
+
+    expect(parseInstructions(raw)).toEqual(ENGLISH)
+  })
+
+  it("rejects invalid JSON", () => {
+    expect(parseInstructions('{"setup": ["Lie back",}')).toBeNull()
+  })
+
+  it("rejects an incomplete shape", () => {
+    const { breathing: _breathing, ...missingSection } = ENGLISH
+
+    expect(parseInstructions(JSON.stringify(missingSection))).toBeNull()
+  })
+
+  it("rejects a section holding something other than strings", () => {
+    const raw = JSON.stringify({ ...ENGLISH, movement: [{ text: "Press up" }] })
+
+    expect(parseInstructions(raw)).toBeNull()
+  })
+
+  it.each([null, undefined, "", "no json at all"])(
+    "rejects %o",
+    (raw) => {
+      expect(parseInstructions(raw)).toBeNull()
+    },
+  )
+})
+
+describe("buildReviewPrompt", () => {
+  it("aligns every pair under its section and index", () => {
+    const { user } = buildReviewPrompt(SUBJECT, ENGLISH)
+
+    expect(user).toContain("[setup 0]\n  FR: Allonge-toi sur le banc\n  EN: Lie back on the bench")
+    expect(user).toContain("[common_mistakes 0]")
+  })
+
+  it("skips a French sentence the translation has no counterpart for", () => {
+    const truncated: ExerciseInstructions = { ...ENGLISH, movement: [] }
+
+    expect(buildReviewPrompt(SUBJECT, truncated).user).not.toContain("[movement 0]")
+  })
+
+  it("keeps the reviewer off the French source", () => {
+    expect(buildReviewPrompt(SUBJECT, ENGLISH).system).toContain(
+      "Never comment on the French itself",
+    )
+  })
+})
+
+describe("parseObjections", () => {
+  const objection = {
+    section: "setup",
+    index: 0,
+    verdict: "measurement-changed",
+    note: "'largeur des épaules' rendered as hip-width",
+  }
+
+  it("reads a verdict", () => {
+    expect(parseObjections(JSON.stringify({ objections: [objection] }), ENGLISH)).toEqual([
+      objection,
+    ])
+  })
+
+  it("reads an empty verdict as no objection, not as no answer", () => {
+    expect(parseObjections('{"objections": []}', ENGLISH)).toEqual([])
+  })
+
+  it("reads a verdict wrapped in prose", () => {
+    const raw = `Here you go:\n${JSON.stringify({ objections: [objection] })}`
+
+    expect(parseObjections(raw, ENGLISH)).toHaveLength(1)
+  })
+
+  // `null` is the signal that no checker answered, which the status derivation
+  // turns into `flagged`. Returning `[]` here would mint a clean row out of a
+  // broken response.
+  it.each(['{"verdicts": []}', "not json", "", null, undefined])(
+    "returns null for %o",
+    (raw) => {
+      expect(parseObjections(raw, ENGLISH)).toBeNull()
+    },
+  )
+
+  it("drops an objection pointing at a sentence that does not exist", () => {
+    const raw = JSON.stringify({
+      objections: [objection, { ...objection, index: 7 }, { ...objection, section: "warmup" }],
+    })
+
+    expect(parseObjections(raw, ENGLISH)).toEqual([objection])
+  })
+
+  it("drops an objection with no verdict", () => {
+    const raw = JSON.stringify({ objections: [{ section: "setup", index: 0, note: "hm" }] })
+
+    expect(parseObjections(raw, ENGLISH)).toEqual([])
+  })
+})

--- a/src/lib/instructionPrompt.ts
+++ b/src/lib/instructionPrompt.ts
@@ -1,0 +1,211 @@
+/**
+ * Prompts and response parsing for the instruction-translation pipeline (#417).
+ *
+ * Pure: builds strings and reads strings. The HTTP calls, the keys and the
+ * retry policy stay in `scripts/translate-instructions.ts`. Splitting it this
+ * way is what lets the prompt rules and the parser be type-checked and tested,
+ * since CI never looks at `scripts/`.
+ */
+import { INSTRUCTION_SECTIONS, type InstructionSection } from "@/lib/instructionQuality"
+import enCatalog from "@/locales/en/catalog.json"
+import type { ExerciseInstructions, TranslationAudit } from "@/types/database"
+
+/**
+ * Stamped on every row in `instructions_en_audit`. Bump it whenever a rule in
+ * `buildPrompt` changes, so a later re-run is diffable rather than a mystery.
+ */
+export const PROMPT_VERSION = 1
+
+export type TranslationObjection = TranslationAudit["objections"][number]
+
+/** The columns the prompts need. Same shape the CLI selects. */
+export interface PromptSubject {
+  name: string
+  name_en: string | null
+  muscle_group: string
+  equipment: string
+  instructions: ExerciseInstructions
+}
+
+const MUSCLE_LABELS: Record<string, string> = enCatalog.muscles
+const EQUIPMENT_LABELS: Record<string, string> = enCatalog.equipment
+
+export interface Prompt {
+  system: string
+  user: string
+}
+
+/**
+ * The translation prompt, unchanged from the spike that measured Gemini 2.5
+ * Flash at 29/30 clean rows over a seeded sample of 30. Every rule in it
+ * answers a defect that was actually observed, so edits here need their own
+ * measurement — and a `PROMPT_VERSION` bump.
+ */
+export function buildPrompt(subject: PromptSubject): Prompt {
+  // Canonical labels are Title Case for badges; lowercase them or the model
+  // copies the casing into the middle of sentences.
+  const muscleLabel = (
+    MUSCLE_LABELS[subject.muscle_group] ?? subject.muscle_group
+  ).toLowerCase()
+  const equipmentLabel = (
+    EQUIPMENT_LABELS[subject.equipment] ?? subject.equipment
+  ).toLowerCase()
+
+  const system = `You are an expert strength coach translating exercise coaching cues from French to English. You reply with valid JSON only, no commentary.
+
+Strict rules:
+- Translate meaning, not words. The result must read like it was written by an English-speaking coach, not translated.
+- Preserve the structure EXACTLY: same keys, same number of items in each array, same order. One French sentence maps to one English sentence.
+- Preserve EVERY concrete detail: durations, angles, tempos, degrees, parenthetical anatomical notes. "1-2 secondes" stays "1-2 seconds"; "30-45°" stays "30-45°". Dropping a number is a failure.
+- The French source deliberately used French equipment words. Map them back: "haltère" → dumbbell, "barre" → barbell, "poulie" → pulley, "câble" → cable, "élastique" → band, "banc" → bench, "barre de traction" → pull-up bar, "barre EZ" → EZ bar. This exercise's equipment is "${equipmentLabel}"; do not introduce equipment the French source does not mention.
+- "décliné" means declined and "incliné" means inclined. Never swap them.
+- Anatomy glossary, apply exactly. These two are distinct and must never be swapped: "épaules" → shoulders; "omoplates" → shoulder blades. Also: "hanches" → hips (note "largeur de hanches" is hip-width, NOT shoulder-width), "ischios" → hamstrings, "lombaires" → lower back, "gainage" → bracing or plank depending on context. The target muscle is "${muscleLabel}".
+- Address the reader in the second person throughout, consistently: "your back", "your hips", never "the back" or "the hips". Do not switch register between sentences.
+- The "common_mistakes" entries NAME an error; they are not instructions. Each one MUST stay a noun phrase in English, normally a gerund. "Arrondir le dos pendant le tirage" → "Rounding your back during the pull", NEVER "Round your back during the pull". An imperative here tells the reader to commit the mistake, which is the opposite of the intent. This applies to every entry in that array without exception.
+- Write equipment and muscle names in normal lowercase sentence case, never Title Case, unless they are proper nouns (Smith machine, EZ bar).
+- Refer to the exercise as "${subject.name_en ?? subject.name}" if you name it at all.
+- Keep standard gym terms as they already are in English (squat, curl, pull-up, deadlift, hip thrust, face pull, plank...).
+- Never introduce a number of reps or sets that the French does not state. Never start a sentence with "Repeat" or "Remember".
+- Do not add, remove, soften or improve any cue. If the French is wrong, translate it faithfully — correctness is reviewed separately.`
+
+  const user = `Exercise: ${subject.name}${subject.name_en ? ` (${subject.name_en})` : ""}
+Muscle group: ${subject.muscle_group} (English: ${MUSCLE_LABELS[subject.muscle_group] ?? subject.muscle_group})
+Equipment: ${subject.equipment} (English: ${EQUIPMENT_LABELS[subject.equipment] ?? subject.equipment})
+
+Translate this JSON to English, same shape, same array lengths:
+
+${JSON.stringify(subject.instructions, null, 2)}`
+
+  return { system, user }
+}
+
+/**
+ * Reads a model response into an instruction block, or `null` when it cannot be
+ * trusted. Tolerates prose around the JSON — models wrap it in prose or in a
+ * fence often enough that refusing would throw away good translations — but not
+ * a missing key or a non-string entry: a partial block must never reach the
+ * database.
+ */
+export function parseInstructions(
+  raw: string | null | undefined,
+): ExerciseInstructions | null {
+  if (typeof raw !== "string") return null
+  const match = raw.match(/\{[\s\S]*\}/)
+  if (!match) return null
+  try {
+    const parsed = JSON.parse(match[0]) as ExerciseInstructions
+    const wellFormed = INSTRUCTION_SECTIONS.every(
+      (section) =>
+        Array.isArray(parsed[section]) &&
+        parsed[section].every((entry) => typeof entry === "string"),
+    )
+    return wellFormed ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+/** Sentence pairs the cross-checker is asked to rule on, in a stable order. */
+const alignedPairs = (source: ExerciseInstructions, translation: ExerciseInstructions) =>
+  INSTRUCTION_SECTIONS.flatMap((section) =>
+    source[section].flatMap((fr, index) => {
+      const en = translation[section][index]
+      return en === undefined ? [] : [{ section, index, fr, en }]
+    }),
+  )
+
+/**
+ * Cross-check prompt for the second model. It runs on a different provider from
+ * the translator on purpose: correlated errors would make the second opinion
+ * worthless, and this is the only thing that can catch "largeur des épaules"
+ * rendered as *hip-width* — fluent, structurally identical, and invisible to
+ * every regex in the gate.
+ */
+export function buildReviewPrompt(
+  subject: PromptSubject,
+  translation: ExerciseInstructions,
+): Prompt {
+  const system = `You are a bilingual French/English strength-coaching editor. You audit an existing translation of exercise cues, sentence pair by sentence pair, and you reply with valid JSON only, no commentary.
+
+For each numbered pair, decide whether the English says the same thing as the French. Report ONLY real divergences. A different but equivalent wording is not a divergence; neither is a stylistic choice you would have made differently.
+
+These standard renderings are CORRECT. Never report them: "ischios"/"ischio-jambiers" → hamstrings, "épaules" → shoulders, "omoplates" → shoulder blades, "lombaires" → lower back, "fessiers" → glutes, "mollets" → calves, "quadriceps" → quads, "trapèzes" → traps, "abdos" → abs, "gainage" → bracing or plank, "haltère" → dumbbell, "barre" → barbell, "barre EZ" → EZ bar, "poulie" → pulley or cable, "élastique" → band, "banc" → bench, "pupitre" → preacher bench. Translating a French term into its English equivalent is the job, not an error.
+
+When you hesitate, do not report. A false objection sends a correct translation back to a human for nothing.
+
+Report a pair when:
+- "meaning-changed": the English states something the French does not, or omits a cue the French gives.
+- "measurement-changed": a body-part reference, width, angle, tempo, count or duration differs ("largeur des épaules" rendered as hip-width).
+- "equipment-changed": the English names equipment the French does not, or drops the one it names.
+- "anatomy-changed": a muscle or joint is swapped for another ("épaules" rendered as shoulder blades).
+- "mood-flipped": a "common_mistakes" entry that NAMES an error in French reads as an order in English ("Rounding your back" is right, "Round your back" is not).
+
+Never comment on the French itself, even when it is wrong: the source is out of scope and is corrected elsewhere.
+
+Reply exactly with:
+{"objections":[{"section":"setup|movement|breathing|common_mistakes","index":<number>,"verdict":"<one of the labels above>","note":"<one short sentence, in English>"}]}
+
+An empty array means the translation is faithful. Use it when it is.`
+
+  const pairs = alignedPairs(subject.instructions, translation)
+    .map(
+      ({ section, index, fr, en }) =>
+        `[${section} ${index}]\n  FR: ${fr}\n  EN: ${en}`,
+    )
+    .join("\n")
+
+  const user = `Exercise: ${subject.name}${subject.name_en ? ` (${subject.name_en})` : ""}
+
+${pairs}`
+
+  return { system, user }
+}
+
+const isSection = (value: unknown): value is InstructionSection =>
+  INSTRUCTION_SECTIONS.some((section) => section === value)
+
+/**
+ * Reads the cross-checker's verdict. `null` means "no usable answer" — the
+ * caller must treat that as an unavailable checker and flag the row, never as
+ * an absence of objections.
+ *
+ * Objections pointing at a sentence that does not exist are dropped rather than
+ * failing the whole response: a hallucinated index says nothing about the other
+ * verdicts, and the review screen anchors every objection to a real sentence.
+ */
+export function parseObjections(
+  raw: string | null | undefined,
+  translation: ExerciseInstructions,
+): TranslationObjection[] | null {
+  if (typeof raw !== "string") return null
+  const match = raw.match(/\{[\s\S]*\}/)
+  if (!match) return null
+  try {
+    const parsed = JSON.parse(match[0]) as { objections?: unknown }
+    if (!Array.isArray(parsed.objections)) return null
+
+    return parsed.objections
+      .filter((entry): entry is Record<string, unknown> => typeof entry === "object" && entry !== null)
+      .flatMap((entry) => {
+        const { section, index, verdict, note } = entry
+        return isSection(section) &&
+          typeof index === "number" &&
+          Number.isInteger(index) &&
+          index >= 0 &&
+          index < translation[section].length &&
+          typeof verdict === "string" &&
+          verdict.trim() !== ""
+          ? [
+              {
+                section,
+                index,
+                verdict: verdict.trim(),
+                note: typeof note === "string" ? note.trim() : "",
+              },
+            ]
+          : []
+      })
+  } catch {
+    return null
+  }
+}

--- a/src/lib/instructionQuality.test.ts
+++ b/src/lib/instructionQuality.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest"
 import source from "./instructionQuality.ts?raw"
 import { importsOf } from "@/test/imports"
 import {
+  buildLabelPattern,
   checkTranslation,
   gateFlags,
   moodOf,
@@ -137,6 +138,30 @@ describe("Unicode word boundaries", () => {
     const translated = block({ movement: ["Move élastiquement through the rep"] })
 
     expect(checkTranslation(bandKickback, translated).frenchLeftovers).toBe(false)
+  })
+})
+
+describe("buildLabelPattern", () => {
+  // Muscle and equipment labels are content, edited in a JSON file by whoever
+  // adds a muscle group. An unescaped "." would match any character and an
+  // unescaped "(" would throw while the module loads, taking the whole app
+  // down at import time rather than failing a test.
+  it("matches a label with regex metacharacters literally", () => {
+    const pattern = new RegExp(buildLabelPattern(["Deltoids post."]), "u")
+
+    expect(pattern.test("Deltoids post.")).toBe(true)
+    expect(pattern.test("Deltoids posts")).toBe(false)
+  })
+
+  it("does not throw on a label with an unbalanced bracket", () => {
+    expect(() => new RegExp(buildLabelPattern(["Chest (upper"]), "u")).not.toThrow()
+  })
+
+  it("keeps the labels as separate alternatives", () => {
+    const pattern = new RegExp(buildLabelPattern(["Lower back", "EZ Bar"]), "u")
+
+    expect(pattern.test("EZ Bar")).toBe(true)
+    expect(pattern.test("Lower back")).toBe(true)
   })
 })
 

--- a/src/lib/instructionQuality.test.ts
+++ b/src/lib/instructionQuality.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from "vitest"
+
+import source from "./instructionQuality.ts?raw"
+import { importsOf } from "@/test/imports"
+import {
+  checkTranslation,
+  gateFlags,
+  moodOf,
+  type TranslationSubject,
+} from "./instructionQuality"
+import type { ExerciseInstructions } from "@/types/database"
+
+const block = (
+  overrides: Partial<ExerciseInstructions> = {},
+): ExerciseInstructions => ({
+  setup: [],
+  movement: [],
+  breathing: [],
+  common_mistakes: [],
+  ...overrides,
+})
+
+const subject = (
+  muscle_group: string,
+  instructions: Partial<ExerciseInstructions>,
+): TranslationSubject => ({ muscle_group, instructions: block(instructions) })
+
+const BENCH_PRESS = subject("Pectoraux", {
+  setup: ["Allonge-toi sur le banc, pieds au sol"],
+  movement: ["Pousse la barre vers le haut"],
+  breathing: ["Expire à la poussée"],
+  common_mistakes: ["Arrondir le dos pendant la poussée"],
+})
+
+const BENCH_PRESS_EN = block({
+  setup: ["Lie back on the bench with your feet flat on the floor"],
+  movement: ["Press the bar up"],
+  breathing: ["Exhale on the push"],
+  common_mistakes: ["Rounding your back during the press"],
+})
+
+describe("purity", () => {
+  // The gate is promoted into src/ precisely so tsc and vitest cover it. An
+  // import of the Supabase client or of React would make it a module the CLI
+  // cannot call and a component could ship, so assert on the source.
+  it.each(["react", "i18next", "@/lib/supabase", "@supabase"])(
+    "does not import %s",
+    (module) => {
+      expect(importsOf(source, module)).toEqual([])
+    },
+  )
+})
+
+describe("a faithful translation", () => {
+  it("raises no flag", () => {
+    expect(gateFlags(checkTranslation(BENCH_PRESS, BENCH_PRESS_EN))).toEqual([])
+  })
+})
+
+describe("known false positives", () => {
+  // Measured at the spike: the French names a preacher bench after Larry Scott
+  // and never says "banc", so "preacher bench" looked like invented equipment
+  // while being the only correct translation.
+  it("accepts « pupitre Larry Scott » translated as preacher bench", () => {
+    const preacherCurl = subject("Biceps", {
+      setup: ["Cale tes bras sur le pupitre Larry Scott"],
+      movement: ["Monte la barre EZ jusqu'aux épaules"],
+      breathing: ["Expire à la montée"],
+      common_mistakes: ["Décoller les coudes du support"],
+    })
+    const translated = block({
+      setup: ["Rest your arms on the preacher bench"],
+      movement: ["Curl the EZ bar up to your shoulders"],
+      breathing: ["Exhale on the way up"],
+      common_mistakes: ["Lifting your elbows off the pad"],
+    })
+
+    const checks = checkTranslation(preacherCurl, translated)
+
+    expect(checks.inventedEquipment).toEqual([])
+    expect(gateFlags(checks)).toEqual([])
+  })
+
+  // "Lower back" is the English label of the muscle group "Lombaires", and the
+  // gate used to scan the whole block as one string: every sentence but the
+  // first lost its sentence-opener exemption, so an imperative "Lower" read as
+  // the muscle name in Title Case.
+  it("accepts « Lower back to 90° » where lower is a verb", () => {
+    const goodMorning = subject("Lombaires", {
+      setup: ["Barre posée sur les trapèzes"],
+      movement: ["Descends jusqu'à 90°", "Remonte en poussant les hanches vers l'avant"],
+      breathing: ["Inspire à la descente"],
+      common_mistakes: ["Arrondir le dos"],
+    })
+    const translated = block({
+      setup: ["Bar resting on your traps"],
+      movement: ["Lower back to 90°", "Drive your hips forward to stand up"],
+      breathing: ["Inhale on the way down"],
+      common_mistakes: ["Rounding your back"],
+    })
+
+    const checks = checkTranslation(goodMorning, translated)
+
+    expect(checks.casingBleed).toBeNull()
+    expect(gateFlags(checks)).toEqual([])
+  })
+})
+
+describe("Unicode word boundaries", () => {
+  // `\b` sits on the ASCII word class, so `\bélastique\b` never matches: the
+  // term is skipped in silence and the check reports clean. These two would
+  // both pass with a broken boundary, which is the whole danger.
+  it("sees a French leftover that starts with an accent", () => {
+    const bandKickback = subject("Fessiers", {
+      movement: ["Garde l'élastique tendu"],
+    })
+    const translated = block({ movement: ["Keep the élastique taut"] })
+
+    expect(checkTranslation(bandKickback, translated).frenchLeftovers).toBe(true)
+  })
+
+  it("sees an accented glossary term on the French side", () => {
+    const facePull = subject("Épaules", {
+      movement: ["Écarte les épaules vers l'arrière"],
+    })
+    const translated = block({ movement: ["Pull the blades apart"] })
+
+    expect(
+      checkTranslation(facePull, translated).glossary.map(({ term }) => term),
+    ).toEqual(["épaules"])
+  })
+
+  it("does not match an accented term buried inside a longer word", () => {
+    const bandKickback = subject("Fessiers", {
+      movement: ["Garde l'élastique tendu"],
+    })
+    const translated = block({ movement: ["Move élastiquement through the rep"] })
+
+    expect(checkTranslation(bandKickback, translated).frenchLeftovers).toBe(false)
+  })
+})
+
+describe("checks", () => {
+  it("flags a section that lost an entry", () => {
+    const checks = checkTranslation(
+      subject("Dos", { movement: ["Tire la barre", "Contrôle la descente"] }),
+      block({ movement: ["Pull the bar and control the way down"] }),
+    )
+
+    expect(checks.lengthParity).toBe(false)
+    // Sentence i ↔ sentence i no longer holds, so the glossary stands down.
+    expect(checks.glossary).toEqual([])
+    expect(gateFlags(checks)).toContain("length drift")
+  })
+
+  it("flags a dropped number", () => {
+    const checks = checkTranslation(
+      subject("Abdos", { breathing: ["Tiens la position 1-2 secondes"] }),
+      block({ breathing: ["Hold the position briefly"] }),
+    )
+
+    expect(checks.droppedNumbers).toEqual(["1", "2"])
+  })
+
+  it("flags equipment the French never mentions", () => {
+    const checks = checkTranslation(
+      subject("Pectoraux", { setup: ["Allonge-toi et pousse"] }),
+      block({ setup: ["Lie down on the machine and press"] }),
+    )
+
+    expect(checks.inventedEquipment).toEqual(["machine"])
+  })
+
+  it("flags a muscle name left in French", () => {
+    const checks = checkTranslation(
+      subject("Fessiers", { movement: ["Serre les fessiers en haut"] }),
+      block({ movement: ["Squeeze your fessiers at the top"] }),
+    )
+
+    expect(checks.untranslatedMuscle).toBe(true)
+  })
+
+  it("flags a Title Case label bleeding mid-sentence", () => {
+    const checks = checkTranslation(
+      subject("Fessiers", { movement: ["Serre les fessiers en haut"] }),
+      block({ movement: ["Squeeze your Glutes at the top"] }),
+    )
+
+    expect(checks.casingBleed).toBe("Glutes")
+  })
+
+  it("flags a glossary term swapped for the one it is confused with", () => {
+    const checks = checkTranslation(
+      subject("Épaules", { setup: ["Prends la barre à largeur d'épaules"] }),
+      block({ setup: ["Grip the bar at shoulder-blade width"] }),
+    )
+
+    expect(checks.glossary).toEqual([
+      expect.objectContaining({ section: "setup", index: 0, term: "épaules" }),
+    ])
+  })
+
+  it("flags a common mistake that reads as an order", () => {
+    const checks = checkTranslation(
+      subject("Dos", { common_mistakes: ["Arrondir le dos pendant le tirage"] }),
+      block({ common_mistakes: ["Round your back during the pull"] }),
+    )
+
+    expect(checks.imperativeMistakes).toEqual([
+      { sentence: "Round your back during the pull", mood: "imperative" },
+    ])
+  })
+
+  it("flags a French anatomical calque", () => {
+    const checks = checkTranslation(
+      subject("Abdos", { setup: ["Rétroversion du bassin"] }),
+      block({ setup: ["Start with a retroversion of the pelvis"] }),
+    )
+
+    expect(checks.calques).toEqual(["retroversion"])
+  })
+
+  it("flags reps the French never prescribed", () => {
+    const checks = checkTranslation(
+      subject("Biceps", { movement: ["Monte la barre"] }),
+      block({ movement: ["Do 3 sets of 10 curls"] }),
+    )
+
+    expect(checks.prescribesReps).toBe(true)
+  })
+
+  it("measures the second-person ratio without flagging it", () => {
+    const checks = checkTranslation(
+      subject("Dos", { movement: ["Garde le dos droit", "Pousse les hanches"] }),
+      block({ movement: ["Keep your back flat", "Drive the hips forward"] }),
+    )
+
+    expect(checks.person).toEqual({ total: 2, yours: 1 })
+    expect(gateFlags(checks)).toEqual([])
+  })
+
+  it("reports no second-person ratio when no body part is named", () => {
+    const checks = checkTranslation(
+      subject("Abdos", { breathing: ["Respire calmement"] }),
+      block({ breathing: ["Breathe calmly"] }),
+    )
+
+    expect(checks.person).toBeNull()
+  })
+})
+
+describe("moodOf", () => {
+  it.each([
+    ["Rounding your back during the pull", "noun-phrase"],
+    ["Round your back during the pull", "imperative"],
+    ["Jerk: pushing only with your arms", "noun-phrase"],
+    ["Excessive weight on the first set", "unclassified"],
+  ])("reads %o as %s", (sentence, mood) => {
+    expect(moodOf(sentence)).toBe(mood)
+  })
+})

--- a/src/lib/instructionQuality.ts
+++ b/src/lib/instructionQuality.ts
@@ -1,0 +1,348 @@
+/**
+ * Automated quality gate over a (French source, English translation) pair.
+ *
+ * Pure by construction: no I/O, no network, no Supabase. It lives in `src/`
+ * rather than next to the CLI that calls it because `tsconfig.app.json` only
+ * includes `src`, so nothing under `scripts/` is type-checked — and the gate is
+ * the one part of the pipeline that has to be right.
+ *
+ * Every check compares the English against ITS OWN French source, never against
+ * the `equipment` column. Checking against the column produced only false
+ * positives during the spike: the French of a cable row genuinely says
+ * "machine", and a Smith machine row genuinely mentions a bench and a bar.
+ */
+import enCatalog from "@/locales/en/catalog.json"
+import type { ExerciseInstructions } from "@/types/database"
+
+export const INSTRUCTION_SECTIONS = [
+  "setup",
+  "movement",
+  "breathing",
+  "common_mistakes",
+] as const satisfies readonly (keyof ExerciseInstructions)[]
+
+export type InstructionSection = (typeof INSTRUCTION_SECTIONS)[number]
+
+/** The columns of the source row the gate reads. */
+export interface TranslationSubject {
+  muscle_group: string
+  instructions: ExerciseInstructions
+}
+
+const MUSCLE_LABELS: Record<string, string> = enCatalog.muscles
+const EQUIPMENT_LABELS: Record<string, string> = enCatalog.equipment
+
+/**
+ * `\b` is defined on the ASCII word class, so it sees no boundary next to an
+ * accented letter: `\bépaules\b` and `\bélastique\b` can never match, and the
+ * term is skipped in silence. Unicode-property lookarounds are the only safe
+ * boundary here.
+ */
+const word = (pattern: string) =>
+  new RegExp(`(?<![\\p{L}\\p{N}])(?:${pattern})(?![\\p{L}\\p{N}])`, "iu")
+
+/**
+ * English equipment noun → the French words whose presence would justify it.
+ *
+ * `bench` carries synonyms because the French names a preacher bench after
+ * Larry Scott and never says "banc": the spike flagged "pupitre Larry Scott" →
+ * "preacher bench" as invented equipment, which is the correct translation.
+ */
+const EQUIPMENT_EVIDENCE: ReadonlyArray<readonly [en: string, fr: readonly string[]]> = [
+  ["barbell", ["barre"]],
+  ["dumbbell", ["haltère", "haltere"]],
+  ["cable", ["câble", "cable", "poulie"]],
+  ["pulley", ["poulie"]],
+  ["machine", ["machine"]],
+  ["kettlebell", ["kettlebell"]],
+  ["band", ["élastique", "elastique", "bande"]],
+  ["bench", ["banc", "pupitre", "larry scott"]],
+  ["smith machine", ["smith"]],
+]
+
+/**
+ * Title Case bleed: a canonical badge label ("Lower back", "EZ Bar") copied
+ * into the middle of a sentence. Applied to one sentence at a time, so the
+ * `(?<!^)` guard actually protects a sentence opener — over the whole block
+ * joined together it only ever protected the very first one, which is how
+ * "Lower back to 90°" was reported as a stray muscle label when `Lower` is a
+ * verb.
+ */
+const CASING_BLEED = new RegExp(
+  `(?<!^)(?<![.!?—:]\\s)(?<![\\p{L}\\p{N}])(${[
+    ...Object.values(MUSCLE_LABELS),
+    ...Object.values(EQUIPMENT_LABELS),
+    "Pulley",
+  ]
+    .filter((label) => label !== "Other")
+    .join("|")})(?![\\p{L}\\p{N}])`,
+  "u",
+)
+
+const REP_PATTERNS = [
+  /\b\d+\s*(?:to|-|–)\s*\d+\s*(?:reps?|repetitions?|sets?)\b/i,
+  /\b\d+\s*(?:reps?|repetitions?|sets?)\b/i,
+  /\bsets? of \d+/i,
+]
+
+const FRENCH_LEFTOVERS = word(
+  "le|la|les|des|une|vous|votre|jambes?|haltères?|poulie|élastiques?|gainage|serrez|gardez|expirez|inspirez",
+)
+
+/** French anatomical calques a coach would not write in English. */
+const CALQUES = word(
+  "retroversion|rétroversion|anteversion|coccyx|clavicular bundle|dorsal|lumbars?|ischio[-\\s]?jambiers?|deltoids? bundle",
+)
+
+const numbersIn = (text: string) => (text.match(/\d+/g) ?? []).sort()
+
+/**
+ * Body parts referenced as "your back" versus "the back". Mixing the two inside
+ * one exercise reads as two authors, and it is invisible to every other check —
+ * a run can be flawless on the gate and still switch register mid-sentence.
+ */
+const BODY_PART =
+  /\b(your|the)\s+(back|hips?|knees?|elbows?|shoulders?|shoulder blades?|glutes|core|chest|legs?|feet|foot|arms?|wrists?|ankles?|pelvis|torso|head|abs|hamstrings|quads|calves|spine|neck)\b/gi
+
+export interface SecondPersonRatio {
+  total: number
+  yours: number
+}
+
+const secondPersonRatio = (text: string): SecondPersonRatio | null => {
+  const articles = [...text.matchAll(BODY_PART)].map(([, article]) =>
+    article.toLowerCase(),
+  )
+  return articles.length === 0
+    ? null
+    : {
+        total: articles.length,
+        yours: articles.filter((article) => article === "your").length,
+      }
+}
+
+/**
+ * Sentence-aligned glossary. Structure parity means French sentence i maps to
+ * English sentence i, so a term present on one side must be present on the
+ * other. This is the only regex check that sees semantic drift — a
+ * mistranslation reads fluently, keeps the structure, invents no equipment and
+ * drops no number.
+ *
+ * It is a net, not a proof: it rewards keyword PRESENCE, not meaning. The spike
+ * saw it pass "let your shoulders hang loosely at your sides" for someone
+ * hanging from a pull-up bar, purely because the token was there. Catching that
+ * class of defect is the cross-checker's job, not this one's.
+ */
+const GLOSSARY: ReadonlyArray<{
+  term: string
+  fr: RegExp
+  en: RegExp
+  /** A term routinely substituted for the right one; its presence is a violation by itself. */
+  not?: RegExp
+}> = [
+  // "shoulders" must stand alone: a sentence naming both omoplates and épaules
+  // has to translate both, and "shoulder blades" is not evidence of "shoulders".
+  {
+    term: "épaules",
+    fr: word("épaules?"),
+    en: /(?<![\p{L}\p{N}])shoulders?(?!\s*[- ]\s*blades?)(?![\p{L}\p{N}])/iu,
+  },
+  { term: "omoplates", fr: word("omoplates?"), en: word("shoulder blades?|scapulae?") },
+  { term: "ischios", fr: word("ischios?|ischio-jambiers?"), en: word("hamstrings?") },
+  { term: "lombaires", fr: word("lombaires?"), en: word("lower back|lumbar") },
+  { term: "fessiers", fr: word("fessiers?"), en: word("glutes?|gluteal") },
+  { term: "mollets", fr: word("mollets?"), en: word("calves?|calf") },
+  { term: "genoux", fr: word("genoux?"), en: word("knees?") },
+  // "largeur de hanches" came back as "shoulder-width" — hip-width is the tell.
+  { term: "hanches", fr: word("hanches?"), en: word("hips?") },
+  { term: "coudes", fr: word("coudes?"), en: word("elbows?") },
+  { term: "chevilles", fr: word("chevilles?"), en: word("ankles?") },
+  { term: "poignets", fr: word("poignets?"), en: word("wrists?") },
+  { term: "haltère", fr: word("haltères?"), en: word("dumbbells?"), not: word("barbells?") },
+  { term: "élastique", fr: word("élastiques?"), en: word("bands?") },
+  { term: "banc", fr: word("bancs?"), en: word("bench(?:es)?") },
+]
+
+export interface GlossaryViolation {
+  section: InstructionSection
+  index: number
+  term: string
+  fr: string
+  en: string
+  /** The English used a term this one is commonly confused with. */
+  confused: boolean
+}
+
+const glossaryViolations = (
+  section: InstructionSection,
+  fr: readonly string[],
+  en: readonly string[],
+): GlossaryViolation[] =>
+  fr.flatMap((sentence, index) => {
+    const translated = en[index] ?? ""
+    return GLOSSARY.filter((entry) => entry.fr.test(sentence)).flatMap((entry) => {
+      const confused = entry.not?.test(translated) ?? false
+      return !entry.en.test(translated) || confused
+        ? [{ section, index, term: entry.term, fr: sentence, en: translated, confused }]
+        : []
+    })
+  })
+
+/**
+ * Base-form verbs seen opening a `common_mistakes` entry. The check is a
+ * heuristic, not a parser: an entry NAMES an error, so it should be a gerund or
+ * a noun phrase — an opening base-form verb reads as an instruction to commit
+ * the mistake. Unlisted verbs fall through as `unclassified` rather than being
+ * silently counted as clean, so the miss rate stays visible.
+ */
+const IMPERATIVE_VERBS: ReadonlySet<string> = new Set([
+  "allow", "arch", "avoid", "bend", "bounce", "bring", "cheat", "collapse",
+  "cross", "curl", "do", "don't", "drop", "extend", "flare", "flex", "forget",
+  "go", "hold", "hunch", "jerk", "keep", "lean", "let", "lift", "lock", "look",
+  "lower", "move", "neglect", "overextend", "pinch", "place", "press", "pull",
+  "push", "raise", "relax", "release", "rely", "rest", "rock", "roll", "rotate",
+  "round", "rush", "shrug", "sit", "skip", "squeeze", "stand", "start", "stop",
+  "straighten", "swing", "throw", "tilt", "touch", "turn", "twist", "use",
+])
+
+export type MistakeMood = "noun-phrase" | "imperative" | "unclassified"
+
+/**
+ * Some cues open with a phase label — "Jerk: pushing only with your arms" — and
+ * the label is a noun, not the verb under test.
+ */
+const stripLabel = (sentence: string) => sentence.replace(/^[^:]{1,24}:\s*/u, "")
+
+export function moodOf(sentence: string): MistakeMood {
+  const first = stripLabel(sentence)
+    .trim()
+    .split(/[\s,;:—-]+/)[0]
+    ?.toLowerCase()
+    .replace(/[^\p{L}']/gu, "")
+  if (!first) return "unclassified"
+  if (first.endsWith("ing")) return "noun-phrase"
+  return IMPERATIVE_VERBS.has(first) ? "imperative" : "unclassified"
+}
+
+export interface MistakeMoodEntry {
+  sentence: string
+  mood: MistakeMood
+}
+
+export interface TranslationChecks {
+  /** Every section has the same number of entries on both sides. */
+  lengthParity: boolean
+  /** Numbers present in the French and absent from the English. */
+  droppedNumbers: string[]
+  /** English equipment nouns with no French word to justify them. */
+  inventedEquipment: string[]
+  /** The French muscle-group name survived into the English text. */
+  untranslatedMuscle: boolean
+  /** A canonical badge label copied Title Case into mid-sentence, or null. */
+  casingBleed: string | null
+  glossary: GlossaryViolation[]
+  imperativeMistakes: MistakeMoodEntry[]
+  unclassifiedMistakes: number
+  calques: string[]
+  /** "your back" vs "the back" tally, or null when no body part is named. */
+  person: SecondPersonRatio | null
+  prescribesReps: boolean
+  frenchLeftovers: boolean
+  charsFr: number
+  charsEn: number
+}
+
+export function checkTranslation(
+  subject: TranslationSubject,
+  translation: ExerciseInstructions,
+): TranslationChecks {
+  const enSentences = INSTRUCTION_SECTIONS.flatMap((section) => translation[section])
+  const frSentences = INSTRUCTION_SECTIONS.flatMap(
+    (section) => subject.instructions[section],
+  )
+  const enText = enSentences.join(" ")
+  const frText = frSentences.join(" ")
+  const enLower = enText.toLowerCase()
+  const frLower = frText.toLowerCase()
+
+  const lengthParity = INSTRUCTION_SECTIONS.every(
+    (section) => translation[section].length === subject.instructions[section].length,
+  )
+
+  // The number-preservation check is what caught "1-2 secondes" being dropped.
+  const enNumbers = new Set(numbersIn(enText))
+  const droppedNumbers = numbersIn(frText).filter((n) => !enNumbers.has(n))
+
+  // Substring matching, not `word()`: `.includes()` is immune to the accent
+  // trap because it never inspects the surrounding characters.
+  const inventedEquipment = EQUIPMENT_EVIDENCE.filter(
+    ([en, evidence]) =>
+      enLower.includes(en) && !evidence.some((fr) => frLower.includes(fr)),
+  ).map(([en]) => en)
+
+  const frMuscle = subject.muscle_group.toLowerCase()
+  const enMuscle = (MUSCLE_LABELS[subject.muscle_group] ?? subject.muscle_group).toLowerCase()
+
+  const moods = translation.common_mistakes.map((sentence) => ({
+    sentence,
+    mood: moodOf(sentence),
+  }))
+
+  return {
+    lengthParity,
+    droppedNumbers,
+    inventedEquipment,
+    // Biceps and Triceps are spelled identically in both languages: comparing
+    // them would flag every correct translation.
+    untranslatedMuscle:
+      frMuscle !== enMuscle && enLower.includes(frMuscle) && !enLower.includes(enMuscle),
+    casingBleed:
+      enSentences
+        .map((sentence) => CASING_BLEED.exec(sentence)?.[1] ?? null)
+        .find((match) => match !== null) ?? null,
+    // Sentence i ↔ sentence i only holds while the arrays line up.
+    glossary: lengthParity
+      ? INSTRUCTION_SECTIONS.flatMap((section) =>
+          glossaryViolations(
+            section,
+            subject.instructions[section],
+            translation[section],
+          ),
+        )
+      : [],
+    imperativeMistakes: moods.filter(({ mood }) => mood === "imperative"),
+    unclassifiedMistakes: moods.filter(({ mood }) => mood === "unclassified").length,
+    calques: [...enText.matchAll(new RegExp(CALQUES.source, "giu"))].map(([match]) => match),
+    person: secondPersonRatio(enText),
+    prescribesReps:
+      REP_PATTERNS.some((pattern) => pattern.test(enText)) &&
+      !/\breps?\b|répétitions?/i.test(frText),
+    frenchLeftovers: FRENCH_LEFTOVERS.test(enText),
+    charsFr: frText.length,
+    charsEn: enText.length,
+  }
+}
+
+/**
+ * The checks a human would want named on the row. The second-person ratio is
+ * deliberately absent: it is a corpus measurement, and a single row switching
+ * register once is not worth sending back to French.
+ */
+export function gateFlags(checks: TranslationChecks): string[] {
+  return [
+    !checks.lengthParity && "length drift",
+    checks.droppedNumbers.length > 0 &&
+      `dropped numbers: ${checks.droppedNumbers.join(", ")}`,
+    checks.inventedEquipment.length > 0 &&
+      `invented equipment: ${checks.inventedEquipment.join(", ")}`,
+    checks.untranslatedMuscle && "untranslated muscle",
+    checks.casingBleed && `Title Case bleed: ${checks.casingBleed}`,
+    checks.glossary.length > 0 &&
+      `glossary: ${[...new Set(checks.glossary.map((v) => v.term))].join(", ")}`,
+    checks.imperativeMistakes.length > 0 &&
+      `imperative mistakes: ${checks.imperativeMistakes.length}`,
+    checks.calques.length > 0 && `calques: ${[...new Set(checks.calques)].join(", ")}`,
+    checks.prescribesReps && "prescribes reps",
+    checks.frenchLeftovers && "French leftovers",
+  ].filter((flag): flag is string => typeof flag === "string")
+}

--- a/src/lib/instructionQuality.ts
+++ b/src/lib/instructionQuality.ts
@@ -61,6 +61,20 @@ const EQUIPMENT_EVIDENCE: ReadonlyArray<readonly [en: string, fr: readonly strin
 ]
 
 /**
+ * An alternation over labels taken literally.
+ *
+ * The labels are data: they live in the catalog JSON under `src/locales` and
+ * change with content work, not with code review. A label like "Deltoids
+ * (rear)" or "Abs (lower)" would silently widen the pattern or throw at module
+ * load, so nothing is left to chance about what a label means inside a regex.
+ * Exported for the test that
+ * proves it, since the labels themselves reach this module through a static
+ * import with no seam to inject through.
+ */
+export const buildLabelPattern = (labels: readonly string[]): string =>
+  labels.map((label) => label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")
+
+/**
  * Title Case bleed: a canonical badge label ("Lower back", "EZ Bar") copied
  * into the middle of a sentence. Applied to one sentence at a time, so the
  * `(?<!^)` guard actually protects a sentence opener — over the whole block
@@ -69,13 +83,13 @@ const EQUIPMENT_EVIDENCE: ReadonlyArray<readonly [en: string, fr: readonly strin
  * verb.
  */
 const CASING_BLEED = new RegExp(
-  `(?<!^)(?<![.!?—:]\\s)(?<![\\p{L}\\p{N}])(${[
-    ...Object.values(MUSCLE_LABELS),
-    ...Object.values(EQUIPMENT_LABELS),
-    "Pulley",
-  ]
-    .filter((label) => label !== "Other")
-    .join("|")})(?![\\p{L}\\p{N}])`,
+  `(?<!^)(?<![.!?—:]\\s)(?<![\\p{L}\\p{N}])(${buildLabelPattern(
+    [
+      ...Object.values(MUSCLE_LABELS),
+      ...Object.values(EQUIPMENT_LABELS),
+      "Pulley",
+    ].filter((label) => label !== "Other"),
+  )})(?![\\p{L}\\p{N}])`,
   "u",
 )
 

--- a/src/lib/translationPipeline.test.ts
+++ b/src/lib/translationPipeline.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest"
+
+import source from "./translationPipeline.ts?raw"
+import { importsOf } from "@/test/imports"
+import { parseInstructions, type TranslationObjection } from "./instructionPrompt"
+import {
+  buildTranslationUpdate,
+  deriveStatus,
+  isTranslationCandidate,
+  type TranslationOutcome,
+} from "./translationPipeline"
+import type { ExerciseInstructions } from "@/types/database"
+
+const FRENCH: ExerciseInstructions = {
+  setup: ["Allonge-toi sur le banc"],
+  movement: ["Pousse la barre vers le haut"],
+  breathing: ["Expire à la poussée"],
+  common_mistakes: ["Arrondir le dos"],
+}
+
+const ENGLISH: ExerciseInstructions = {
+  setup: ["Lie back on the bench"],
+  movement: ["Press the bar up"],
+  breathing: ["Exhale on the push"],
+  common_mistakes: ["Rounding your back"],
+}
+
+const OBJECTION: TranslationObjection = {
+  section: "setup",
+  index: 0,
+  verdict: "measurement-changed",
+  note: "'largeur des épaules' rendered as hip-width",
+}
+
+const outcome = (overrides: Partial<TranslationOutcome> = {}): TranslationOutcome => ({
+  translation: ENGLISH,
+  gateFlags: [],
+  objections: [],
+  model: "gemini-2.5-flash",
+  checkerModel: "llama-3.3-70b-versatile",
+  translatedAt: "2026-08-02T09:12:00.000Z",
+  ...overrides,
+})
+
+describe("purity", () => {
+  it.each(["react", "i18next", "@/lib/supabase", "@supabase"])(
+    "does not import %s",
+    (module) => {
+      expect(importsOf(source, module)).toEqual([])
+    },
+  )
+})
+
+describe("isTranslationCandidate", () => {
+  it("takes a row with French and no English", () => {
+    expect(
+      isTranslationCandidate({ instructions: FRENCH, instructions_en: null }),
+    ).toBe(true)
+  })
+
+  // The idempotence claim, in one line: a second run sees what the first one
+  // wrote and has nothing to do.
+  it("skips a row a previous run already translated", () => {
+    expect(
+      isTranslationCandidate({
+        instructions: FRENCH,
+        instructions_en: ENGLISH,
+        instructions_en_status: "clean",
+      }),
+    ).toBe(false)
+  })
+
+  it("skips a row with no French to translate", () => {
+    expect(isTranslationCandidate({ instructions: null })).toBe(false)
+  })
+
+  it("skips a row whose French block is present but blank", () => {
+    const blank: ExerciseInstructions = {
+      setup: [""],
+      movement: [],
+      breathing: [],
+      common_mistakes: ["   "],
+    }
+
+    expect(isTranslationCandidate({ instructions: blank })).toBe(false)
+  })
+
+  it("retakes a flagged row under --force", () => {
+    expect(
+      isTranslationCandidate(
+        {
+          instructions: FRENCH,
+          instructions_en: ENGLISH,
+          instructions_en_status: "flagged",
+        },
+        { force: true },
+      ),
+    ).toBe(true)
+  })
+
+  it.each([{ force: true }, { force: false }])(
+    "leaves an approved row alone with %o",
+    (options) => {
+      expect(
+        isTranslationCandidate(
+          {
+            instructions: FRENCH,
+            instructions_en: ENGLISH,
+            instructions_en_status: "approved",
+          },
+          options,
+        ),
+      ).toBe(false)
+    },
+  )
+
+  // A model answer that will not parse means no update is built, so the four
+  // columns stay null — and a row with null columns is a candidate again.
+  it("picks up again a row whose model answer was unparseable", () => {
+    const untouched = { instructions: FRENCH, instructions_en: null }
+
+    expect(parseInstructions("I could not translate this.")).toBeNull()
+    expect(isTranslationCandidate(untouched)).toBe(true)
+  })
+})
+
+describe("deriveStatus", () => {
+  it("calls a row clean when the gate and the checker both pass", () => {
+    expect(deriveStatus([], [], true)).toBe("clean")
+  })
+
+  it("flags a row the checker objected to", () => {
+    expect(deriveStatus([], [OBJECTION], true)).toBe("flagged")
+  })
+
+  it("flags a row the gate caught", () => {
+    expect(deriveStatus(["dropped numbers: 90"], [], true)).toBe("flagged")
+  })
+
+  // A dead quota must not mint clean English.
+  it("flags a row no checker could review", () => {
+    expect(deriveStatus([], [], false)).toBe("flagged")
+  })
+})
+
+describe("buildTranslationUpdate", () => {
+  it("writes the four columns and nothing else", () => {
+    expect(Object.keys(buildTranslationUpdate(outcome())).sort()).toEqual([
+      "instructions_en",
+      "instructions_en_audit",
+      "instructions_en_reviewed_at",
+      "instructions_en_status",
+    ])
+  })
+
+  it("records the models, the prompt version and the verdicts", () => {
+    const update = buildTranslationUpdate(
+      outcome({ gateFlags: ["dropped numbers: 90"], objections: [OBJECTION] }),
+    )
+
+    expect(update.instructions_en).toEqual(ENGLISH)
+    expect(update.instructions_en_status).toBe("flagged")
+    expect(update.instructions_en_audit).toEqual({
+      model: "gemini-2.5-flash",
+      prompt_version: 1,
+      translated_at: "2026-08-02T09:12:00.000Z",
+      checker_model: "llama-3.3-70b-versatile",
+      gate_flags: ["dropped numbers: 90"],
+      objections: [OBJECTION],
+    })
+  })
+
+  // The review queue selects on `instructions_en_reviewed_at IS NULL`. Stamping
+  // it here would empty the queue without a human reading a word.
+  it("leaves the review timestamp null", () => {
+    expect(buildTranslationUpdate(outcome()).instructions_en_reviewed_at).toBeNull()
+  })
+
+  it("records no checker model when none answered", () => {
+    const update = buildTranslationUpdate(outcome({ objections: null }))
+
+    expect(update.instructions_en_status).toBe("flagged")
+    expect(update.instructions_en_audit.checker_model).toBeNull()
+    expect(update.instructions_en_audit.objections).toEqual([])
+  })
+})

--- a/src/lib/translationPipeline.ts
+++ b/src/lib/translationPipeline.ts
@@ -1,0 +1,117 @@
+/**
+ * The two decisions the translation CLI makes about a row: whether to touch it
+ * at all, and what to write when it does.
+ *
+ * They live here, pure and tested, rather than inside the I/O loop, because
+ * they are what makes the script idempotent — and idempotence is not something
+ * you can demonstrate by reading a `for` loop that also does HTTP.
+ */
+import { INSTRUCTION_SECTIONS } from "@/lib/instructionQuality"
+import { PROMPT_VERSION, type TranslationObjection } from "@/lib/instructionPrompt"
+import type { ExerciseInstructions, TranslationAudit } from "@/types/database"
+
+/** The two statuses the pipeline can write. `approved` is a human's word. */
+export type PipelineStatus = "clean" | "flagged"
+
+/** A human verdict the pipeline must never overwrite. */
+const APPROVED = "approved"
+
+export interface TranslationCandidate {
+  instructions?: ExerciseInstructions | null
+  instructions_en?: ExerciseInstructions | null
+  instructions_en_status?: string | null
+}
+
+/** At least one step that is not blank. */
+const hasContent = (block: ExerciseInstructions | null | undefined): boolean =>
+  INSTRUCTION_SECTIONS.some((section) =>
+    (block?.[section] ?? []).some((step) => step.trim() !== ""),
+  )
+
+/**
+ * Mirrors the SQL filter the CLI selects with — `instructions IS NOT NULL AND
+ * instructions_en IS NULL` — and adds the two guards the query cannot express.
+ *
+ * A row with no French has nothing to translate. A row a human approved is
+ * never rewritten, `--force` included: `--force` exists to replay a machine
+ * verdict, not to overrule a person.
+ */
+export function isTranslationCandidate(
+  row: TranslationCandidate,
+  options: { force?: boolean } = {},
+): boolean {
+  if (!hasContent(row.instructions)) return false
+  if (row.instructions_en_status === APPROVED) return false
+  return options.force === true || row.instructions_en == null
+}
+
+/**
+ * `clean` only when the automated gate found nothing AND a cross-checker
+ * actually answered with no objection.
+ *
+ * An unavailable checker — dead quota, HTTP error, unparseable verdict — yields
+ * `flagged`, which renders French. A missing second opinion is not evidence of
+ * quality, and English nobody checked is exactly the failure this epic exists
+ * to avoid.
+ */
+export function deriveStatus(
+  gateFlags: readonly string[],
+  objections: readonly TranslationObjection[],
+  checkerAvailable: boolean,
+): PipelineStatus {
+  return checkerAvailable && gateFlags.length === 0 && objections.length === 0
+    ? "clean"
+    : "flagged"
+}
+
+export interface TranslationOutcome {
+  translation: ExerciseInstructions
+  gateFlags: readonly string[]
+  /** `null` when the cross-checker gave no usable answer. */
+  objections: readonly TranslationObjection[] | null
+  model: string
+  checkerModel: string
+  translatedAt: string
+}
+
+/** The four columns, always written together. */
+export interface TranslationUpdate {
+  instructions_en: ExerciseInstructions
+  instructions_en_status: PipelineStatus
+  instructions_en_reviewed_at: null
+  instructions_en_audit: TranslationAudit
+}
+
+/**
+ * One row, four columns, one update. A partial write would leave content with
+ * no status, which the display resolver reads as "unknown" and renders as
+ * French — a silent half-migration nobody would notice.
+ *
+ * `instructions_en_reviewed_at` is written as `null` on purpose: the pipeline
+ * is not a review, and the review queue selects on that column being null. A
+ * timestamp here would empty the queue without anyone reading a word.
+ */
+export function buildTranslationUpdate(
+  outcome: TranslationOutcome,
+): TranslationUpdate {
+  const objections = outcome.objections ?? []
+  const checkerAvailable = outcome.objections !== null
+
+  return {
+    instructions_en: outcome.translation,
+    instructions_en_status: deriveStatus(
+      outcome.gateFlags,
+      objections,
+      checkerAvailable,
+    ),
+    instructions_en_reviewed_at: null,
+    instructions_en_audit: {
+      model: outcome.model,
+      prompt_version: PROMPT_VERSION,
+      translated_at: outcome.translatedAt,
+      checker_model: checkerAvailable ? outcome.checkerModel : null,
+      gate_flags: [...outcome.gateFlags],
+      objections: [...objections],
+    },
+  }
+}


### PR DESCRIPTION
## What

The write side of English exercise instructions: a quality gate promoted into `src/lib/`, and a CLI that translates with Gemini, has a second provider cross-check the result sentence pair by sentence pair, and writes the four `instructions_en_*` columns in one update per row.

- `src/lib/instructionQuality.ts` — pure checks over a (French, English) pair: length parity, dropped numbers, invented equipment, untranslated muscle, Title Case bleed, French leftovers, sentence-level glossary, imperative mood under `common_mistakes`, anatomical calques, second-person ratio.
- `src/lib/instructionPrompt.ts` — `buildPrompt()`, `parseInstructions()`, `PROMPT_VERSION`, plus the cross-check prompt and its verdict parser.
- `src/lib/translationPipeline.ts` — `isTranslationCandidate()`, `deriveStatus()`, `buildTranslationUpdate()`.
- `scripts/translate-instructions.ts` — CLI: dry-run by default, `--apply`, `--unlogged`, `--top N`, `--ids`, `--force`, `--verbose`.
- The five uncommitted `scripts/spike-*.ts` files are gone; their logic lives in the three libs above.

Closes nothing on its own — it is PR 2 of 4 on #436, for #417.

## Why

CI never type-checks `scripts/`: `tsconfig.app.json` is `include: ["src"]` and `tsconfig.node.json` covers `vite.config.ts` alone. A quality gate sitting next to the CLI would be the one piece of the pipeline that has to be correct and the one piece nothing verifies. Moving it into `src/lib/` buys `tsc -b` and vitest for free, and no component imports it, so it never ships in a bundle.

Selection and the write decision are pure functions rather than conditionals buried in the I/O loop, because idempotence is only an honest claim if it is testable without a database.

The cross-checker is a different provider from the translator on purpose. Correlated errors would make the second opinion worthless, and this is the only thing that can catch "largeur des épaules" rendered as *hip-width* — fluent, structurally identical, invisible to every regex. When it is unavailable the row lands on `flagged`, never `clean`: a dead quota must not mint English that looks reviewed.

## How

Verified without writing anything to the database.

| AC | Verified how |
|---|---|
| « pupitre Larry Scott » no longer flagged | Named test `accepts « pupitre Larry Scott » translated as preacher bench`; `bench` now carries French synonyms |
| « Lower back to 90° » no longer flagged | Named test `accepts « Lower back to 90° » where lower is a verb`; casing bleed is evaluated one sentence at a time, so a sentence opener keeps its exemption |
| Word boundaries survive accents | `Unicode word boundaries` block: `élastique` detected as a leftover, `épaules` detected on the French side, and neither matches inside a longer word |
| Cross-checker unavailable → `flagged` | `deriveStatus([], [], false)` is `flagged`; every failure mode of the checker (no key, dead quota, HTTP error, unparseable verdict) collapses into `null` objections |
| No `--apply`, no write | Complete dry-run over the `--top 30` wave plus 12 long-tail rows against production; `instructions_en`, the status, the audit and the review timestamp are all still null on all 372 rows |
| Two consecutive `--apply` runs write nothing the second time | `isTranslationCandidate` returns `false` for a row that already has `instructions_en`, mirroring the `instructions_en IS NULL` filter the CLI selects on |
| `--force` spares `approved` rows | `isTranslationCandidate(..., { force: true })` is `false` on `approved`, tested with force both on and off |
| Invalid model JSON is skipped and retried later | `parseInstructions` returns `null`, no update is built, the four columns stay null, and the untouched row is a candidate again |
| The five spike files are gone | `scripts/spike-*.ts` no longer exists |
| **Démo** | **Not done here** — it needs `--apply` against production. See below. |

Measured on the way: 30 most-logged rows came back 27 clean / 3 flagged, and 12 long-tail rows 11 clean / 1 flagged. `Retry-After` was honoured on a dozen Groq 429s; a backoff longer than two minutes is treated as an unavailable provider rather than waited out, which is what a 43-minute daily-quota reply deserves.

## Demo command

Left for a human, on three never-logged long-tail rows:

```bash
npm run translate-instructions -- --ids d565cf7f-b8f4-4d2f-9682-8c43c01b24d3,1fec5cba-0e34-4c1f-bb45-14a8df1aa693,27e7d300-6146-488f-bbc8-1f70a0e9d8fa --apply
```

- **Reverse Preacher Curl (Close Grip, EZ Bar)** — the "pupitre" regression on real data. Dry-run: `clean`.
- **Band Pull-Apart** — accented boundaries, `élastique` and `épaules`. Dry-run: `clean`.
- **Cat-Cow Stretch** — its French says "lombaire" and "coccyx" and the model reliably answers "lumbar". Dry-run: `flagged`, so it must keep rendering French in the English app.

Re-running the same command must report 0 rows.

Made with [Cursor](https://cursor.com)