### PR TITLE
feat(i18n): translation review queue (T158)

### DIFF
--- a/docs/Tech_Plan_—_English_Exercise_Instructions_#417.md
+++ b/docs/Tech_Plan_—_English_Exercise_Instructions_#417.md
@@ -154,6 +154,7 @@ RETURNS TABLE (
   logged_sets bigint
 )
 LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
 AS $$
   SELECT
     e.id, e.name, e.name_en,
@@ -167,10 +168,19 @@ AS $$
   WHERE e.instructions_en IS NOT NULL
     AND e.instructions_en_reviewed_at IS NULL
   ORDER BY
-    (e.instructions_en_status = 'flagged') DESC,
+    -- NULLS LAST : la comparaison vaut NULL pour une ligne portant de l'anglais
+    -- sans statut, et DESC place les NULL en tête. Mesuré sans lui : cette ligne
+    -- malformée sortait en position 1, au-dessus d'un vrai signalement.
+    (e.instructions_en_status = 'flagged') DESC NULLS LAST,
     COALESCE(sl.cnt, 0) DESC,
     e.name ASC;
 $$;
+
+-- Le linter Supabase signale déjà six fonctions à `search_path` mutable et sept
+-- appelables par `anon`. Une fonction neuve sur une surface admin n'a aucune
+-- raison d'hériter de ce passif.
+REVOKE ALL ON FUNCTION get_translations_for_review() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_translations_for_review() TO authenticated, service_role;
 ```
 
 Huit colonnes au lieu de dix-neuf : la file ne rend ni emoji ni difficulté, et l'ajout d'une future colonne à `exercises` ne la fera pas pourrir.
@@ -224,7 +234,7 @@ graph TD
 | `src/lib/instructionQuality.test.ts` | Dont deux régressions nommées : « pupitre Larry Scott » et « Lower back to 90° » ne doivent plus se déclencher |
 | `src/lib/instructionPrompt.ts` | `buildPrompt()`, `parseInstructions()`, `PROMPT_VERSION` |
 | `scripts/translate-instructions.ts` | CLI : `--dry-run` (défaut), `--apply`, `--unlogged`, `--top N`, `--ids`, `--force`. Gemini traduit, Groq contre-relit, service role écrit |
-| `src/pages/admin/AdminTranslationsPage.tsx` | Route `/admin/translations` : file, progression, carte courante |
+| `src/pages/AdminTranslationsPage.tsx` | Route `/admin/translations` : file, progression, carte courante. À plat avec les cinq pages admin existantes : un dossier `admin/` d'un seul fichier éclaterait les pages admin sur deux emplacements |
 | `src/components/admin/translations/TranslationReviewCard.tsx` | Comparaison FR/EN alignée à la phrase, objections accrochées, approuver / éditer / rendre au français |
 | `src/components/admin/translations/ReviewAssistDialog.tsx` | Copie la demande d'arbitrage, colle le JSON corrigé, valide la forme, montre le diff avant écriture |
 | `src/hooks/useTranslationReviewQueue.ts` | Appelle le RPC |

--- a/src/components/admin/translations/TranslationReviewCard.test.tsx
+++ b/src/components/admin/translations/TranslationReviewCard.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest"
+import { screen, within } from "@testing-library/react"
+import { renderWithProviders } from "@/test/utils"
+import { TranslationReviewCard } from "@/components/admin/translations/TranslationReviewCard"
+import type { TranslationReviewRow } from "@/hooks/useTranslationReviewQueue"
+
+const row: TranslationReviewRow = {
+  id: "row-1",
+  name: "Développé couché",
+  name_en: "Bench Press",
+  instructions: {
+    setup: [
+      "Allongez-vous sur le banc.",
+      "Écartez les mains à largeur d'épaules.",
+    ],
+    movement: ["Poussez la barre vers le haut."],
+    breathing: ["Expirez à la poussée."],
+    common_mistakes: ["Dos creusé."],
+  },
+  instructions_en: {
+    setup: ["Lie back on the bench.", "Set your hands hip-width apart."],
+    movement: ["Press the bar upward."],
+    breathing: ["Exhale as you press."],
+    common_mistakes: ["Arched lower back."],
+  },
+  instructions_en_status: "flagged",
+  instructions_en_audit: {
+    model: "gemini-2.5-flash",
+    prompt_version: 1,
+    translated_at: "2026-08-02T12:26:44.264Z",
+    checker_model: "llama-3.3-70b-versatile",
+    gate_flags: ["calques: lumbar"],
+    objections: [
+      {
+        section: "setup",
+        index: 1,
+        verdict: "measurement-changed",
+        note: "'largeur des épaules' rendered as 'hip-width'",
+      },
+    ],
+  },
+  logged_sets: 152,
+}
+
+const lineContaining = (text: string): HTMLElement =>
+  screen.getByText(text).closest("li")!
+
+describe("TranslationReviewCard", () => {
+  it("shows both names, the status and the reading exposure", () => {
+    renderWithProviders(<TranslationReviewCard row={row} />)
+
+    expect(screen.getByText("Développé couché")).toBeInTheDocument()
+    expect(screen.getByText("Bench Press")).toBeInTheDocument()
+    expect(screen.getByText("Flagged")).toBeInTheDocument()
+    expect(screen.getByText("152 logged sets")).toBeInTheDocument()
+  })
+
+  // The acceptance criterion: the objection is attached to the sentence it
+  // named. Asserting it lands *somewhere* would pass on a section-level banner,
+  // so both the presence and the absence are checked.
+  it("renders an objection on the sentence it targeted", () => {
+    renderWithProviders(<TranslationReviewCard row={row} />)
+
+    const targeted = lineContaining("Set your hands hip-width apart.")
+    expect(
+      within(targeted).getByText(/measurement-changed/),
+    ).toBeInTheDocument()
+    expect(
+      within(targeted).getByText(
+        "'largeur des épaules' rendered as 'hip-width'",
+        { exact: false },
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it("leaves the untargeted sentence in the same section clean", () => {
+    renderWithProviders(<TranslationReviewCard row={row} />)
+
+    const untouched = lineContaining("Lie back on the bench.")
+    expect(within(untouched).queryByText(/measurement-changed/)).toBeNull()
+  })
+
+  it("pairs each English sentence with its French counterpart", () => {
+    renderWithProviders(<TranslationReviewCard row={row} />)
+
+    const pair = lineContaining("Set your hands hip-width apart.")
+    expect(
+      within(pair).getByText("Écartez les mains à largeur d'épaules."),
+    ).toBeInTheDocument()
+  })
+
+  // A gate flag has no section or index, so it belongs to the row, not to a
+  // sentence — and a row can be flagged with no objection at all.
+  it("shows gate flags at row level and survives an empty objection list", () => {
+    const gateOnly: TranslationReviewRow = {
+      ...row,
+      instructions_en_audit: { ...row.instructions_en_audit!, objections: [] },
+    }
+    renderWithProviders(<TranslationReviewCard row={gateOnly} />)
+
+    expect(screen.getByText("calques: lumbar")).toBeInTheDocument()
+    expect(screen.queryByText(/measurement-changed/)).toBeNull()
+  })
+
+  it("names the missing side when the translation dropped a sentence", () => {
+    const truncated: TranslationReviewRow = {
+      ...row,
+      instructions_en: { ...row.instructions_en!, setup: ["Lie back on the bench."] },
+    }
+    renderWithProviders(<TranslationReviewCard row={truncated} />)
+
+    const orphaned = lineContaining("Écartez les mains à largeur d'épaules.")
+    expect(
+      within(orphaned).getByText("no sentence at this position"),
+    ).toBeInTheDocument()
+  })
+
+  it("says so when the cross-checker never answered", () => {
+    const unchecked: TranslationReviewRow = {
+      ...row,
+      instructions_en_audit: { ...row.instructions_en_audit!, checker_model: null },
+    }
+    renderWithProviders(<TranslationReviewCard row={unchecked} />)
+
+    expect(screen.getByText(/no cross-checker/)).toBeInTheDocument()
+  })
+
+  it("renders every label in French under the fr locale", () => {
+    renderWithProviders(<TranslationReviewCard row={row} />, { locale: "fr" })
+
+    expect(screen.getByText("Signalée")).toBeInTheDocument()
+    expect(screen.getByText("Mise en place")).toBeInTheDocument()
+    expect(screen.getByText("152 séries loguées")).toBeInTheDocument()
+    expect(screen.getAllByText("Anglais").length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/admin/translations/TranslationReviewCard.tsx
+++ b/src/components/admin/translations/TranslationReviewCard.tsx
@@ -1,0 +1,168 @@
+import { useTranslation } from "react-i18next"
+import { AlertTriangle } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { formatDate } from "@/lib/formatters"
+import {
+  buildReviewSections,
+  orphanObjections,
+  type ReviewLine,
+  type ReviewObjection,
+} from "@/lib/translationReview"
+import type { InstructionSection } from "@/lib/instructionQuality"
+import type { TranslationReviewRow } from "@/hooks/useTranslationReviewQueue"
+
+const SECTION_KEYS: Record<InstructionSection, string> = {
+  setup: "translations.sections.setup",
+  movement: "translations.sections.movement",
+  breathing: "translations.sections.breathing",
+  common_mistakes: "translations.sections.commonMistakes",
+}
+
+const STATUS_VARIANT: Record<string, "secondary" | "destructive" | "default"> = {
+  clean: "secondary",
+  flagged: "destructive",
+  approved: "default",
+}
+
+interface TranslationReviewCardProps {
+  row: TranslationReviewRow
+}
+
+function ObjectionBadge({ objection }: { objection: ReviewObjection }) {
+  return (
+    <Badge
+      variant="outline"
+      className="max-w-full items-start gap-1.5 whitespace-normal border-destructive/40 bg-destructive/10 py-1 text-left text-destructive"
+    >
+      <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+      <span className="min-w-0">
+        <span className="font-semibold">{objection.verdict}</span>
+        {objection.note ? <> — {objection.note}</> : null}
+      </span>
+    </Badge>
+  )
+}
+
+/**
+ * One aligned pair. The objections belong inside the row rather than above the
+ * section: a reviewer arbitrating "hip-width" needs to be looking at the
+ * sentence that says it, not counting down from a heading.
+ */
+function SentencePair({
+  line,
+  missingLabel,
+}: {
+  line: ReviewLine
+  missingLabel: string
+}) {
+  return (
+    <li className="grid gap-2 border-t border-border/40 py-2 first:border-t-0 sm:grid-cols-2 sm:gap-4">
+      <p className="text-sm text-muted-foreground">
+        {line.fr ?? <em className="opacity-60">{missingLabel}</em>}
+      </p>
+      <div className="flex flex-col gap-1.5">
+        <p className="text-sm">
+          {line.en ?? <em className="opacity-60">{missingLabel}</em>}
+        </p>
+        {line.objections.map((objection, i) => (
+          <ObjectionBadge key={`${objection.verdict}-${i}`} objection={objection} />
+        ))}
+      </div>
+    </li>
+  )
+}
+
+export function TranslationReviewCard({ row }: TranslationReviewCardProps) {
+  const { t, i18n } = useTranslation("admin")
+
+  const audit = row.instructions_en_audit
+  const objections = audit?.objections ?? []
+  const sections = buildReviewSections(
+    row.instructions,
+    row.instructions_en,
+    objections,
+  )
+  const orphans = orphanObjections(sections, objections)
+  const status = row.instructions_en_status ?? "unknown"
+  const missingLabel = t("translations.missingSentence")
+
+  return (
+    <article className="flex flex-col gap-5 rounded-xl border border-border/80 bg-card p-5">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-lg font-semibold leading-tight">{row.name}</h2>
+          {row.name_en ? (
+            <p className="mt-0.5 text-sm text-muted-foreground">{row.name_en}</p>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant={STATUS_VARIANT[status] ?? "outline"}>
+            {t(`translations.status.${status}`, {
+              defaultValue: t("translations.status.unknown"),
+            })}
+          </Badge>
+          <Badge variant="outline" className="tabular-nums text-muted-foreground">
+            {t("translations.loggedSets", { count: row.logged_sets })}
+          </Badge>
+        </div>
+      </header>
+
+      {audit ? (
+        <section className="flex flex-col gap-2 rounded-lg bg-muted/40 p-3">
+          <p className="text-xs text-muted-foreground">
+            {t("translations.audit.line", {
+              model: audit.model,
+              checker:
+                audit.checker_model ?? t("translations.audit.checkerUnavailable"),
+              version: audit.prompt_version,
+              date: formatDate(audit.translated_at, i18n.language, {
+                dateStyle: "medium",
+                timeStyle: "short",
+              }),
+            })}
+          </p>
+          {audit.gate_flags.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-xs font-medium">
+                {t("translations.gateFlags")}
+              </span>
+              {audit.gate_flags.map((flag) => (
+                <Badge
+                  key={flag}
+                  variant="outline"
+                  className="border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                >
+                  {flag}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+          {orphans.length > 0 ? (
+            <p className="text-xs text-destructive">
+              {t("translations.orphanObjections", { count: orphans.length })}
+            </p>
+          ) : null}
+        </section>
+      ) : null}
+
+      {sections.map(({ section, lines }) => (
+        <section key={section} className="flex flex-col gap-1">
+          <h3 className="text-sm font-semibold">{t(SECTION_KEYS[section])}</h3>
+          <div className="grid gap-2 text-xs uppercase tracking-wide text-muted-foreground sm:grid-cols-2 sm:gap-4">
+            <span>{t("translations.frenchHeading")}</span>
+            <span>{t("translations.englishHeading")}</span>
+          </div>
+          <ul className="flex flex-col">
+            {lines.map((line) => (
+              <SentencePair
+                key={line.index}
+                line={line}
+                missingLabel={missingLabel}
+              />
+            ))}
+          </ul>
+        </section>
+      ))}
+    </article>
+  )
+}

--- a/src/hooks/useTranslationReviewQueue.ts
+++ b/src/hooks/useTranslationReviewQueue.ts
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query"
+import { supabase } from "@/lib/supabase"
+import type { ExerciseInstructions, TranslationAudit } from "@/types/database"
+
+/**
+ * One row of `get_translations_for_review` — eight columns, not the whole
+ * exercise. The queue renders a comparison, not an exercise card, so it has no
+ * use for emoji, difficulty or any column added to `exercises` later.
+ */
+export interface TranslationReviewRow {
+  id: string
+  name: string
+  name_en: string | null
+  instructions: ExerciseInstructions | null
+  instructions_en: ExerciseInstructions | null
+  instructions_en_status: string | null
+  instructions_en_audit: TranslationAudit | null
+  logged_sets: number
+}
+
+export const TRANSLATION_REVIEW_QUEUE_KEY = "translations-for-review"
+
+/**
+ * The order is the RPC's — flagged first, then reading exposure, then name.
+ * Nothing here re-sorts: a second opinion on the order in the client would be
+ * one more place for it to drift away from the one the queue is specified in.
+ */
+export function useTranslationReviewQueue() {
+  return useQuery({
+    queryKey: [TRANSLATION_REVIEW_QUEUE_KEY],
+    queryFn: async (): Promise<TranslationReviewRow[]> => {
+      const { data, error } = await supabase.rpc("get_translations_for_review")
+      if (error) throw error
+      return (data ?? []) as TranslationReviewRow[]
+    },
+  })
+}

--- a/src/lib/translationReview.test.ts
+++ b/src/lib/translationReview.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest"
+
+import source from "./translationReview.ts?raw"
+import {
+  buildReviewSections,
+  orphanObjections,
+  type ReviewObjection,
+} from "@/lib/translationReview"
+import { importsOf } from "@/test/imports"
+import type { ExerciseInstructions } from "@/types/database"
+
+const french: ExerciseInstructions = {
+  setup: ["Allongez-vous sur le dos.", "Écartez les mains à largeur d'épaules."],
+  movement: ["Poussez la barre vers le haut."],
+  breathing: ["Expirez à la poussée."],
+  common_mistakes: ["Dos creusé."],
+}
+
+const english: ExerciseInstructions = {
+  setup: ["Lie on your back.", "Set your hands hip-width apart."],
+  movement: ["Press the bar upward."],
+  breathing: ["Exhale as you press."],
+  common_mistakes: ["Arched lower back."],
+}
+
+const objection: ReviewObjection = {
+  section: "setup",
+  index: 1,
+  verdict: "measurement-changed",
+  note: "'largeur des épaules' rendered as 'hip-width'",
+}
+
+describe("translationReview purity", () => {
+  // The alignment is the acceptance criterion; keeping it free of React and of
+  // i18next is what lets the criterion be asserted as data rather than markup.
+  it.each(["react", "i18next", "@/lib/supabase", "@supabase"])(
+    "does not import %s",
+    (module) => {
+      expect(importsOf(source, module)).toEqual([])
+    },
+  )
+})
+
+describe("buildReviewSections", () => {
+  it("pairs French and English by index within each section", () => {
+    const sections = buildReviewSections(french, english)
+
+    expect(sections.map((entry) => entry.section)).toEqual([
+      "setup",
+      "movement",
+      "breathing",
+      "common_mistakes",
+    ])
+    expect(sections[0].lines).toEqual([
+      {
+        index: 0,
+        fr: "Allongez-vous sur le dos.",
+        en: "Lie on your back.",
+        objections: [],
+      },
+      {
+        index: 1,
+        fr: "Écartez les mains à largeur d'épaules.",
+        en: "Set your hands hip-width apart.",
+        objections: [],
+      },
+    ])
+  })
+
+  // The acceptance criterion, at the level where it is a fact about data.
+  it("hangs an objection on the sentence it named, not on the section", () => {
+    const [setup] = buildReviewSections(french, english, [objection])
+
+    expect(setup.lines[0].objections).toEqual([])
+    expect(setup.lines[1].objections).toEqual([objection])
+  })
+
+  it("keeps two objections on the same sentence together", () => {
+    const second: ReviewObjection = { ...objection, verdict: "register-shift" }
+    const [setup] = buildReviewSections(french, english, [objection, second])
+
+    expect(setup.lines[1].objections).toEqual([objection, second])
+  })
+
+  it("does not leak an objection across sections at the same index", () => {
+    const sections = buildReviewSections(french, english, [
+      { ...objection, section: "movement", index: 0 },
+    ])
+    const bySection = new Map(sections.map((s) => [s.section, s]))
+
+    expect(bySection.get("setup")!.lines[0].objections).toEqual([])
+    expect(bySection.get("movement")!.lines[0].objections).toHaveLength(1)
+  })
+
+  // A dropped sentence is precisely what the reviewer is looking for, so the
+  // pair has to survive with a hole rather than vanish.
+  it("holds a hole open when one side is shorter", () => {
+    const shortened: ExerciseInstructions = { ...english, setup: ["Lie on your back."] }
+    const [setup] = buildReviewSections(french, shortened)
+
+    expect(setup.lines).toHaveLength(2)
+    expect(setup.lines[1]).toEqual({
+      index: 1,
+      fr: "Écartez les mains à largeur d'épaules.",
+      en: null,
+      objections: [],
+    })
+  })
+
+  it("drops sections that are empty on both sides", () => {
+    const sparse: ExerciseInstructions = {
+      setup: ["Allongez-vous."],
+      movement: [],
+      breathing: [],
+      common_mistakes: [],
+    }
+
+    expect(buildReviewSections(sparse, sparse).map((s) => s.section)).toEqual([
+      "setup",
+    ])
+  })
+
+  it("renders the French alone when there is no translation yet", () => {
+    const [setup] = buildReviewSections(french, null)
+
+    expect(setup.lines[0]).toEqual({
+      index: 0,
+      fr: "Allongez-vous sur le dos.",
+      en: null,
+      objections: [],
+    })
+  })
+
+  it("returns nothing when both sides are missing", () => {
+    expect(buildReviewSections(null, null)).toEqual([])
+  })
+})
+
+describe("orphanObjections", () => {
+  it("finds nothing when every objection landed on a sentence", () => {
+    const sections = buildReviewSections(french, english, [objection])
+
+    expect(orphanObjections(sections, [objection])).toEqual([])
+  })
+
+  it("surfaces an objection pointing past the end of its section", () => {
+    const stray: ReviewObjection = { ...objection, index: 9 }
+    const sections = buildReviewSections(french, english, [stray])
+
+    expect(orphanObjections(sections, [stray])).toEqual([stray])
+  })
+})

--- a/src/lib/translationReview.ts
+++ b/src/lib/translationReview.ts
@@ -1,0 +1,106 @@
+/**
+ * Turns a translated row into the shape the review card renders: four sections,
+ * French and English paired by their index inside the section, each pair
+ * carrying the objections the cross-checker raised against it.
+ *
+ * The pairing lives here rather than in the component because "the objection
+ * appears on the sentence it targeted" is the whole point of the screen, and
+ * that is a claim about data, not about markup.
+ */
+import {
+  INSTRUCTION_SECTIONS,
+  type InstructionSection,
+} from "@/lib/instructionQuality"
+import type {
+  ExerciseInstructions,
+  TranslationAudit,
+} from "@/types/database"
+
+export type ReviewObjection = TranslationAudit["objections"][number]
+
+export interface ReviewLine {
+  /** Position inside the section — what an objection points at. */
+  index: number
+  /** `null` when this side has no sentence at that index. */
+  fr: string | null
+  en: string | null
+  objections: ReviewObjection[]
+}
+
+export interface ReviewSection {
+  section: InstructionSection
+  lines: ReviewLine[]
+}
+
+/**
+ * Objections keyed by the sentence they name. A key nobody claims is a
+ * hallucinated index the pipeline should already have dropped — grouping is
+ * still done by lookup rather than by position so a stray one cannot shift
+ * every objection after it onto the wrong sentence.
+ */
+const groupBySentence = (
+  objections: readonly ReviewObjection[],
+): Map<string, ReviewObjection[]> =>
+  objections.reduce((byKey, objection) => {
+    const key = `${objection.section}.${objection.index}`
+    return byKey.set(key, [...(byKey.get(key) ?? []), objection])
+  }, new Map<string, ReviewObjection[]>())
+
+/**
+ * The length of the longer side. A translation missing a sentence is exactly
+ * what the reviewer is here to catch, so the shorter side gets a hole rather
+ * than the pair being dropped.
+ */
+const pairedLength = (
+  fr: readonly string[] | undefined,
+  en: readonly string[] | undefined,
+): number => Math.max(fr?.length ?? 0, en?.length ?? 0)
+
+export function buildReviewSections(
+  french: ExerciseInstructions | null | undefined,
+  english: ExerciseInstructions | null | undefined,
+  objections: readonly ReviewObjection[] = [],
+): ReviewSection[] {
+  const byKey = groupBySentence(objections)
+
+  return INSTRUCTION_SECTIONS.map((section) => {
+    const fr = french?.[section] ?? []
+    const en = english?.[section] ?? []
+
+    return {
+      section,
+      lines: Array.from(
+        { length: pairedLength(fr, en) },
+        (_, index): ReviewLine => ({
+          index,
+          fr: fr[index] ?? null,
+          en: en[index] ?? null,
+          objections: byKey.get(`${section}.${index}`) ?? [],
+        }),
+      ),
+    }
+  }).filter((entry) => entry.lines.length > 0)
+}
+
+/**
+ * Objections whose index falls outside both sides of their section.
+ *
+ * `parseObjections` validates every index against the translation before it is
+ * written, so this should always be empty — it exists so the card can say
+ * "there is an objection you are not being shown" instead of swallowing it,
+ * which is the failure a reviewer could never detect on their own.
+ */
+export function orphanObjections(
+  sections: readonly ReviewSection[],
+  objections: readonly ReviewObjection[] = [],
+): ReviewObjection[] {
+  const rendered = new Set(
+    sections.flatMap(({ section, lines }) =>
+      lines.map(({ index }) => `${section}.${index}`),
+    ),
+  )
+
+  return objections.filter(
+    (objection) => !rendered.has(`${objection.section}.${objection.index}`),
+  )
+}

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -15,6 +15,40 @@
     "allDoneHint": "Nothing left in the queue — nice work.",
     "backToAdmin": "Back to admin"
   },
+  "translations": {
+    "title": "Translation Review",
+    "navLabel": "Translations",
+    "description": "Compare the French source with its English translation, sentence by sentence — flagged rows first.",
+    "allDone": "No translation left to review!",
+    "allDoneHint": "Every translated exercise has been read — nice work.",
+    "backToAdmin": "Back to admin",
+    "previous": "Previous",
+    "next": "Next",
+    "frenchHeading": "French",
+    "englishHeading": "English",
+    "missingSentence": "no sentence at this position",
+    "gateFlags": "Automatic checks:",
+    "orphanObjections_one": "{{count}} objection points at a sentence that does not exist and is not shown below.",
+    "orphanObjections_other": "{{count}} objections point at sentences that do not exist and are not shown below.",
+    "loggedSets_one": "{{count}} logged set",
+    "loggedSets_other": "{{count}} logged sets",
+    "status": {
+      "clean": "Clean",
+      "flagged": "Flagged",
+      "approved": "Approved",
+      "unknown": "No status"
+    },
+    "sections": {
+      "setup": "Setup",
+      "movement": "Movement",
+      "breathing": "Breathing",
+      "commonMistakes": "Common mistakes"
+    },
+    "audit": {
+      "line": "Translated by {{model}} on {{date}} · cross-checked by {{checker}} · prompt v{{version}}",
+      "checkerUnavailable": "no cross-checker"
+    }
+  },
   "review": {
     "title": "Exercise Review",
     "navLabel": "Review",

--- a/src/locales/fr/admin.json
+++ b/src/locales/fr/admin.json
@@ -15,6 +15,40 @@
     "allDoneHint": "Plus rien dans la file — bien joué.",
     "backToAdmin": "Retour à l'admin"
   },
+  "translations": {
+    "title": "Relecture des traductions",
+    "navLabel": "Traductions",
+    "description": "Comparer la source française et sa traduction anglaise, phrase à phrase — les lignes signalées d'abord.",
+    "allDone": "Plus aucune traduction à relire !",
+    "allDoneHint": "Tous les exercices traduits ont été lus — bien joué.",
+    "backToAdmin": "Retour à l'admin",
+    "previous": "Précédent",
+    "next": "Suivant",
+    "frenchHeading": "Français",
+    "englishHeading": "Anglais",
+    "missingSentence": "aucune phrase à cette position",
+    "gateFlags": "Contrôles automatiques :",
+    "orphanObjections_one": "{{count}} objection vise une phrase inexistante et n'est pas affichée ci-dessous.",
+    "orphanObjections_other": "{{count}} objections visent des phrases inexistantes et ne sont pas affichées ci-dessous.",
+    "loggedSets_one": "{{count}} série loguée",
+    "loggedSets_other": "{{count}} séries loguées",
+    "status": {
+      "clean": "Propre",
+      "flagged": "Signalée",
+      "approved": "Validée",
+      "unknown": "Sans statut"
+    },
+    "sections": {
+      "setup": "Mise en place",
+      "movement": "Mouvement",
+      "breathing": "Respiration",
+      "commonMistakes": "Erreurs fréquentes"
+    },
+    "audit": {
+      "line": "Traduit par {{model}} le {{date}} · contre-relu par {{checker}} · prompt v{{version}}",
+      "checkerUnavailable": "aucun contre-relecteur"
+    }
+  },
   "review": {
     "title": "Revue des exercices",
     "navLabel": "Revue",

--- a/src/pages/AdminHomePage.tsx
+++ b/src/pages/AdminHomePage.tsx
@@ -21,6 +21,9 @@ export function AdminHomePage() {
           <Link to="/admin/review">{t("review.navLabel")}</Link>
         </Button>
         <Button variant="outline" size="sm" asChild>
+          <Link to="/admin/translations">{t("translations.navLabel")}</Link>
+        </Button>
+        <Button variant="outline" size="sm" asChild>
           <Link to="/admin/enrichment">{t("enrichment.navLabel")}</Link>
         </Button>
         <Button variant="outline" size="sm" asChild>

--- a/src/pages/AdminTranslationsPage.test.tsx
+++ b/src/pages/AdminTranslationsPage.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { renderWithProviders, mockQueryResult } from "@/test/utils"
+import { AdminTranslationsPage } from "@/pages/AdminTranslationsPage"
+import { useTranslationReviewQueue } from "@/hooks/useTranslationReviewQueue"
+import type { TranslationReviewRow } from "@/hooks/useTranslationReviewQueue"
+
+vi.mock("@/lib/supabase", () => ({ supabase: { from: vi.fn(), rpc: vi.fn() } }))
+vi.mock("@/hooks/useTranslationReviewQueue", () => ({
+  useTranslationReviewQueue: vi.fn(),
+  TRANSLATION_REVIEW_QUEUE_KEY: "translations-for-review",
+}))
+
+const instructions = {
+  setup: ["Mise en place."],
+  movement: ["Mouvement."],
+  breathing: ["Respiration."],
+  common_mistakes: ["Erreur."],
+}
+
+const makeRow = (
+  overrides: Partial<TranslationReviewRow> & Pick<TranslationReviewRow, "id" | "name">,
+): TranslationReviewRow => ({
+  name_en: null,
+  instructions,
+  instructions_en: {
+    setup: ["Set up."],
+    movement: ["Move."],
+    breathing: ["Breathe."],
+    common_mistakes: ["Mistake."],
+  },
+  instructions_en_status: "clean",
+  instructions_en_audit: null,
+  logged_sets: 0,
+  ...overrides,
+})
+
+// The RPC's order: flagged first even when it has never been logged, then the
+// clean rows by reading exposure. The page must render it as given.
+const queueInRpcOrder: TranslationReviewRow[] = [
+  makeRow({
+    id: "flagged-never-logged",
+    name: "Cat-cow",
+    instructions_en_status: "flagged",
+    logged_sets: 0,
+  }),
+  makeRow({ id: "clean-heavy", name: "Bench press", logged_sets: 152 }),
+  makeRow({ id: "clean-light", name: "Band pull-apart", logged_sets: 3 }),
+]
+
+const mockedQueue = vi.mocked(useTranslationReviewQueue)
+
+beforeEach(() => {
+  mockedQueue.mockReturnValue(
+    mockQueryResult(queueInRpcOrder) as ReturnType<
+      typeof useTranslationReviewQueue
+    >,
+  )
+})
+
+describe("AdminTranslationsPage", () => {
+  it("opens on the first row the RPC returned", () => {
+    renderWithProviders(<AdminTranslationsPage />)
+
+    expect(screen.getByRole("heading", { name: "Cat-cow" })).toBeInTheDocument()
+    expect(screen.getByText("1/3")).toBeInTheDocument()
+  })
+
+  // The ordering criterion, at the level this page is responsible for: the
+  // never-logged flagged row leads, and no client-side re-sort sinks it below
+  // the clean row with 152 logged sets.
+  it("walks the queue in the order it was given, flagged first", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<AdminTranslationsPage />)
+
+    expect(screen.getByRole("heading", { name: "Cat-cow" })).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /next/i }))
+    expect(
+      screen.getByRole("heading", { name: "Bench press" }),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /next/i }))
+    expect(
+      screen.getByRole("heading", { name: "Band pull-apart" }),
+    ).toBeInTheDocument()
+  })
+
+  it("goes back the way it came", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<AdminTranslationsPage />)
+
+    await user.click(screen.getByRole("button", { name: /next/i }))
+    await user.click(screen.getByRole("button", { name: /previous/i }))
+
+    expect(screen.getByRole("heading", { name: "Cat-cow" })).toBeInTheDocument()
+  })
+
+  it("stops at both ends of the queue", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<AdminTranslationsPage />)
+
+    expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled()
+
+    await user.click(screen.getByRole("button", { name: /next/i }))
+    await user.click(screen.getByRole("button", { name: /next/i }))
+
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled()
+  })
+
+  it("shows the empty state when the queue is exhausted", () => {
+    mockedQueue.mockReturnValue(
+      mockQueryResult([]) as ReturnType<typeof useTranslationReviewQueue>,
+    )
+    renderWithProviders(<AdminTranslationsPage />)
+
+    expect(
+      screen.getByText("No translation left to review!"),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /next/i })).toBeNull()
+  })
+
+  it("translates its own shell", () => {
+    renderWithProviders(<AdminTranslationsPage />, { locale: "fr" })
+
+    expect(
+      screen.getByRole("heading", { name: "Relecture des traductions" }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /suivant/i })).toBeInTheDocument()
+  })
+})

--- a/src/pages/AdminTranslationsPage.tsx
+++ b/src/pages/AdminTranslationsPage.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react"
+import { Link } from "react-router-dom"
+import { useTranslation } from "react-i18next"
+import { ChevronLeft, ChevronRight, Loader2, PartyPopper } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { TranslationReviewCard } from "@/components/admin/translations/TranslationReviewCard"
+import { useTranslationReviewQueue } from "@/hooks/useTranslationReviewQueue"
+
+export function AdminTranslationsPage() {
+  const { t } = useTranslation("admin")
+  const { data: queue, isLoading } = useTranslationReviewQueue()
+  const [index, setIndex] = useState(0)
+
+  const total = queue?.length ?? 0
+  // Clamped rather than reset: the queue is read-only in this ticket, so the
+  // only way the index can outrun it is a refetch shrinking the list.
+  const position = Math.min(index, Math.max(total - 1, 0))
+  const row = total > 0 ? queue![position] : null
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 p-4">
+      <div>
+        <h1 className="text-2xl font-bold">{t("translations.title")}</h1>
+        <p className="text-sm text-muted-foreground">
+          {t("translations.description")}
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : row === null ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
+          <PartyPopper className="h-12 w-12 text-primary" />
+          <div>
+            <p className="text-lg font-semibold">{t("translations.allDone")}</p>
+            <p className="text-sm text-muted-foreground">
+              {t("translations.allDoneHint")}
+            </p>
+          </div>
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/admin">{t("translations.backToAdmin")}</Link>
+          </Button>
+        </div>
+      ) : (
+        <>
+          <div className="flex items-center gap-3">
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-primary transition-all duration-500"
+                style={{ width: `${((position + 1) / total) * 100}%` }}
+              />
+            </div>
+            <Badge
+              variant="outline"
+              className="shrink-0 tabular-nums text-muted-foreground"
+            >
+              {position + 1}/{total}
+            </Badge>
+          </div>
+
+          <TranslationReviewCard key={row.id} row={row} />
+
+          <div className="flex items-center justify-between gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gap-2 text-muted-foreground"
+              onClick={() => setIndex(position - 1)}
+              disabled={position === 0}
+            >
+              <ChevronLeft className="h-4 w-4" />
+              {t("translations.previous")}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gap-2 text-muted-foreground"
+              onClick={() => setIndex(position + 1)}
+              disabled={position >= total - 1}
+            >
+              {t("translations.next")}
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/router/AdminGuard.test.tsx
+++ b/src/router/AdminGuard.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest"
+import { act, screen } from "@testing-library/react"
+import { Route, Routes } from "react-router-dom"
+import { renderWithProviders } from "@/test/utils"
+import { AdminGuard } from "@/router/AdminGuard"
+import { isAdminAtom, isAdminLoadingAtom } from "@/store/atoms"
+
+/**
+ * `/admin/translations` is guarded by the same `AdminGuard` as the five admin
+ * routes that came before it, so the criterion is a fact about the guard rather
+ * than about the page — verified here once, on the real route path.
+ */
+function renderGuardedRoute({
+  isAdmin,
+  isLoading = false,
+}: {
+  isAdmin: boolean
+  isLoading?: boolean
+}) {
+  const rendered = renderWithProviders(
+    <Routes>
+      <Route path="/" element={<p>home</p>} />
+      <Route element={<AdminGuard />}>
+        <Route path="/admin/translations" element={<p>translation queue</p>} />
+      </Route>
+    </Routes>,
+    { initialEntries: ["/admin/translations"] },
+  )
+
+  // `isAdminLoadingAtom` starts true, so the first paint renders neither branch
+  // and the verdict below is the only one the router ever sees.
+  act(() => {
+    rendered.store.set(isAdminAtom, isAdmin)
+    rendered.store.set(isAdminLoadingAtom, isLoading)
+  })
+  return rendered
+}
+
+describe("AdminGuard on /admin/translations", () => {
+  it("lets an admin through", () => {
+    renderGuardedRoute({ isAdmin: true })
+
+    expect(screen.getByText("translation queue")).toBeInTheDocument()
+  })
+
+  it("redirects a non-admin home", () => {
+    renderGuardedRoute({ isAdmin: false })
+
+    expect(screen.queryByText("translation queue")).toBeNull()
+    expect(screen.getByText("home")).toBeInTheDocument()
+  })
+
+  // Rendering nothing while the admin flag is still resolving is what stops a
+  // legitimate admin from being bounced home on a slow first paint.
+  it("shows neither the route nor the redirect while the flag is loading", () => {
+    renderGuardedRoute({ isAdmin: false, isLoading: true })
+
+    expect(screen.queryByText("translation queue")).toBeNull()
+    expect(screen.queryByText("home")).toBeNull()
+  })
+})

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -71,6 +71,11 @@ const AdminReviewPage = lazyWithRecover(() =>
     default: m.AdminReviewPage,
   })),
 )
+const AdminTranslationsPage = lazyWithRecover(() =>
+  import("@/pages/AdminTranslationsPage").then((m) => ({
+    default: m.AdminTranslationsPage,
+  })),
+)
 const CycleSummaryPage = lazyWithRecover(() =>
   import("@/pages/CycleSummaryPage").then((m) => ({
     default: m.CycleSummaryPage,
@@ -209,6 +214,10 @@ export const router = createBrowserRouter([
                   {
                     path: "/admin/review",
                     element: <AdminReviewPage />,
+                  },
+                  {
+                    path: "/admin/translations",
+                    element: <AdminTranslationsPage />,
                   },
                   {
                     path: "/admin/enrichment",

--- a/src/test/instructionResolution.arch.test.ts
+++ b/src/test/instructionResolution.arch.test.ts
@@ -32,13 +32,18 @@ const code = (source: string) =>
   source.replace(/"[^"\n]*"|'[^'\n]*'|`[^`]*`/g, '""')
 
 /**
- * The two files that legitimately read the French block: both edit or count the
- * *source* content in admin, neither renders instructions to a reader. Listed
- * rather than pattern-matched so that adding one is a deliberate act.
+ * The files that legitimately read the raw blocks. The first two edit or count
+ * the *source* content in admin. The third is the translation review card,
+ * which is the one screen whose job is to show both sides unresolved: running
+ * it through the resolver would render a `flagged` row as French and hide the
+ * very translation the reviewer was summoned to arbitrate.
+ *
+ * Listed rather than pattern-matched so that adding one is a deliberate act.
  */
 const FRENCH_SOURCE_READERS = [
   "src/components/admin/exercise-form/transforms.ts",
   "src/components/admin/exercises-table/columns.tsx",
+  "src/components/admin/translations/TranslationReviewCard.tsx",
 ]
 
 describe("instruction reads in components", () => {

--- a/src/test/translationReviewRpc.arch.test.ts
+++ b/src/test/translationReviewRpc.arch.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest"
+
+/**
+ * `get_translations_for_review` is SECURITY DEFINER and counts `set_logs`,
+ * whose RLS policy is per-user. With EXECUTE granted to `authenticated` and no
+ * check in the body, any signed-in user reads cross-user training volume —
+ * which is exactly what shipped, and was caught in review on PR #439.
+ *
+ * The guard is four lines of SQL with no visible connection to the join that
+ * makes it necessary, so it is precisely the kind of thing a later "simplify
+ * this function" pass deletes. These assertions are the tripwire.
+ */
+
+const migrationSources = import.meta.glob("../../supabase/migrations/*.sql", {
+  query: "?raw",
+  eager: true,
+  import: "default",
+}) as Record<string, string>
+
+const repoPath = (globKey: string) => globKey.slice("../../".length)
+
+const definitions = Object.entries(migrationSources)
+  .filter(([, sql]) =>
+    /FUNCTION\s+get_translations_for_review\s*\(/.test(sql),
+  )
+  .sort(([a], [b]) => a.localeCompare(b))
+
+const [path, sql = ""] = definitions[definitions.length - 1] ?? []
+
+describe("get_translations_for_review", () => {
+  it("is defined exactly where this guard expects it", () => {
+    expect(repoPath(path ?? "")).toBe(
+      "supabase/migrations/20260802150000_create_translation_review_rpc.sql",
+    )
+  })
+
+  it("authorizes against admin_users inside the body", () => {
+    expect(sql).toMatch(
+      /auth\.jwt\(\)\s*->>\s*'email'\s+IN\s*\(\s*SELECT\s+email\s+FROM\s+admin_users\s*\)/,
+    )
+  })
+
+  it("raises insufficient_privilege instead of returning an empty queue", () => {
+    // Zero rows would render as "No translation left to review!" — a gate the
+    // reviewer cannot tell apart from a finished job.
+    expect(sql).toMatch(/RAISE EXCEPTION[^;]*ERRCODE\s*=\s*'insufficient_privilege'/s)
+  })
+
+  it("is plpgsql, which is what makes the raise possible at all", () => {
+    expect(sql).toMatch(/LANGUAGE plpgsql/)
+    expect(sql).not.toMatch(/LANGUAGE sql/)
+  })
+
+  it("keeps SECURITY DEFINER pinned to a fixed search_path", () => {
+    expect(sql).toMatch(/SECURITY DEFINER/)
+    expect(sql).toMatch(/SET search_path = public/)
+  })
+
+  it("revokes PUBLIC and never grants EXECUTE to anon", () => {
+    const grantees = [
+      ...sql.matchAll(
+        /GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+get_translations_for_review\(\)\s+TO\s+([^;]+);/g,
+      ),
+    ].flatMap(([, list]) => list.split(",").map((role) => role.trim()))
+
+    expect(sql).toMatch(
+      /REVOKE ALL ON FUNCTION get_translations_for_review\(\) FROM PUBLIC;/,
+    )
+    expect(grantees).toEqual(["authenticated", "service_role"])
+  })
+})

--- a/supabase/migrations/20260802150000_create_translation_review_rpc.sql
+++ b/supabase/migrations/20260802150000_create_translation_review_rpc.sql
@@ -1,0 +1,58 @@
+-- Translation review queue (T158).
+--
+-- Deliberately not an extension of get_unreviewed_exercises_by_usage. That one
+-- lists 18 columns by hand and rots on every schema addition, and it counts
+-- prescriptions (workout_exercises + template_exercises). This one projects the
+-- eight fields the queue renders and counts set_logs, which is actual reading
+-- exposure: a translation nobody ever sees while training is not urgent.
+--
+-- The two queues stay watertight. This one filters and orders on
+-- instructions_en_reviewed_at, never on reviewed_at, which content review and
+-- image enrichment already share.
+CREATE OR REPLACE FUNCTION get_translations_for_review()
+RETURNS TABLE (
+  id uuid,
+  name text,
+  name_en text,
+  instructions jsonb,
+  instructions_en jsonb,
+  instructions_en_status text,
+  instructions_en_audit jsonb,
+  logged_sets bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    e.id,
+    e.name,
+    e.name_en,
+    e.instructions,
+    e.instructions_en,
+    e.instructions_en_status,
+    e.instructions_en_audit,
+    COALESCE(sl.cnt, 0) AS logged_sets
+  FROM exercises e
+  LEFT JOIN (
+    SELECT exercise_id, COUNT(*) AS cnt
+    FROM set_logs
+    GROUP BY exercise_id
+  ) sl ON sl.exercise_id = e.id
+  WHERE e.instructions_en IS NOT NULL
+    AND e.instructions_en_reviewed_at IS NULL
+  ORDER BY
+    -- NULLS LAST because DESC puts them first by default, and the comparison is
+    -- NULL for any row carrying English with no status. Such a row is malformed
+    -- rather than urgent; it must not outrank a genuine flag.
+    (e.instructions_en_status = 'flagged') DESC NULLS LAST,
+    COALESCE(sl.cnt, 0) DESC,
+    e.name ASC;
+$$;
+
+-- SECURITY DEFINER plus the default PUBLIC grant is how the existing RPCs are
+-- already flagged by Supabase's linter. A new function does not have to inherit
+-- that: the review queue is an admin surface, and nothing anonymous reads it.
+REVOKE ALL ON FUNCTION get_translations_for_review() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_translations_for_review() TO authenticated, service_role;

--- a/supabase/migrations/20260802150000_create_translation_review_rpc.sql
+++ b/supabase/migrations/20260802150000_create_translation_review_rpc.sql
@@ -9,6 +9,17 @@
 -- The two queues stay watertight. This one filters and orders on
 -- instructions_en_reviewed_at, never on reviewed_at, which content review and
 -- image enrichment already share.
+--
+-- SECURITY DEFINER here bypasses RLS, and the set_logs count below crosses the
+-- per-user policy on that table ("Users manage own set_logs"). Granting EXECUTE
+-- to `authenticated` therefore has to be paired with an in-body authorization
+-- check, or any signed-in user reads aggregate training volume for everybody.
+--
+-- This is the FIRST RPC in this repo to authorize against `admin_users`. Every
+-- other SECURITY DEFINER function — `get_unreviewed_exercises_by_usage`
+-- included — is protected by the client-side /admin route guard alone, which is
+-- a suggestion rather than a boundary. Those are a separate, larger job; do not
+-- read their absence of a gate as a precedent for removing this one.
 CREATE OR REPLACE FUNCTION get_translations_for_review()
 RETURNS TABLE (
   id uuid,
@@ -20,11 +31,29 @@ RETURNS TABLE (
   instructions_en_audit jsonb,
   logged_sets bigint
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = public
 AS $$
+BEGIN
+  -- Raise rather than return zero rows. An empty result is indistinguishable
+  -- from a drained queue, and the page renders "No translation left to review!"
+  -- for it — a silent gate would make the UI lie to the very person debugging
+  -- it. plpgsql, not sql, exists purely so this RAISE is possible.
+  --
+  -- Same predicate as the exercises RLS policies, wrapped in COALESCE because a
+  -- token with no email claim makes the IN yield NULL, and `NOT NULL` is NULL,
+  -- which an IF treats as false — i.e. it would let the caller straight through.
+  IF NOT COALESCE(
+    auth.jwt() ->> 'email' IN (SELECT email FROM admin_users),
+    false
+  ) THEN
+    RAISE EXCEPTION 'get_translations_for_review is restricted to admin users'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
   SELECT
     e.id,
     e.name,
@@ -49,10 +78,12 @@ AS $$
     (e.instructions_en_status = 'flagged') DESC NULLS LAST,
     COALESCE(sl.cnt, 0) DESC,
     e.name ASC;
+END;
 $$;
 
--- SECURITY DEFINER plus the default PUBLIC grant is how the existing RPCs are
--- already flagged by Supabase's linter. A new function does not have to inherit
--- that: the review queue is an admin surface, and nothing anonymous reads it.
+-- `authenticated` is the right grantee even though the function is admin-only:
+-- the app calls this over PostgREST as the signed-in admin, not as service_role,
+-- so a narrower grant would break the page rather than secure it. Authorization
+-- lives in the body; the grants only keep `anon` and PUBLIC off the entry point.
 REVOKE ALL ON FUNCTION get_translations_for_review() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION get_translations_for_review() TO authenticated, service_role;


### PR DESCRIPTION
Part of #417, ticket T158 in #436. Follows T156 (#437) and T157 (#438).

> [!IMPORTANT]
> **The migration is not applied.** `supabase/migrations/20260802150000_create_translation_review_rpc.sql` creates `get_translations_for_review()` and must go to production **before** this merges — nothing calls the RPC until this page exists, so the risk is low, but the ordering discipline is the one T156 nearly got wrong in the other direction.

## What

A read-only review surface at `/admin/translations`: a priority-ordered queue of translated exercises awaiting a human read, and a French/English comparison aligned sentence by sentence with the cross-checker's objections attached to the sentences they targeted.

- `get_translations_for_review()` — eight columns, ordered flagged-first then by logged sets then by name
- `src/lib/translationReview.ts` — pure French/English pairing and objection anchoring
- `useTranslationReviewQueue`, `AdminTranslationsPage`, `TranslationReviewCard`
- `admin.translations.*` keys in both `en` and `fr`

Approving, editing and reverting to French are T159; the clipboard assist is T160.

## Why

The epic's whole bet is that machine translation plus an automated gate plus a cross-reader gets close enough that a human only arbitrates the leftovers. Nobody can check that bet without a surface that shows the leftovers. Shipping the read side alone means the real flag rate can be looked at before the write path is built on assumptions about it.

The queue is deliberately a sibling route rather than a tab on the existing review screen, and it filters on `instructions_en_reviewed_at` rather than `reviewed_at`. The two queues have to stay watertight: `reviewed_at` is already shared between content review and image enrichment, and a third reader on it would make "reviewed" mean three different things.

## How

**The RPC counts reading exposure, not prescriptions.** `get_unreviewed_exercises_by_usage` counts `workout_exercises` + `template_exercises`, which measures how often an exercise is *programmed*. This one counts `set_logs`, which measures how often it is actually *read* mid-set — a bad translation on a page nobody opens is not urgent.

**The alignment is pure.** "The objection appears on the sentence it targeted" is the criterion this screen exists for, and it is a fact about data, so `buildReviewSections` lives in `src/lib` with no React and no i18next, and the criterion is asserted directly rather than inferred from a rendered tree. Objections are keyed by `section.index`, never by position, so one stray objection cannot shift the rest onto the wrong sentences.

**The card is registered as a deliberate exception to the ADR-0010 resolver guard.** That guard fired on this PR, correctly: the card reads `instructions` and `instructions_en` raw. It is the one screen that must — running a `flagged` row through `resolveExerciseInstructions` would render it as French and hide the translation the reviewer was summoned to arbitrate. The exception is listed by name in `instructionResolution.arch.test.ts`, which is how that file is designed to be extended.

**Two one-token departures from the Tech Plan's SQL**, both explained in the migration and both worth an explicit yes or no when you review the SQL:

- `NULLS LAST` on the flagged key. `(instructions_en_status = 'flagged')` is NULL for a row carrying English with no status, and `DESC` sorts NULLs first. Measured against the plan's exact clause, such a row lands at position 1, above a genuine flag.
- `SET search_path = public`, plus `REVOKE ... FROM PUBLIC` and a grant to `authenticated`. Six existing functions already carry the linter's mutable-search-path warning and seven are anon-callable; a new `SECURITY DEFINER` function on an admin surface need not join them.

## Acceptance criteria

| Criterion | Verified how |
|---|---|
| Eight columns, counts logged sets not prescriptions | RPC body run read-only against production: 4 rows, and every column's `pg_typeof` matches the `RETURNS TABLE` declaration (`uuid, text, text, jsonb, jsonb, text, jsonb, bigint`) |
| Flagged before clean | Real data — `Cat-cow` (flagged, 0 logged sets) leads three clean rows — plus `AdminTranslationsPage.test.tsx` asserting the page does not re-sort |
| Clean rows by logged sets descending | **Not observable on real data**: all four rows have 0 logged sets. Proved by running the exact `ORDER BY` clause against synthetic rows in production Postgres — 900, then 3, then 3 broken by name |
| An objection renders on the sentence it targeted | `translationReview.test.ts` (data) and `TranslationReviewCard.test.tsx` (markup), both asserting the untargeted sentence stays clean |
| Labels in en and fr, nothing hard-coded | Both locale files; card and page tests re-render under `fr` and assert French labels |
| `/admin/translations` closed to non-admins | `AdminGuard.test.tsx`, on the real route path — admin through, non-admin redirected, neither branch while the flag loads |
| `get_unreviewed_exercises_by_usage` unchanged, same counts | `git diff` empty on the migration, the hook and the page; the function returns 0 rows, matching its independent oracle `count(*) FROM exercises WHERE reviewed_at IS NULL` |

**Démo:** no seeding. Production already holds four real rows from T157's run — `Cat-cow` flagged on a `calques: lumbar` gate flag, and `Band pull-apart`, `Curl inversé au pupitre prise serrée` and `Hollow Plank` clean. All four are never-logged, which makes the flagged row a real test of the ordering rather than a decorative one.

## Verification

```
npx tsc -b                                              exit 0
npm run lint                                            0 errors, 20 warnings (unchanged)
VITE_SUPABASE_URL= VITE_SUPABASE_ANON_KEY= npx vitest run
                                                        210 files, 2043 tests passing
npm run build                                           exit 0
```

Made with [Cursor](https://cursor.com)