### PR TITLE
chore(test): architecture guard for SECURITY DEFINER functions (#440)

### DIFF
--- a/src/test/securityDefiner.arch.test.ts
+++ b/src/test/securityDefiner.arch.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from "vitest"
+
+/**
+ * PR #442 closed the SECURITY DEFINER holes that existed on the day it was
+ * written (#440). It does nothing about the next one. A SECURITY DEFINER
+ * function runs as its owner and reads straight past RLS, so the only thing
+ * between a caller and everybody else's rows is a check inside the body — and
+ * the whole finding in #440 was that route guards in the React app had been
+ * mistaken for that check.
+ *
+ * This sweeps every migration and refuses to let a new unguarded one land.
+ *
+ * What it can and cannot say: it proves an authorization signal is *present*,
+ * not that it is *correct*. The fail-open guard #440 found —
+ * `auth.uid() IS NOT NULL AND auth.uid() <> p_user_id`, which admits every
+ * keyless caller — would satisfy this test, because it is a real comparison
+ * against a real user column. Judging whether a guard holds stays a human job.
+ * This only guarantees there is something for the human to judge.
+ */
+
+const migrationSources = import.meta.glob("../../supabase/migrations/*.sql", {
+  query: "?raw",
+  eager: true,
+  import: "default",
+}) as Record<string, string>
+
+const repoPath = (globKey: string) => globKey.slice("../../".length)
+
+/**
+ * Line comments only. `supabase/migrations/` contains no C-style comment blocks
+ * and no `--` inside a string literal; either would need real lexing rather
+ * than a replace, and would make this scan understate the surface it covers.
+ * The migration in #442 argues for itself in 90 lines of prose containing the
+ * words SECURITY DEFINER eight times, so scanning comments is not an option.
+ */
+const stripComments = (sql: string) => sql.replace(/--[^\n]*/g, "")
+
+const FUNCTION_HEAD = /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s/i
+
+type FunctionStatement = {
+  readonly name: string
+  readonly file: string
+  /** The declared parameter list, normalized, for the overload check below. */
+  readonly signature: string
+  /** Everything from `CREATE` up to the opening `$$`. */
+  readonly header: string
+  /** Everything between the `$$` delimiters. */
+  readonly body: string
+  /** Everything from the closing `$$` to the terminating `;`. */
+  readonly trailer: string
+}
+
+/**
+ * Postgres accepts the attribute clauses on either side of the body —
+ * `20260405120000_transactional_email.sql` writes `$$ LANGUAGE plpgsql;` — so
+ * SECURITY DEFINER and SET search_path have to be looked for in both.
+ */
+const attributes = (statement: FunctionStatement) =>
+  `${statement.header}\n${statement.trailer}`
+
+/**
+ * Split on the statement boundary, then cut each chunk on its `$$` delimiters.
+ * Every body in this directory is delimited by a bare `$$`; no named `$tag$` is
+ * in use. Cutting on delimiters rather than matching a whole statement with one
+ * regex keeps the parameter list, the RETURNS TABLE column list and the body
+ * out of each other's way — all three contain commas and parentheses.
+ */
+const parseFunctions = (path: string, sql: string): FunctionStatement[] =>
+  sql
+    .split(new RegExp(`(?=${FUNCTION_HEAD.source})`, "i"))
+    .filter((chunk) => new RegExp(`^${FUNCTION_HEAD.source}`, "i").test(chunk))
+    .map((chunk) => {
+      const open = chunk.indexOf("$$")
+      const close = chunk.indexOf("$$", open + 2)
+      const terminator = chunk.indexOf(";", close + 2)
+      const header = open === -1 ? chunk : chunk.slice(0, open)
+
+      return {
+        name: /FUNCTION\s+(?:public\.)?(\w+)/i.exec(chunk)?.[1] ?? "",
+        file: repoPath(path),
+        signature: header
+          .slice(0, header.search(/\bRETURNS\b/i))
+          .replace(FUNCTION_HEAD, "")
+          .replace(/\bpublic\./i, "")
+          .replace(/\s+/g, " ")
+          .trim(),
+        header,
+        body: open === -1 || close === -1 ? "" : chunk.slice(open + 2, close),
+        trailer:
+          close === -1
+            ? ""
+            : chunk.slice(close + 2, terminator === -1 ? undefined : terminator),
+      }
+    })
+
+/**
+ * Migration filenames are `<version>_<slug>.sql`, so lexicographic order is
+ * apply order, and a file's chunks come out in the order they run.
+ */
+const statements = Object.entries(migrationSources)
+  .sort(([a], [b]) => a.localeCompare(b))
+  .flatMap(([path, sql]) => parseFunctions(path, stripComments(sql)))
+
+/**
+ * THE ORDERING RULE, and the subtle part of this file.
+ *
+ * A function can be created insecurely and hardened later by a
+ * `CREATE OR REPLACE` in a newer migration — which is exactly what PR #442 did
+ * to five of these. Only the *last* definition survives in the database, so
+ * only the last one may be asserted on. Asserting on every definition would
+ * fail over history that no longer exists; asserting on the first would miss
+ * every fix. The reverse case matters just as much: a function hardened in one
+ * migration and replaced by a careless copy-paste in a later one is a
+ * regression this test has to catch, and only last-wins catches it.
+ *
+ * `new Map(entries)` keeps the last value for a repeated key, and `statements`
+ * is already in apply order, so this line is that rule and nothing else.
+ *
+ * Keyed on the bare name, not the full signature. Postgres identifies a
+ * function by name *and* argument types, so two overloads would collapse into
+ * one entry here and hide the un-hardened twin. No function in this repo is
+ * overloaded; the parameter-list assertion below is what keeps that true.
+ */
+const effectiveDefinitions = new Map(
+  statements.map((statement) => [statement.name, statement] as const),
+)
+
+const securityDefiners = [...effectiveDefinitions.values()]
+  .filter((statement) => /\bSECURITY\s+DEFINER\b/i.test(attributes(statement)))
+  .sort((a, b) => a.name.localeCompare(b.name))
+
+/**
+ * Recognized authorization signals, named so a failure reports which kind of
+ * check was looked for rather than dumping a regex at the reader.
+ */
+const AUTHORIZATION_SIGNALS: ReadonlyArray<readonly [string, RegExp]> = [
+  [
+    "auth.uid() compared against a user column",
+    /auth\.uid\(\)\s*(?:=|<>)|(?:=|<>)\s*auth\.uid\(\)/i,
+  ],
+  ["admin_users membership", /\badmin_users\b/i],
+  ["is_trusted_backend_caller()", /\bis_trusted_backend_caller\s*\(\s*\)/i],
+  [
+    "RAISE ... USING ERRCODE = 'insufficient_privilege'",
+    /ERRCODE\s*=\s*'insufficient_privilege'/i,
+  ],
+  ["auth.role() / auth.jwt() claim check", /auth\.(?:role|jwt)\(\)/i],
+]
+
+const signalsIn = (statement: FunctionStatement) =>
+  AUTHORIZATION_SIGNALS.filter(([, pattern]) =>
+    pattern.test(statement.body),
+  ).map(([label]) => label)
+
+const SECURITY_DEFINER_FUNCTIONS = [
+  "check_and_grant_achievements",
+  "get_badge_status",
+  "get_cycle_stats",
+  "get_exercise_filter_options",
+  "get_translations_for_review",
+  "get_unreviewed_exercises_by_usage",
+  "get_volume_by_muscle_group",
+  "validate_title_ownership",
+]
+
+/**
+ * SECURITY DEFINER functions that carry no in-body authorization check, and the
+ * reason each is allowed not to. Adding a name here is a security decision, so
+ * it costs a line of justification.
+ *
+ * - get_exercise_filter_options: reads nothing but `exercises`, whose SELECT
+ *   policy is `USING (true)` for PUBLIC, so there is no per-user notion to
+ *   check and definer rights buy the caller no reach it lacks — the same three
+ *   lists come out of GET /rest/v1/exercises.
+ * - validate_title_ownership: a trigger function. Postgres refuses a direct
+ *   call and PostgREST does not expose RETURNS trigger over /rpc, so it has no
+ *   caller to authorize; the ownership check it makes on NEW.user_id is the
+ *   purpose of the function rather than a gate on it.
+ */
+const UNGUARDED_BY_DESIGN = [
+  "get_exercise_filter_options",
+  "validate_title_ownership",
+]
+
+/**
+ * SECURITY DEFINER functions whose effective definition does not pin
+ * `search_path`. That is a privilege-escalation vector rather than a style
+ * nit: owner rights plus a caller-influenced resolution order lets a shadowing
+ * schema substitute its own `exercises` or `admin_users` under the function.
+ *
+ * Empty, and it should stay that way. `get_unreviewed_exercises_by_usage` was
+ * the one offender — created without it in 20260414000000 — and PR #442's
+ * redefinition supplied it. That repair is only visible through the ordering
+ * rule above, which is a decent argument for the rule.
+ */
+const MISSING_SEARCH_PATH: string[] = []
+
+describe("migration parsing", () => {
+  // A regex sweep over SQL that quietly matches nothing is the failure mode to
+  // fear here: it reports green forever and nobody looks again. These three say
+  // the sweep reached every statement and cut each one where it meant to.
+  it("finds every CREATE FUNCTION statement in the migrations directory", () => {
+    const declared = Object.values(migrationSources)
+      .map(stripComments)
+      .flatMap((sql) => [
+        ...sql.matchAll(new RegExp(FUNCTION_HEAD.source, "gi")),
+      ]).length
+
+    expect(statements).toHaveLength(declared)
+    expect(statements.length).toBeGreaterThan(0)
+  })
+
+  it("delimits a body for every one of them", () => {
+    const bodyless = statements
+      .filter((statement) => statement.body.trim() === "")
+      .map((statement) => `${statement.file}: ${statement.name}`)
+
+    expect(bodyless).toEqual([])
+  })
+
+  it("recovers the LANGUAGE clause for every one of them", () => {
+    // Independent of the cut: every Postgres function must declare a LANGUAGE
+    // and it sits outside the body, so a misaligned header/trailer slice shows
+    // up here rather than as a silently empty scan.
+    //
+    // The optional quotes are not decoration. 20260314000003 writes
+    // `$$ language 'plpgsql';` — the legacy quoted form, still accepted — and
+    // an unquoted-only pattern reports it as unparsed.
+    const unrecognized = statements
+      .filter(
+        (statement) =>
+          !/\bLANGUAGE\s+'?(?:sql|plpgsql)'?/i.test(attributes(statement)),
+      )
+      .map((statement) => `${statement.file}: ${statement.name}`)
+
+    expect(unrecognized).toEqual([])
+  })
+
+  it("sees one parameter list per function, so name-keying is sound", () => {
+    // An overload — same name, different argument types — is a second function
+    // in Postgres, and the map above would keep only one of the two. If this
+    // ever fails, the fix is to key effectiveDefinitions on the signature, not
+    // to delete the assertion.
+    const overloaded = [...new Set(statements.map(({ name }) => name))]
+      .filter(
+        (name) =>
+          new Set(
+            statements
+              .filter((statement) => statement.name === name)
+              .map(({ signature }) => signature),
+          ).size > 1,
+      )
+      .sort()
+
+    expect(overloaded).toEqual([])
+  })
+})
+
+describe("SECURITY DEFINER functions", () => {
+  it("are exactly this set", () => {
+    expect(securityDefiners.map(({ name }) => name)).toEqual(
+      SECURITY_DEFINER_FUNCTIONS,
+    )
+  })
+
+  it("each carry an authorization check in the body", () => {
+    const unguarded = securityDefiners
+      .filter((statement) => signalsIn(statement).length === 0)
+      .map(({ name }) => name)
+
+    expect(unguarded).toEqual(UNGUARDED_BY_DESIGN)
+  })
+
+  it("each pin search_path against schema shadowing", () => {
+    const unpinned = securityDefiners
+      .filter(
+        (statement) => !/\bSET\s+search_path\s*=/i.test(attributes(statement)),
+      )
+      .map(({ name }) => name)
+
+    expect(unpinned).toEqual(MISSING_SEARCH_PATH)
+  })
+
+  it("keep the waiver list free of names that no longer exist", () => {
+    // Otherwise a function can be renamed out from under its own waiver, and
+    // the rename inherits the exemption in silence.
+    const stale = UNGUARDED_BY_DESIGN.filter(
+      (name) => !SECURITY_DEFINER_FUNCTIONS.includes(name),
+    )
+
+    expect(stale).toEqual([])
+  })
+})


### PR DESCRIPTION
Stacked on #442 — base is `fix/440-security-definer-guards`, so **merge this after #442**. The test asserts against the SQL that PR adds and goes red on `main` alone.

This is PR 2 of #440: the inventory and the architecture test #442 promised in its follow-up section. Test-only — no production SQL is touched.

## What

One new file, `src/test/securityDefiner.arch.test.ts`, 8 assertions in two groups.

The inventory it pins, which is the effective state of the database once #442 is applied:

| Function | Effective definition | Guard signals found |
| --- | --- | --- |
| `check_and_grant_achievements` | `20260802170000` | `auth.uid()` comparison, `is_trusted_backend_caller()`, `insufficient_privilege` |
| `get_badge_status` | `20260802170000` | same three |
| `get_cycle_stats` | `20260802170000` | same three |
| `get_volume_by_muscle_group` | `20260802170000` | same three |
| `get_unreviewed_exercises_by_usage` | `20260802170000` | `admin_users`, `insufficient_privilege`, `auth.jwt()` |
| `get_translations_for_review` | `20260802150000` | `admin_users`, `insufficient_privilege`, `auth.jwt()` |
| `get_exercise_filter_options` | `20260313160001` | **none — waived**, reads only the public catalog |
| `validate_title_ownership` | `20260401000003` | **none — waived**, trigger function, no caller to authorize |

All eight pin `SET search_path`, so the known-gaps list ships empty.

## Why

#442 closed the holes that existed on the day it was written. It does nothing about the ninth function, and #440's actual finding — that route guards in the React app had been mistaken for a security boundary — is a mistake that is just as easy to make the second time. A `SECURITY DEFINER` function reads straight past RLS; the only thing between a caller and everybody else's rows is a check in the body, and nothing in the repo said so out loud until now.

The `search_path` assertion is the same argument one level down. A definer function without a pinned `search_path` is a privilege-escalation vector: owner rights plus a caller-influenced resolution order lets a shadowing schema substitute its own `exercises` or `admin_users` underneath the function.

## How

**The effective-definition rule**, which is the subtle part. A function can be created insecurely and hardened later by a `CREATE OR REPLACE` in a newer migration — which is exactly what #442 did to five of these. Only the last definition survives in the database, so only the last one may be asserted on. The test sorts migrations lexicographically (filenames are `<version>_<slug>.sql`, so that is apply order), keeps a file's statements in source order, and folds them through `new Map(entries)`, which keeps the last value per key.

This is not bookkeeping. `get_unreviewed_exercises_by_usage` was created in `20260414000000` with no `SET search_path` at all; #442's redefinition supplied it. Asserting on every definition would fail over history that no longer exists. Asserting on the first would miss every fix. And the reverse case is the regression this test exists to catch: a hardened function replaced by a careless copy-paste in a later migration.

**Parsing.** Split each file on the `CREATE [OR REPLACE] FUNCTION` boundary, then cut each chunk on its `$$` delimiters into header / body / trailer. Attribute clauses are looked for in header *and* trailer, because Postgres accepts them on either side and `20260314000003` writes `$$ language 'plpgsql';`. Guard signals are looked for in the body only. Line comments are stripped first — #442's migration argues for itself in 90 lines of prose containing the words SECURITY DEFINER eight times.

**Guarding against a scan that silently matches nothing**, which is the failure mode that matters for a regex test — it reports green forever and nobody looks again. Four defences:

- the parsed statement count must equal an independent count of `CREATE FUNCTION` occurrences (51 statements; a plain grep finds 52 across the directory, and the difference is one mention inside a comment in `20260506004927`)
- every statement must yield a non-empty body
- every statement must yield a `LANGUAGE` clause — independent of the cut, since `LANGUAGE` sits outside the body, so a misaligned slice surfaces here rather than as an empty scan. This assertion earned its keep during development: it caught the legacy `language 'plpgsql'` quoted form
- no function may have two different parameter lists, because the map is keyed on the bare name and Postgres identifies a function by name *and* argument types. If an overload ever lands, the fix is to key on the signature, not to delete the assertion

**Failure shape.** The name set and the unguarded partition are asserted as exact arrays, following `FRENCH_SOURCE_READERS` in `instructionResolution.arch.test.ts`, so a new unguarded function is a readable diff rather than a boolean. Each waiver carries its reason in the source, one line each, and a fourth assertion keeps the waiver list from outliving the names on it.

**What this test cannot say.** It proves an authorization signal is *present*, not that it is *correct*. The fail-open guard #440 found — `auth.uid() IS NOT NULL AND auth.uid() <> p_user_id` — would satisfy it, because it is a real comparison against a real user column. Judging whether a guard holds stays a human job. This only guarantees there is something for the human to judge. That limitation is stated at the top of the file so nobody mistakes a green run for an audit.

## Test plan

- [x] `npx tsc -p tsconfig.app.json --noEmit` clean
- [x] `npx eslint src/test/securityDefiner.arch.test.ts` clean
- [x] `VITE_SUPABASE_URL= VITE_SUPABASE_ANON_KEY= npx vitest run` — 212 files, 2057 tests passing
- [x] **mutation check, new function** — a scratch migration adding an unguarded `SECURITY DEFINER` function with no `SET search_path` turns three assertions red at once, naming `leaky_user_dump` in each diff
- [x] **mutation check, ordering rule** — a scratch migration re-creating the already-hardened `get_cycle_stats` with the guard dropped turns the authorization assertion red, and the name-set assertion correctly stays green because the set did not change. This is the one that proves last-wins actually works
- [x] scratch migration deleted, working tree clean, suite green again

## Note for the reviewer, not addressed here

`get_translations_for_review` (from #439) is revoked `FROM PUBLIC` only — `anon` is never named, and #442 does not re-revoke it. By the central argument of #442's own description, a PUBLIC-only revoke leaves Supabase's explicit `anon=X` default-privilege grant standing.

**Not exploitable.** The body gate fails closed for `anon`: no email claim makes the `IN` yield NULL, `COALESCE(..., false)` turns that into false, and the function raises `insufficient_privilege`. So this is a defence-in-depth gap rather than a data exposure — but it is the exact shape of defect #442 was written to eliminate, and it is the only one of the eight functions still carrying it. Left alone deliberately, since a grant change needs its own production migration. Worth a follow-up issue.

Relates to #440.

Made with [Cursor](https://cursor.com)

---

**CI does not run on this PR.** `.github/workflows/ci.yml` is gated on `pull_request: branches: [main]`, and this one targets `fix/440-security-definer-guards`, so the checks list is empty by configuration rather than by failure. Everything in the test plan above was run locally. If you would rather see a green tick than take my word for it, retarget with `gh pr edit 443 --base main` — the diff then also carries #442's three commits, since this branch is built on them.
