### PR TITLE
feat(i18n): approve, edit & revert translations (T159)

### DIFF
--- a/src/components/admin/translations/TranslationReviewCard.test.tsx
+++ b/src/components/admin/translations/TranslationReviewCard.test.tsx
@@ -7,10 +7,12 @@ import type { TranslationReviewRow } from "@/hooks/useTranslationReviewQueue"
 
 type Payload = Record<string, unknown>
 
-const single = vi.fn()
-const eq = vi.fn<
-  (column: string, id: string) => { select: () => { single: typeof single } }
->(() => ({ select: () => ({ single }) }))
+type Response = { data: { id: string }[] | null; error: Error | null }
+
+const select = vi.fn<(columns: string) => Promise<Response>>()
+const eq = vi.fn<(column: string, id: string) => { select: typeof select }>(
+  () => ({ select }),
+)
 const update = vi.fn<(payload: Payload) => { eq: typeof eq }>(() => ({ eq }))
 const toastSuccess = vi.fn()
 const toastError = vi.fn()
@@ -30,7 +32,7 @@ const lastPayload = (): Payload => update.mock.calls.at(-1)?.[0] ?? {}
 
 beforeEach(() => {
   vi.clearAllMocks()
-  single.mockResolvedValue({ data: { id: "row-1" }, error: null })
+  select.mockResolvedValue({ data: [{ id: "row-1" }], error: null })
 })
 
 const row: TranslationReviewRow = {
@@ -341,7 +343,7 @@ describe("TranslationReviewCard decisions", () => {
   // The failure path the reviewer must be able to trust: nothing was recorded,
   // so the row has to still be there — and they have to be told.
   it("reports a failed write and keeps the row on screen", async () => {
-    single.mockResolvedValue({ data: null, error: new Error("rls denied") })
+    select.mockResolvedValue({ data: null, error: new Error("rls denied") })
     const user = userEvent.setup()
     renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
 
@@ -354,11 +356,91 @@ describe("TranslationReviewCard decisions", () => {
     ).toBeInTheDocument()
   })
 
+  // Half of Bugbot's high finding: `E` opened the editor but left focus on the
+  // card, so the first thing typed went to the shortcut handler.
+  it("puts the cursor in the first section when edit mode opens", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("e")
+
+    expect(screen.getAllByRole("textbox")[0]).toHaveFocus()
+  })
+
+  // The other half, and the reason focus management alone will not do: a
+  // reviewer can click the card background, or the browser can restore focus
+  // somewhere unhelpful. With the handler live, typing the word "bar" approves
+  // the translation on their behalf — an action attributed to a human who did
+  // not take it.
+  it("stops handling shortcuts while edit mode is open, wherever focus lands", async () => {
+    const user = userEvent.setup()
+    const onSkip = vi.fn()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={onSkip} />)
+
+    await user.keyboard("e")
+    await user.click(screen.getByRole("article"))
+    await user.keyboard("bar{ArrowRight}")
+
+    expect(update).not.toHaveBeenCalled()
+    expect(onSkip).not.toHaveBeenCalled()
+    expect(screen.getAllByRole("textbox")).toHaveLength(4)
+  })
+
+  // Escape is the only key the handler still answers in edit mode, and it means
+  // what the button next to it says: cancel. The draft goes, and the shortcuts
+  // come back — which they cannot do unless focus comes back to the card too.
+  it("discards the correction and re-arms the shortcuts on Escape", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("e")
+    await user.type(screen.getAllByRole("textbox")[0], " Rewritten.")
+    await user.keyboard("{Escape}")
+
+    expect(screen.queryAllByRole("textbox")).toHaveLength(0)
+
+    await user.keyboard("a")
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1))
+    expect(Object.keys(lastPayload())).not.toContain("instructions_en")
+  })
+
+  // The card announces its shortcuts in its accessible name, so silencing them
+  // in edit mode without saying so would leave a screen reader reading out keys
+  // that no longer do anything.
+  it("announces the only shortcut that still works while editing", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("e")
+
+    expect(
+      screen.getByRole("article", { name: /escape/i }),
+    ).toBeInTheDocument()
+  })
+
+  // A refused write and a dropped connection are not the same problem for the
+  // reviewer: retrying fixes one and never fixes the other, so the toast has to
+  // tell them apart.
+  it("names a refused write rather than blaming the connection", async () => {
+    select.mockResolvedValue({ data: [], error: null })
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("a")
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        expect.stringContaining("refused"),
+      ),
+    )
+  })
+
   // A held key repeats, and the queue only rebuilds once the first write lands.
   // Without a guard the second press writes the row a second time, and a third
   // could land on a row the reviewer can no longer see.
   it("ignores a second decision while the first is still in flight", async () => {
-    single.mockReturnValue(new Promise(() => {}))
+    select.mockReturnValue(new Promise(() => {}))
     const user = userEvent.setup()
     renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
 
@@ -366,6 +448,59 @@ describe("TranslationReviewCard decisions", () => {
     await user.keyboard("r")
 
     expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  // `isPending` goes false the moment the write resolves, but the decided row
+  // stays on screen until the queue refetch lands. In that window approve and
+  // revert are live again and the second verdict wins — one reviewer
+  // contradicting themselves inside a single row.
+  it("refuses a contradictory second verdict after the first one lands", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("a")
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled())
+    await user.keyboard("r")
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole("button", { name: /revert/i })).toBeDisabled()
+    // Editing is gated on the same condition rather than left live: a correction
+    // that can no longer be submitted is an invitation to waste typing.
+    expect(screen.getByRole("button", { name: /edit/i })).toBeDisabled()
+    await user.keyboard("e")
+    expect(screen.queryAllByRole("textbox")).toHaveLength(0)
+  })
+
+  // The row is still in the queue after a refused write, so the card the
+  // reviewer is looking at is the one they have to retry from.
+  it("lets the reviewer try again after a write the database refused", async () => {
+    select.mockResolvedValueOnce({ data: [], error: null })
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("a")
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+    await user.keyboard("a")
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(2))
+  })
+
+  // Skip never goes through the mutation — it moves the page index locally — so
+  // it is not gated by accident like approve and revert were. `a` then `→`
+  // before the queue rebuilds advances one row, and the refetch then drops the
+  // decided row and shifts everything up by one more: a row nobody ever looked
+  // at is gone from the session, which is the worst thing a review queue can do.
+  it("refuses to skip once a verdict has been issued", async () => {
+    select.mockReturnValue(new Promise(() => {}))
+    const user = userEvent.setup()
+    const onSkip = vi.fn()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={onSkip} />)
+
+    await user.keyboard("a")
+    await user.keyboard("{ArrowRight}")
+
+    expect(onSkip).not.toHaveBeenCalled()
+    expect(screen.getByRole("button", { name: /skip/i })).toBeDisabled()
   })
 
   it("skips from the button too", async () => {

--- a/src/components/admin/translations/TranslationReviewCard.test.tsx
+++ b/src/components/admin/translations/TranslationReviewCard.test.tsx
@@ -1,8 +1,37 @@
-import { describe, it, expect } from "vitest"
-import { screen, within } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { renderWithProviders } from "@/test/utils"
 import { TranslationReviewCard } from "@/components/admin/translations/TranslationReviewCard"
 import type { TranslationReviewRow } from "@/hooks/useTranslationReviewQueue"
+
+type Payload = Record<string, unknown>
+
+const single = vi.fn()
+const eq = vi.fn<
+  (column: string, id: string) => { select: () => { single: typeof single } }
+>(() => ({ select: () => ({ single }) }))
+const update = vi.fn<(payload: Payload) => { eq: typeof eq }>(() => ({ eq }))
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: () => ({ update: (payload: Payload) => update(payload) }) },
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}))
+
+const lastPayload = (): Payload => update.mock.calls.at(-1)?.[0] ?? {}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  single.mockResolvedValue({ data: { id: "row-1" }, error: null })
+})
 
 const row: TranslationReviewRow = {
   id: "row-1",
@@ -47,7 +76,7 @@ const lineContaining = (text: string): HTMLElement =>
 
 describe("TranslationReviewCard", () => {
   it("shows both names, the status and the reading exposure", () => {
-    renderWithProviders(<TranslationReviewCard row={row} />)
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
 
     expect(screen.getByText("Développé couché")).toBeInTheDocument()
     expect(screen.getByText("Bench Press")).toBeInTheDocument()
@@ -59,7 +88,7 @@ describe("TranslationReviewCard", () => {
   // named. Asserting it lands *somewhere* would pass on a section-level banner,
   // so both the presence and the absence are checked.
   it("renders an objection on the sentence it targeted", () => {
-    renderWithProviders(<TranslationReviewCard row={row} />)
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
 
     const targeted = lineContaining("Set your hands hip-width apart.")
     expect(
@@ -74,14 +103,14 @@ describe("TranslationReviewCard", () => {
   })
 
   it("leaves the untargeted sentence in the same section clean", () => {
-    renderWithProviders(<TranslationReviewCard row={row} />)
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
 
     const untouched = lineContaining("Lie back on the bench.")
     expect(within(untouched).queryByText(/measurement-changed/)).toBeNull()
   })
 
   it("pairs each English sentence with its French counterpart", () => {
-    renderWithProviders(<TranslationReviewCard row={row} />)
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
 
     const pair = lineContaining("Set your hands hip-width apart.")
     expect(
@@ -96,7 +125,7 @@ describe("TranslationReviewCard", () => {
       ...row,
       instructions_en_audit: { ...row.instructions_en_audit!, objections: [] },
     }
-    renderWithProviders(<TranslationReviewCard row={gateOnly} />)
+    renderWithProviders(<TranslationReviewCard row={gateOnly} onSkip={vi.fn()} />)
 
     expect(screen.getByText("calques: lumbar")).toBeInTheDocument()
     expect(screen.queryByText(/measurement-changed/)).toBeNull()
@@ -107,7 +136,9 @@ describe("TranslationReviewCard", () => {
       ...row,
       instructions_en: { ...row.instructions_en!, setup: ["Lie back on the bench."] },
     }
-    renderWithProviders(<TranslationReviewCard row={truncated} />)
+    renderWithProviders(
+      <TranslationReviewCard row={truncated} onSkip={vi.fn()} />,
+    )
 
     const orphaned = lineContaining("Écartez les mains à largeur d'épaules.")
     expect(
@@ -120,17 +151,231 @@ describe("TranslationReviewCard", () => {
       ...row,
       instructions_en_audit: { ...row.instructions_en_audit!, checker_model: null },
     }
-    renderWithProviders(<TranslationReviewCard row={unchecked} />)
+    renderWithProviders(
+      <TranslationReviewCard row={unchecked} onSkip={vi.fn()} />,
+    )
 
     expect(screen.getByText(/no cross-checker/)).toBeInTheDocument()
   })
 
   it("renders every label in French under the fr locale", () => {
-    renderWithProviders(<TranslationReviewCard row={row} />, { locale: "fr" })
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />, {
+      locale: "fr",
+    })
 
     expect(screen.getByText("Signalée")).toBeInTheDocument()
     expect(screen.getByText("Mise en place")).toBeInTheDocument()
     expect(screen.getByText("152 séries loguées")).toBeInTheDocument()
     expect(screen.getAllByText("Anglais").length).toBeGreaterThan(0)
+    expect(
+      screen.getByRole("button", { name: /rendre au français/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /approuver/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("names its editing controls in French too", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />, {
+      locale: "fr",
+    })
+
+    await user.keyboard("e")
+
+    expect(
+      screen.getByRole("textbox", { name: /mise en place/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /annuler l'édition/i }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe("TranslationReviewCard decisions", () => {
+  it("records an approval for the row it is showing", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: /^approve$/i }))
+
+    await waitFor(() =>
+      expect(lastPayload()).toMatchObject({
+        instructions_en_status: "approved",
+      }),
+    )
+    expect(eq).toHaveBeenCalledWith("id", "row-1")
+  })
+
+  // The card takes focus on mount so the shortcuts work on arrival: a reviewer
+  // who has to click the card before pressing A is not going faster than the
+  // mouse, which is the entire point of the four keys.
+  it("approves on A without anything being clicked first", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("a")
+
+    await waitFor(() =>
+      expect(lastPayload()).toMatchObject({
+        instructions_en_status: "approved",
+      }),
+    )
+  })
+
+  it("sends the row back to French from the button", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: /revert to french/i }))
+
+    await waitFor(() =>
+      expect(lastPayload()).toMatchObject({
+        instructions_en_status: "flagged",
+      }),
+    )
+    expect(Object.keys(lastPayload())).not.toContain("instructions_en")
+  })
+
+  it("sends the row back to French on R", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("r")
+
+    await waitFor(() =>
+      expect(lastPayload()).toMatchObject({
+        instructions_en_status: "flagged",
+      }),
+    )
+  })
+
+  // Skipping is the only affordance that must reach the page: a row nobody
+  // decided has to stay in the queue for the next pass.
+  it("skips on arrow right without recording anything", async () => {
+    const user = userEvent.setup()
+    const onSkip = vi.fn()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={onSkip} />)
+
+    await user.keyboard("{ArrowRight}")
+
+    expect(onSkip).toHaveBeenCalledTimes(1)
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  // One textarea per section, one sentence per line — deliberately spartan.
+  // Structured correction, shape validation and the diff are T160's job.
+  it("opens one named textarea per section on E, one sentence per line", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("e")
+
+    expect(screen.getAllByRole("textbox")).toHaveLength(4)
+    expect(screen.getByRole("textbox", { name: /setup/i })).toHaveValue(
+      "Lie back on the bench.\nSet your hands hip-width apart.",
+    )
+    expect(screen.getByRole("textbox", { name: /common mistakes/i })).toHaveValue(
+      "Arched lower back.",
+    )
+  })
+
+  it("approves the corrected English, leaving the untouched sections intact", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("e")
+    const setupBox = screen.getByRole("textbox", { name: /setup/i })
+    await user.clear(setupBox)
+    await user.type(
+      setupBox,
+      "Lie back on the bench.{Enter}Set your hands shoulder-width apart.",
+    )
+    await user.click(screen.getByRole("button", { name: /^approve/i }))
+
+    await waitFor(() =>
+      expect(lastPayload().instructions_en).toEqual({
+        setup: [
+          "Lie back on the bench.",
+          "Set your hands shoulder-width apart.",
+        ],
+        movement: ["Press the bar upward."],
+        breathing: ["Exhale as you press."],
+        common_mistakes: ["Arched lower back."],
+      }),
+    )
+    expect(lastPayload()).toMatchObject({ instructions_en_status: "approved" })
+  })
+
+  // The acceptance criterion that keeps the shortcuts from eating the edit:
+  // "a rack" contains A, R and E, which is every letter shortcut there is.
+  it("does not fire a shortcut while the reviewer is typing a correction", async () => {
+    const user = userEvent.setup()
+    const onSkip = vi.fn()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={onSkip} />)
+
+    await user.keyboard("e")
+    await user.type(
+      screen.getByRole("textbox", { name: /movement/i }),
+      " a rack{ArrowRight}",
+    )
+
+    expect(update).not.toHaveBeenCalled()
+    expect(onSkip).not.toHaveBeenCalled()
+    expect(screen.getAllByRole("textbox")).toHaveLength(4)
+  })
+
+  it("confirms a recorded decision by name", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("a")
+
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith(
+        expect.stringContaining("Développé couché"),
+      ),
+    )
+  })
+
+  // The failure path the reviewer must be able to trust: nothing was recorded,
+  // so the row has to still be there — and they have to be told.
+  it("reports a failed write and keeps the row on screen", async () => {
+    single.mockResolvedValue({ data: null, error: new Error("rls denied") })
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("a")
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+    expect(toastSuccess).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole("heading", { name: "Développé couché" }),
+    ).toBeInTheDocument()
+  })
+
+  // A held key repeats, and the queue only rebuilds once the first write lands.
+  // Without a guard the second press writes the row a second time, and a third
+  // could land on a row the reviewer can no longer see.
+  it("ignores a second decision while the first is still in flight", async () => {
+    single.mockReturnValue(new Promise(() => {}))
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("a")
+    await user.keyboard("r")
+
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips from the button too", async () => {
+    const user = userEvent.setup()
+    const onSkip = vi.fn()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={onSkip} />)
+
+    await user.click(screen.getByRole("button", { name: /skip/i }))
+
+    expect(onSkip).toHaveBeenCalledTimes(1)
+    expect(update).not.toHaveBeenCalled()
   })
 })

--- a/src/components/admin/translations/TranslationReviewCard.tsx
+++ b/src/components/admin/translations/TranslationReviewCard.tsx
@@ -1,14 +1,26 @@
+import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { AlertTriangle } from "lucide-react"
+import { AlertTriangle, Check, Pencil, SkipForward, Undo2 } from "lucide-react"
+import { toast } from "sonner"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  useApproveTranslation,
+  type TranslationVerdict,
+} from "@/hooks/useApproveTranslation"
 import { formatDate } from "@/lib/formatters"
 import {
   buildReviewSections,
+  fromInstructionDraft,
   orphanObjections,
+  toInstructionDraft,
+  type InstructionDraft,
   type ReviewLine,
   type ReviewObjection,
 } from "@/lib/translationReview"
 import type { InstructionSection } from "@/lib/instructionQuality"
+import type { ExerciseInstructions } from "@/types/database"
 import type { TranslationReviewRow } from "@/hooks/useTranslationReviewQueue"
 
 const SECTION_KEYS: Record<InstructionSection, string> = {
@@ -26,6 +38,8 @@ const STATUS_VARIANT: Record<string, "secondary" | "destructive" | "default"> = 
 
 interface TranslationReviewCardProps {
   row: TranslationReviewRow
+  /** Move to the next row without recording a verdict. */
+  onSkip: () => void
 }
 
 function ObjectionBadge({ objection }: { objection: ReviewObjection }) {
@@ -40,6 +54,32 @@ function ObjectionBadge({ objection }: { objection: ReviewObjection }) {
         {objection.note ? <> — {objection.note}</> : null}
       </span>
     </Badge>
+  )
+}
+
+/**
+ * Whether the event came from somewhere the reviewer is composing text. Checked
+ * on the event target rather than on the editing flag: the flag says a textarea
+ * exists, this says the keystroke landed in one.
+ */
+const isTypingTarget = (target: EventTarget): boolean =>
+  target instanceof HTMLTextAreaElement ||
+  target instanceof HTMLInputElement ||
+  (target instanceof HTMLElement && target.isContentEditable)
+
+/**
+ * The key hint on a button. `aria-hidden` because the shortcut is already
+ * spelled out on the card's own label, and a screen reader announcing
+ * "Approve A" reads as a typo.
+ */
+function Shortcut({ children }: { children: string }) {
+  return (
+    <kbd
+      aria-hidden
+      className="rounded border border-current/30 px-1 text-[10px] font-semibold opacity-70"
+    >
+      {children}
+    </kbd>
   )
 }
 
@@ -72,8 +112,88 @@ function SentencePair({
   )
 }
 
-export function TranslationReviewCard({ row }: TranslationReviewCardProps) {
+export function TranslationReviewCard({
+  row,
+  onSkip,
+}: TranslationReviewCardProps) {
   const { t, i18n } = useTranslation("admin")
+  const decide = useApproveTranslation()
+  const cardRef = useRef<HTMLElement>(null)
+  // `null` means "not editing". Holding the draft and the mode in one value
+  // makes the impossible state — editing with no draft — unrepresentable.
+  const [draft, setDraft] = useState<InstructionDraft | null>(null)
+
+  // The shortcuts are local `onKeyDown` handlers, so they only fire while focus
+  // is inside the card — and taking focus on mount is what makes the keyboard
+  // path work on arrival instead of after a click. The page remounts this
+  // component per row, so each new row re-arms it.
+  useEffect(() => {
+    cardRef.current?.focus()
+  }, [])
+
+  /**
+   * Every decision reports the same way, and the toast names the exercise: the
+   * queue has already moved on by the time it appears, so "saved" alone would
+   * be ambiguous about which row it saved.
+   */
+  const record = (
+    status: TranslationVerdict,
+    instructionsEn?: ExerciseInstructions,
+  ) => {
+    // A held key repeats. The queue only rebuilds once the write lands, so
+    // without this the reviewer decides the same row twice — and the second
+    // verdict could be one they meant for the row they expected to see next.
+    if (decide.isPending) return
+
+    decide.mutate(
+      {
+        exerciseId: row.id,
+        status,
+        ...(instructionsEn ? { instructionsEn } : {}),
+      },
+      {
+        onSuccess: () =>
+          toast.success(
+            t(`translations.toast.${status}`, { name: row.name }),
+          ),
+        onError: () => toast.error(t("translations.toast.error")),
+      },
+    )
+  }
+
+  const approve = () =>
+    record("approved", draft ? fromInstructionDraft(draft) : undefined)
+
+  const revert = () => record("flagged")
+
+  const toggleEditing = () =>
+    setDraft((current) =>
+      current ? null : toInstructionDraft(row.instructions_en),
+    )
+
+  /**
+   * `A` / `E` / `R` / `→`, normalized so a held shift still triggers them while
+   * named keys keep their casing. No global shortcut hook exists in this repo
+   * and this card does not invent one.
+   */
+  const shortcuts: Record<string, () => void> = {
+    a: approve,
+    e: toggleEditing,
+    r: revert,
+    ArrowRight: onSkip,
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent) {
+    // A letter typed into a textarea is a correction, not a verdict. Without
+    // this the first word of any edit would approve the row and move on.
+    if (isTypingTarget(event.target)) return
+
+    const key = event.key.length === 1 ? event.key.toLowerCase() : event.key
+    const action = shortcuts[key]
+    if (!action) return
+    event.preventDefault()
+    action()
+  }
 
   const audit = row.instructions_en_audit
   const objections = audit?.objections ?? []
@@ -87,7 +207,13 @@ export function TranslationReviewCard({ row }: TranslationReviewCardProps) {
   const missingLabel = t("translations.missingSentence")
 
   return (
-    <article className="flex flex-col gap-5 rounded-xl border border-border/80 bg-card p-5">
+    <article
+      ref={cardRef}
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+      aria-label={t("translations.cardLabel", { name: row.name })}
+      className="flex flex-col gap-5 rounded-xl border border-border/80 bg-card p-5 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <h2 className="text-lg font-semibold leading-tight">{row.name}</h2>
@@ -161,8 +287,67 @@ export function TranslationReviewCard({ row }: TranslationReviewCardProps) {
               />
             ))}
           </ul>
+          {draft ? (
+            <Textarea
+              value={draft[section]}
+              aria-label={t("translations.editSection", {
+                section: t(SECTION_KEYS[section]),
+              })}
+              onChange={(event) =>
+                setDraft((current) =>
+                  current ? { ...current, [section]: event.target.value } : current,
+                )
+              }
+              rows={Math.max(lines.length, 2)}
+              className="mt-1 font-mono text-xs"
+            />
+          ) : null}
         </section>
       ))}
+
+      <footer className="flex flex-wrap items-center gap-2">
+        <Button
+          size="sm"
+          className="gap-2"
+          disabled={decide.isPending}
+          onClick={approve}
+        >
+          <Check className="h-4 w-4" />
+          {t("translations.approve")}
+          <Shortcut>A</Shortcut>
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          className="gap-2"
+          onClick={toggleEditing}
+        >
+          <Pencil className="h-4 w-4" />
+          {t(draft ? "translations.cancelEdit" : "translations.edit")}
+          <Shortcut>E</Shortcut>
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          className="gap-2"
+          disabled={decide.isPending}
+          onClick={revert}
+        >
+          <Undo2 className="h-4 w-4" />
+          {t("translations.revert")}
+          <Shortcut>R</Shortcut>
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="gap-2 text-muted-foreground"
+          onClick={onSkip}
+        >
+          <SkipForward className="h-4 w-4" />
+          {t("translations.skip")}
+          <Shortcut>→</Shortcut>
+        </Button>
+      </footer>
     </article>
   )
 }

--- a/src/components/admin/translations/TranslationReviewCard.tsx
+++ b/src/components/admin/translations/TranslationReviewCard.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import {
+  TranslationWriteRefusedError,
   useApproveTranslation,
   type TranslationVerdict,
 } from "@/hooks/useApproveTranslation"
@@ -119,17 +120,42 @@ export function TranslationReviewCard({
   const { t, i18n } = useTranslation("admin")
   const decide = useApproveTranslation()
   const cardRef = useRef<HTMLElement>(null)
+  const firstEditorRef = useRef<HTMLTextAreaElement>(null)
   // `null` means "not editing". Holding the draft and the mode in one value
   // makes the impossible state — editing with no draft — unrepresentable.
   const [draft, setDraft] = useState<InstructionDraft | null>(null)
+  /**
+   * Whether this card has already spoken.
+   *
+   * `decide.isPending` falls back to false the moment the write resolves, but
+   * the decided row stays on screen until the queue refetch lands — a window in
+   * which the reviewer can contradict the verdict they just gave, and the
+   * second write wins. So the gate is not "a write is in flight" but "a verdict
+   * has been issued", which holds until the row leaves. The page keys this
+   * component on the row id, so the next row arrives as a fresh instance with
+   * the gate open; the only way back to false on this row is a write the
+   * database rejected, which leaves it genuinely undecided.
+   */
+  const [verdictIssued, setVerdictIssued] = useState(false)
+
+  const isEditing = draft !== null
 
   // The shortcuts are local `onKeyDown` handlers, so they only fire while focus
   // is inside the card — and taking focus on mount is what makes the keyboard
   // path work on arrival instead of after a click. The page remounts this
   // component per row, so each new row re-arms it.
+  //
+  // Edit mode hands that focus to the editor, because a reviewer who presses
+  // `E` and starts typing expects the letters to land in the text and not on
+  // the verdict buttons. Leaving edit mode has to hand it back: without that,
+  // focus falls to the body and the card goes quietly deaf.
+  //
+  // Keyed on the boolean rather than on `draft`, which changes on every
+  // keystroke and would drag the cursor back to the first section.
   useEffect(() => {
-    cardRef.current?.focus()
-  }, [])
+    if (isEditing) firstEditorRef.current?.focus()
+    else cardRef.current?.focus()
+  }, [isEditing])
 
   /**
    * Every decision reports the same way, and the toast names the exercise: the
@@ -140,10 +166,8 @@ export function TranslationReviewCard({
     status: TranslationVerdict,
     instructionsEn?: ExerciseInstructions,
   ) => {
-    // A held key repeats. The queue only rebuilds once the write lands, so
-    // without this the reviewer decides the same row twice — and the second
-    // verdict could be one they meant for the row they expected to see next.
-    if (decide.isPending) return
+    if (verdictIssued) return
+    setVerdictIssued(true)
 
     decide.mutate(
       {
@@ -156,7 +180,18 @@ export function TranslationReviewCard({
           toast.success(
             t(`translations.toast.${status}`, { name: row.name }),
           ),
-        onError: () => toast.error(t("translations.toast.error")),
+        onError: (error) => {
+          // Nothing was written, so the row is still undecided and the reviewer
+          // has to be able to try again from the card in front of them.
+          setVerdictIssued(false)
+          toast.error(
+            t(
+              error instanceof TranslationWriteRefusedError
+                ? "translations.toast.refused"
+                : "translations.toast.error",
+            ),
+          )
+        },
       },
     )
   }
@@ -166,10 +201,30 @@ export function TranslationReviewCard({
 
   const revert = () => record("flagged")
 
-  const toggleEditing = () =>
-    setDraft((current) =>
-      current ? null : toInstructionDraft(row.instructions_en),
-    )
+  /**
+   * Skip never touches the mutation — it moves the page index — so it is the
+   * one action the write gates by accident, not by design. Left ungated, a skip
+   * issued after a verdict advances the index by one and the refetch then drops
+   * the decided row and shifts the rest up by one more, so the row in between is
+   * gone without ever having been shown. Same condition as the verdicts: this
+   * card has spoken, it gets no further say in where the queue goes.
+   */
+  const skip = () => {
+    if (verdictIssued) return
+    onSkip()
+  }
+
+  /**
+   * Cancelling discards the draft, and `Escape` below is the same door: the
+   * button says "cancel edit", so the two ways out cannot mean different things.
+   * The corrected English survives one way only — by being approved.
+   */
+  const cancelEditing = () => setDraft(null)
+
+  const startEditing = () => {
+    if (verdictIssued) return
+    setDraft(toInstructionDraft(row.instructions_en))
+  }
 
   /**
    * `A` / `E` / `R` / `→`, normalized so a held shift still triggers them while
@@ -178,14 +233,26 @@ export function TranslationReviewCard({
    */
   const shortcuts: Record<string, () => void> = {
     a: approve,
-    e: toggleEditing,
+    e: startEditing,
     r: revert,
-    ArrowRight: onSkip,
+    ArrowRight: skip,
   }
 
   function handleKeyDown(event: React.KeyboardEvent) {
-    // A letter typed into a textarea is a correction, not a verdict. Without
-    // this the first word of any edit would approve the row and move on.
+    // Edit mode silences the whole set, and deliberately not by relying on
+    // focus: a reviewer can click the card background and a browser can restore
+    // focus anywhere, and then typing the word "bar" approves the translation
+    // on their behalf. `Escape` is the one key still answered, so there is
+    // always a way out that does not require the mouse.
+    if (isEditing) {
+      if (event.key !== "Escape") return
+      event.preventDefault()
+      cancelEditing()
+      return
+    }
+
+    // Belt and braces for any future control inside the card that takes typed
+    // input outside edit mode.
     if (isTypingTarget(event.target)) return
 
     const key = event.key.length === 1 ? event.key.toLowerCase() : event.key
@@ -211,7 +278,10 @@ export function TranslationReviewCard({
       ref={cardRef}
       tabIndex={-1}
       onKeyDown={handleKeyDown}
-      aria-label={t("translations.cardLabel", { name: row.name })}
+      aria-label={t(
+        isEditing ? "translations.cardLabelEditing" : "translations.cardLabel",
+        { name: row.name },
+      )}
       className="flex flex-col gap-5 rounded-xl border border-border/80 bg-card p-5 outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <header className="flex flex-wrap items-start justify-between gap-3">
@@ -271,7 +341,7 @@ export function TranslationReviewCard({
         </section>
       ) : null}
 
-      {sections.map(({ section, lines }) => (
+      {sections.map(({ section, lines }, index) => (
         <section key={section} className="flex flex-col gap-1">
           <h3 className="text-sm font-semibold">{t(SECTION_KEYS[section])}</h3>
           <div className="grid gap-2 text-xs uppercase tracking-wide text-muted-foreground sm:grid-cols-2 sm:gap-4">
@@ -289,6 +359,7 @@ export function TranslationReviewCard({
           </ul>
           {draft ? (
             <Textarea
+              ref={index === 0 ? firstEditorRef : undefined}
               value={draft[section]}
               aria-label={t("translations.editSection", {
                 section: t(SECTION_KEYS[section]),
@@ -309,7 +380,7 @@ export function TranslationReviewCard({
         <Button
           size="sm"
           className="gap-2"
-          disabled={decide.isPending}
+          disabled={verdictIssued}
           onClick={approve}
         >
           <Check className="h-4 w-4" />
@@ -320,17 +391,18 @@ export function TranslationReviewCard({
           size="sm"
           variant="outline"
           className="gap-2"
-          onClick={toggleEditing}
+          disabled={verdictIssued}
+          onClick={isEditing ? cancelEditing : startEditing}
         >
           <Pencil className="h-4 w-4" />
-          {t(draft ? "translations.cancelEdit" : "translations.edit")}
+          {t(isEditing ? "translations.cancelEdit" : "translations.edit")}
           <Shortcut>E</Shortcut>
         </Button>
         <Button
           size="sm"
           variant="outline"
           className="gap-2"
-          disabled={decide.isPending}
+          disabled={verdictIssued}
           onClick={revert}
         >
           <Undo2 className="h-4 w-4" />
@@ -341,7 +413,8 @@ export function TranslationReviewCard({
           size="sm"
           variant="ghost"
           className="gap-2 text-muted-foreground"
-          onClick={onSkip}
+          disabled={verdictIssued}
+          onClick={skip}
         >
           <SkipForward className="h-4 w-4" />
           {t("translations.skip")}

--- a/src/hooks/translationReviewRoundTrip.test.ts
+++ b/src/hooks/translationReviewRoundTrip.test.ts
@@ -5,7 +5,10 @@ import {
   useTranslationReviewQueue,
   type TranslationReviewRow,
 } from "@/hooks/useTranslationReviewQueue"
-import { useApproveTranslation } from "@/hooks/useApproveTranslation"
+import {
+  TranslationWriteRefusedError,
+  useApproveTranslation,
+} from "@/hooks/useApproveTranslation"
 import { useExercisesForReview } from "@/hooks/useExercisesForReview"
 
 /**
@@ -88,23 +91,21 @@ vi.mock("@/lib/supabase", () => {
       from: () => ({
         update: (payload: Row) => ({
           eq: (_column: string, id: string) => ({
-            select: () => ({
-              single: async () => {
-                // No row, no write — `.single()` is an error in PostgREST when
-                // the filter matches nothing, and the queue tests below depend
-                // on a genuinely rejected write rather than a silent no-op.
-                if (!(db.rows as Row[]).some((row) => row.id === id)) {
-                  return { data: null, error: new Error("no row matched") }
-                }
-                db.rows = (db.rows as Row[]).map((row) =>
-                  row.id === id ? { ...row, ...payload } : row,
-                )
-                return {
-                  data: (db.rows as Row[]).find((row) => row.id === id) ?? null,
-                  error: null,
-                }
-              },
-            }),
+            // PostgREST answers an UPDATE that matched nothing with an empty
+            // array and no error — the shape an RLS refusal arrives in, and the
+            // reason the mutation counts its rows instead of trusting `error`.
+            // Modelling that faithfully is what makes the rejected-write test
+            // below a test of the mutation rather than a test of this fake.
+            select: async () => {
+              const matched = (db.rows as Row[]).filter((row) => row.id === id)
+              db.rows = (db.rows as Row[]).map((row) =>
+                row.id === id ? { ...row, ...payload } : row,
+              )
+              return {
+                data: matched.map((row) => ({ id: row.id })),
+                error: null,
+              }
+            },
           }),
         }),
       }),
@@ -221,7 +222,10 @@ describe("a reviewed translation and the T158 queue", () => {
     ])
   })
 
-  it("leaves the whole queue standing when the write is rejected", async () => {
+  // The refusal RLS actually produces: a successful request that changed
+  // nothing. The mutation has to read that as a failure, or the reviewer gets a
+  // green toast over a queue that never moved.
+  it("leaves the whole queue standing when the write is refused", async () => {
     const { result } = setup()
     await waitFor(() => expect(result.current.queue.isSuccess).toBe(true))
 
@@ -232,7 +236,7 @@ describe("a reviewed translation and the T158 queue", () => {
           status: "approved",
         })
       }),
-    ).rejects.toThrow("no row matched")
+    ).rejects.toBeInstanceOf(TranslationWriteRefusedError)
 
     const refetched = await act(() => result.current.queue.refetch())
 

--- a/src/hooks/translationReviewRoundTrip.test.ts
+++ b/src/hooks/translationReviewRoundTrip.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { act, waitFor } from "@testing-library/react"
+import { renderHookWithProviders } from "@/test/utils"
+import {
+  useTranslationReviewQueue,
+  type TranslationReviewRow,
+} from "@/hooks/useTranslationReviewQueue"
+import { useApproveTranslation } from "@/hooks/useApproveTranslation"
+import { useExercisesForReview } from "@/hooks/useExercisesForReview"
+
+/**
+ * The seam between T158's read-only queue and T159's write: a decision has to
+ * remove the row from `get_translations_for_review`, and nothing in either hook
+ * says so on its own. The queue's filter lives in SQL, the stamp that satisfies
+ * it lives in the mutation, and the two can drift apart without a single type
+ * error.
+ *
+ * So this drives both real hooks against a fake `exercises` table whose queue
+ * predicate is lifted from the migration itself — see the first test, which
+ * fails the moment the SQL filter stops being the one modelled here.
+ */
+
+const migrationSources = import.meta.glob("../../supabase/migrations/*.sql", {
+  query: "?raw",
+  eager: true,
+  import: "default",
+}) as Record<string, string>
+
+const FUNCTION_HEAD = /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s/i
+
+/**
+ * The surviving definition of a function: migration filenames sort into apply
+ * order, and `CREATE OR REPLACE` means only the last one is what the database
+ * runs. Reading anything else would pin these fakes to history.
+ */
+const lastDefinitionOf = (name: string): string =>
+  Object.entries(migrationSources)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .flatMap(([, sql]) =>
+      sql
+        .replace(/--[^\n]*/g, "")
+        .split(new RegExp(`(?=${FUNCTION_HEAD.source})`, "i")),
+    )
+    .filter((chunk) =>
+      new RegExp(`FUNCTION\\s+(?:public\\.)?${name}\\s*\\(`, "i").test(chunk),
+    )
+    .at(-1) ?? ""
+
+const filterOf = (name: string): string | undefined =>
+  /WHERE([\s\S]*?)ORDER BY/
+    .exec(lastDefinitionOf(name))?.[1]
+    ?.replace(/\s+/g, " ")
+    .trim()
+
+interface FakeRow {
+  id: string
+  name: string
+  instructions_en: TranslationReviewRow["instructions_en"]
+  instructions_en_status: string | null
+  instructions_en_reviewed_at: string | null
+  /** Content review and image enrichment share this one. Nothing here writes it. */
+  reviewed_at: string | null
+}
+
+const english = {
+  setup: ["Lie back on the bench."],
+  movement: ["Press the bar upward."],
+  breathing: ["Exhale as you press."],
+  common_mistakes: ["Arched lower back."],
+}
+
+const makeRow = (id: string, status: string): FakeRow => ({
+  id,
+  name: id,
+  instructions_en: english,
+  instructions_en_status: status,
+  instructions_en_reviewed_at: null,
+  reviewed_at: null,
+})
+
+const db = vi.hoisted(() => ({ rows: [] as unknown[] }))
+
+vi.mock("@/lib/supabase", () => {
+  type Row = Record<string, unknown>
+
+  return {
+    supabase: {
+      from: () => ({
+        update: (payload: Row) => ({
+          eq: (_column: string, id: string) => ({
+            select: () => ({
+              single: async () => {
+                // No row, no write — `.single()` is an error in PostgREST when
+                // the filter matches nothing, and the queue tests below depend
+                // on a genuinely rejected write rather than a silent no-op.
+                if (!(db.rows as Row[]).some((row) => row.id === id)) {
+                  return { data: null, error: new Error("no row matched") }
+                }
+                db.rows = (db.rows as Row[]).map((row) =>
+                  row.id === id ? { ...row, ...payload } : row,
+                )
+                return {
+                  data: (db.rows as Row[]).find((row) => row.id === id) ?? null,
+                  error: null,
+                }
+              },
+            }),
+          }),
+        }),
+      }),
+      // Both predicates are asserted against their migrations below, and
+      // nothing else: no status filter on either, so a row can only leave a
+      // queue by having that queue's own timestamp written.
+      rpc: async (name: string) => ({
+        data:
+          name === "get_translations_for_review"
+            ? (db.rows as Row[]).filter(
+                (row) =>
+                  row.instructions_en !== null &&
+                  row.instructions_en_reviewed_at === null,
+              )
+            : (db.rows as Row[]).filter((row) => row.reviewed_at === null),
+        error: null,
+      }),
+    },
+  }
+})
+
+function setup() {
+  return renderHookWithProviders(() => ({
+    queue: useTranslationReviewQueue(),
+    contentReview: useExercisesForReview(),
+    decide: useApproveTranslation(),
+  }))
+}
+
+const namesInQueue = (queue: TranslationReviewRow[] | undefined) =>
+  (queue ?? []).map(({ name }) => name)
+
+beforeEach(() => {
+  db.rows = [makeRow("clean-row", "clean"), makeRow("flagged-row", "flagged")]
+})
+
+describe("a reviewed translation and the T158 queue", () => {
+  // Pins the fake above to the real thing. If the RPC ever filters on something
+  // else — `reviewed_at`, or the status — this fails first and says so, instead
+  // of the round-trip tests below quietly proving a fiction.
+  it("is filtered by the migration on exactly the two columns modelled here", () => {
+    expect(filterOf("get_translations_for_review")).toBe(
+      "e.instructions_en IS NOT NULL AND e.instructions_en_reviewed_at IS NULL",
+    )
+  })
+
+  it("shares no filter column with the content review queue", () => {
+    expect(filterOf("get_unreviewed_exercises_by_usage")).toBe(
+      "e.reviewed_at IS NULL",
+    )
+  })
+
+  it("drops an approved row from the queue on the next read", async () => {
+    const { result } = setup()
+    await waitFor(() => expect(result.current.queue.isSuccess).toBe(true))
+    expect(namesInQueue(result.current.queue.data)).toContain("clean-row")
+
+    await act(async () => {
+      await result.current.decide.mutateAsync({
+        exerciseId: "clean-row",
+        status: "approved",
+      })
+    })
+
+    await waitFor(() =>
+      expect(namesInQueue(result.current.queue.data)).toEqual(["flagged-row"]),
+    )
+  })
+
+  // The sharp end. `flagged` is the status the queue *prioritises*, so if the
+  // stamp were missing and departure came from the verdict instead, reverting
+  // would leave the row sitting at the top of the queue forever.
+  it("drops a row reverted to French, even though flagged is what the queue ranks first", async () => {
+    const { result } = setup()
+    await waitFor(() => expect(result.current.queue.isSuccess).toBe(true))
+
+    await act(async () => {
+      await result.current.decide.mutateAsync({
+        exerciseId: "clean-row",
+        status: "flagged",
+      })
+    })
+
+    await waitFor(() =>
+      expect(namesInQueue(result.current.queue.data)).toEqual(["flagged-row"]),
+    )
+  })
+
+  // The ticket's stated point de vigilance. `reviewed_at` is shared with image
+  // enrichment and content review, so stamping it here would quietly retire an
+  // exercise from /admin/review that nobody has read a word of — and the only
+  // symptom would be a queue that is shorter than it should be.
+  //
+  // The refetch is the load-bearing part: the mutation does not invalidate this
+  // key, so without it the assertion would merely be reading a stale cache and
+  // would hold no matter what the write did.
+  it("does not retire the row from the content review queue", async () => {
+    const { result } = setup()
+    await waitFor(() => expect(result.current.contentReview.isSuccess).toBe(true))
+    expect(result.current.contentReview.data).toHaveLength(2)
+
+    await act(async () => {
+      await result.current.decide.mutateAsync({
+        exerciseId: "clean-row",
+        status: "approved",
+      })
+    })
+
+    const refetched = await act(() => result.current.contentReview.refetch())
+
+    expect(refetched.data?.map(({ name }) => name)).toEqual([
+      "clean-row",
+      "flagged-row",
+    ])
+  })
+
+  it("leaves the whole queue standing when the write is rejected", async () => {
+    const { result } = setup()
+    await waitFor(() => expect(result.current.queue.isSuccess).toBe(true))
+
+    await expect(
+      act(async () => {
+        await result.current.decide.mutateAsync({
+          exerciseId: "does-not-exist",
+          status: "approved",
+        })
+      }),
+    ).rejects.toThrow("no row matched")
+
+    const refetched = await act(() => result.current.queue.refetch())
+
+    expect(refetched.data?.map(({ name }) => name)).toEqual([
+      "clean-row",
+      "flagged-row",
+    ])
+  })
+})

--- a/src/hooks/useApproveTranslation.test.ts
+++ b/src/hooks/useApproveTranslation.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { act } from "@testing-library/react"
+import { renderHookWithProviders } from "@/test/utils"
+import { EXERCISES_BATCH_QUERY_KEY } from "@/hooks/useExerciseBatch"
+import { TRANSLATION_REVIEW_QUEUE_KEY } from "@/hooks/useTranslationReviewQueue"
+import { useApproveTranslation } from "./useApproveTranslation"
+
+type Payload = Record<string, unknown>
+
+const single = vi.fn()
+const select = vi.fn(() => ({ single }))
+const eq = vi.fn<(column: string, id: string) => { select: typeof select }>(
+  () => ({ select }),
+)
+const update = vi.fn<(payload: Payload) => { eq: typeof eq }>(() => ({ eq }))
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: (table: string) => mockFrom(table) },
+}))
+
+const mockFrom = vi.fn<(table: string) => { update: typeof update }>(() => ({
+  update,
+}))
+
+const lastPayload = (): Payload => update.mock.calls.at(-1)?.[0] ?? {}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  single.mockResolvedValue({ data: { id: "ex-1" }, error: null })
+})
+
+describe("useApproveTranslation", () => {
+  it("stamps the translation verdict and its own review timestamp", async () => {
+    const { result } = renderHookWithProviders(() => useApproveTranslation())
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        exerciseId: "ex-1",
+        status: "approved",
+      })
+    })
+
+    expect(mockFrom).toHaveBeenCalledWith("exercises")
+    expect(eq).toHaveBeenCalledWith("id", "ex-1")
+    expect(lastPayload()).toMatchObject({ instructions_en_status: "approved" })
+    expect(
+      Date.parse(lastPayload().instructions_en_reviewed_at as string),
+    ).not.toBeNaN()
+  })
+
+  // The whole reason this hook exists instead of reusing useAdminUpdateExercise:
+  // `reviewed_at` is shared with content review and image enrichment, so writing
+  // it here would drain /admin/review's queue without anyone reading a word.
+  it("never touches the shared content-review columns", async () => {
+    const { result } = renderHookWithProviders(() => useApproveTranslation())
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        exerciseId: "ex-1",
+        status: "approved",
+      })
+    })
+
+    expect(Object.keys(lastPayload())).not.toContain("reviewed_at")
+    expect(Object.keys(lastPayload())).not.toContain("reviewed_by")
+  })
+
+  it("carries the corrected English when the reviewer fixed it first", async () => {
+    const { result } = renderHookWithProviders(() => useApproveTranslation())
+    const corrected = {
+      setup: ["Set your hands shoulder-width apart."],
+      movement: ["Press the bar upward."],
+      breathing: ["Exhale as you press."],
+      common_mistakes: ["Arched lower back."],
+    }
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        exerciseId: "ex-1",
+        status: "approved",
+        instructionsEn: corrected,
+      })
+    })
+
+    expect(lastPayload().instructions_en).toEqual(corrected)
+  })
+
+  // An untouched approval must not rewrite the column with a round-tripped copy:
+  // the value the pipeline wrote is the value that stays.
+  it("omits the English column entirely when nothing was edited", async () => {
+    const { result } = renderHookWithProviders(() => useApproveTranslation())
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        exerciseId: "ex-1",
+        status: "approved",
+      })
+    })
+
+    expect(Object.keys(lastPayload())).not.toContain("instructions_en")
+  })
+
+  // Reverting is a verdict, not a deletion: the row leaves the queue and the app
+  // falls back to French, but the translation stays in the table so a later
+  // `--force` pass can pick it up instead of paying for it twice.
+  it("reverting flags the row without discarding the translation", async () => {
+    const { result } = renderHookWithProviders(() => useApproveTranslation())
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        exerciseId: "ex-1",
+        status: "flagged",
+      })
+    })
+
+    expect(lastPayload()).toMatchObject({ instructions_en_status: "flagged" })
+    expect(
+      Date.parse(lastPayload().instructions_en_reviewed_at as string),
+    ).not.toBeNaN()
+    expect(Object.keys(lastPayload())).not.toContain("instructions_en")
+  })
+
+  // The catalog row is cached in four places besides the queue, and an approved
+  // translation changes what every one of them renders.
+  it("invalidates the review queue and every catalog cache holding the row", async () => {
+    const { result, queryClient } = renderHookWithProviders(() =>
+      useApproveTranslation(),
+    )
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        exerciseId: "ex-1",
+        status: "approved",
+      })
+    })
+
+    const invalidated = invalidate.mock.calls.map(([args]) => args?.queryKey)
+    expect(invalidated).toEqual(
+      expect.arrayContaining([
+        [TRANSLATION_REVIEW_QUEUE_KEY],
+        ["exercise", "ex-1"],
+        [EXERCISES_BATCH_QUERY_KEY],
+        ["admin-exercises"],
+        ["exercise-library-paginated"],
+      ]),
+    )
+  })
+
+  it("leaves every cache alone when the write fails", async () => {
+    single.mockResolvedValue({ data: null, error: new Error("rls denied") })
+    const { result, queryClient } = renderHookWithProviders(() =>
+      useApproveTranslation(),
+    )
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({
+          exerciseId: "ex-1",
+          status: "approved",
+        })
+      }),
+    ).rejects.toThrow("rls denied")
+
+    expect(invalidate).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useApproveTranslation.test.ts
+++ b/src/hooks/useApproveTranslation.test.ts
@@ -3,12 +3,16 @@ import { act } from "@testing-library/react"
 import { renderHookWithProviders } from "@/test/utils"
 import { EXERCISES_BATCH_QUERY_KEY } from "@/hooks/useExerciseBatch"
 import { TRANSLATION_REVIEW_QUEUE_KEY } from "@/hooks/useTranslationReviewQueue"
-import { useApproveTranslation } from "./useApproveTranslation"
+import {
+  TranslationWriteRefusedError,
+  useApproveTranslation,
+} from "./useApproveTranslation"
 
 type Payload = Record<string, unknown>
 
-const single = vi.fn()
-const select = vi.fn(() => ({ single }))
+type Response = { data: { id: string }[] | null; error: Error | null }
+
+const select = vi.fn<(columns: string) => Promise<Response>>()
 const eq = vi.fn<(column: string, id: string) => { select: typeof select }>(
   () => ({ select }),
 )
@@ -26,10 +30,44 @@ const lastPayload = (): Payload => update.mock.calls.at(-1)?.[0] ?? {}
 
 beforeEach(() => {
   vi.clearAllMocks()
-  single.mockResolvedValue({ data: { id: "ex-1" }, error: null })
+  select.mockResolvedValue({ data: [{ id: "ex-1" }], error: null })
 })
 
 describe("useApproveTranslation", () => {
+  // Copilot's finding: the row comes back only to be discarded, and it carries
+  // both instructions blobs.
+  it("asks the database for an id rather than the row it just wrote", async () => {
+    const { result } = renderHookWithProviders(() => useApproveTranslation())
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        exerciseId: "ex-1",
+        status: "approved",
+      })
+    })
+
+    expect(select).toHaveBeenCalledWith("id")
+  })
+
+  // The defect underneath it. An UPDATE that RLS refuses is not an error over
+  // PostgREST — it is a successful request that matched no rows. A hook that
+  // ignores its result therefore reports success, fires the green toast, and
+  // leaves the row in the queue with nobody able to tell a refused write from
+  // a slow one.
+  it("treats a response carrying no row as a refused write", async () => {
+    select.mockResolvedValue({ data: [], error: null })
+    const { result } = renderHookWithProviders(() => useApproveTranslation())
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({
+          exerciseId: "ex-1",
+          status: "approved",
+        })
+      }),
+    ).rejects.toBeInstanceOf(TranslationWriteRefusedError)
+  })
+
   it("stamps the translation verdict and its own review timestamp", async () => {
     const { result } = renderHookWithProviders(() => useApproveTranslation())
 
@@ -148,7 +186,7 @@ describe("useApproveTranslation", () => {
   })
 
   it("leaves every cache alone when the write fails", async () => {
-    single.mockResolvedValue({ data: null, error: new Error("rls denied") })
+    select.mockResolvedValue({ data: null, error: new Error("rls denied") })
     const { result, queryClient } = renderHookWithProviders(() =>
       useApproveTranslation(),
     )

--- a/src/hooks/useApproveTranslation.ts
+++ b/src/hooks/useApproveTranslation.ts
@@ -2,7 +2,24 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { EXERCISES_BATCH_QUERY_KEY } from "@/hooks/useExerciseBatch"
 import { TRANSLATION_REVIEW_QUEUE_KEY } from "@/hooks/useTranslationReviewQueue"
 import { supabase } from "@/lib/supabase"
-import type { Exercise, ExerciseInstructions } from "@/types/database"
+import type { ExerciseInstructions } from "@/types/database"
+
+/**
+ * The write reached the database and changed nothing.
+ *
+ * RLS refusing an UPDATE is not an error over PostgREST: the request succeeds
+ * and matches zero rows. Without this the mutation resolves, the card shows the
+ * green toast, and the row sits in the queue with the reviewer unable to tell a
+ * refused write from a slow one. Typed rather than a bare `Error` so the card
+ * can say the database refused it instead of blaming the network — the same
+ * reason `useCreatePAT` names its failures.
+ */
+export class TranslationWriteRefusedError extends Error {
+  constructor() {
+    super("translation write refused: the update matched no row")
+    this.name = "TranslationWriteRefusedError"
+  }
+}
 
 /**
  * The two verdicts a reviewer can hand down. `clean` is absent on purpose: it is
@@ -52,14 +69,16 @@ export function useApproveTranslation() {
         ...(instructionsEn ? { instructions_en: instructionsEn } : {}),
       }
 
+      // `select("id")` and not `select()`: the response is only ever counted,
+      // and the full row carries both instruction blobs. The precedent is
+      // `scripts/translate-instructions.ts`, which asks for the same one column.
       const { data, error } = await supabase
         .from("exercises")
         .update(payload)
         .eq("id", exerciseId)
-        .select()
-        .single()
+        .select("id")
       if (error) throw error
-      return data as Exercise
+      if (data?.length !== 1) throw new TranslationWriteRefusedError()
     },
     // The queue key plus the four caches useAdminUpdateExercise invalidates: the
     // same catalog row is cached by id, by batch, by admin list and by library

--- a/src/hooks/useApproveTranslation.ts
+++ b/src/hooks/useApproveTranslation.ts
@@ -1,0 +1,79 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { EXERCISES_BATCH_QUERY_KEY } from "@/hooks/useExerciseBatch"
+import { TRANSLATION_REVIEW_QUEUE_KEY } from "@/hooks/useTranslationReviewQueue"
+import { supabase } from "@/lib/supabase"
+import type { Exercise, ExerciseInstructions } from "@/types/database"
+
+/**
+ * The two verdicts a reviewer can hand down. `clean` is absent on purpose: it is
+ * the pipeline's opinion, and this hook only records a human's.
+ */
+export type TranslationVerdict = "approved" | "flagged"
+
+export interface TranslationDecision {
+  exerciseId: string
+  status: TranslationVerdict
+  /** Corrected English, when the reviewer fixed a typo before approving. */
+  instructionsEn?: ExerciseInstructions
+}
+
+/**
+ * Records a translation review decision.
+ *
+ * Deliberately not `useAdminUpdateExercise`: that hook stamps `reviewed_at` and
+ * `reviewed_by` on every call, and those two belong to content review and image
+ * enrichment. Writing them from here would empty /admin/review's queue without
+ * anyone having read the exercise. Hence its own, short column list.
+ *
+ * `instructions_en_audit` is not in that list either, and the ticket does not
+ * say what should happen to it on a manual edit. It is left alone: the audit
+ * records which model produced the draft and what the cross-checker objected
+ * to, and a human correcting a sentence afterwards does not change either of
+ * those facts. The stale objection is invisible in practice — the row leaves
+ * the queue the moment it is decided — and erasing the provenance would make a
+ * future re-run undiffable, which story 12 of the epic exists to prevent.
+ *
+ * There is no optimistic concurrency control. The epic assumes a single
+ * reviewer, so the losing write of a genuine race would be a second decision by
+ * the same person; last one wins.
+ */
+export function useApproveTranslation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      exerciseId,
+      status,
+      instructionsEn,
+    }: TranslationDecision) => {
+      const payload = {
+        instructions_en_status: status,
+        instructions_en_reviewed_at: new Date().toISOString(),
+        ...(instructionsEn ? { instructions_en: instructionsEn } : {}),
+      }
+
+      const { data, error } = await supabase
+        .from("exercises")
+        .update(payload)
+        .eq("id", exerciseId)
+        .select()
+        .single()
+      if (error) throw error
+      return data as Exercise
+    },
+    // The queue key plus the four caches useAdminUpdateExercise invalidates: the
+    // same catalog row is cached by id, by batch, by admin list and by library
+    // page, and an approved translation changes what all four render.
+    //
+    // The id comes from the variables rather than from a hook argument because
+    // the caller is a queue walking one row after another — binding the hook to
+    // an id would mean re-creating the mutation on every decision.
+    onSuccess: (_data, { exerciseId }) => {
+      queryClient.invalidateQueries({ queryKey: [TRANSLATION_REVIEW_QUEUE_KEY] })
+      queryClient.invalidateQueries({ queryKey: ["exercise", exerciseId] })
+      queryClient.invalidateQueries({ queryKey: [EXERCISES_BATCH_QUERY_KEY] })
+      queryClient.invalidateQueries({ queryKey: ["admin-exercises"] })
+      queryClient.invalidateQueries({ queryKey: ["exercise-library-paginated"] })
+    },
+  })
+}

--- a/src/lib/translationReview.test.ts
+++ b/src/lib/translationReview.test.ts
@@ -3,7 +3,9 @@ import { describe, it, expect } from "vitest"
 import source from "./translationReview.ts?raw"
 import {
   buildReviewSections,
+  fromInstructionDraft,
   orphanObjections,
+  toInstructionDraft,
   type ReviewObjection,
 } from "@/lib/translationReview"
 import { importsOf } from "@/test/imports"
@@ -148,5 +150,58 @@ describe("orphanObjections", () => {
     const sections = buildReviewSections(french, english, [stray])
 
     expect(orphanObjections(sections, [stray])).toEqual([stray])
+  })
+})
+
+describe("the editable draft", () => {
+  it("round-trips a translation nobody touched", () => {
+    expect(fromInstructionDraft(toInstructionDraft(english))).toEqual(english)
+  })
+
+  it("puts one sentence per line", () => {
+    expect(toInstructionDraft(english).setup).toBe(
+      "Lie on your back.\nSet your hands hip-width apart.",
+    )
+  })
+
+  // The likeliest edit of all is a stray return at the end of a textarea, and
+  // an empty sentence would render as a bullet with nothing in it.
+  it("drops blank lines and surrounding whitespace", () => {
+    const edited = fromInstructionDraft({
+      ...toInstructionDraft(english),
+      setup: "  Lie on your back.  \n\n   \nSet your hands shoulder-width apart.\n",
+    })
+
+    expect(edited.setup).toEqual([
+      "Lie on your back.",
+      "Set your hands shoulder-width apart.",
+    ])
+  })
+
+  // A partial object would fail the resolver's section-parity check, so the row
+  // would read `approved` and still render French — the one outcome nobody
+  // could debug from the screen.
+  it("keeps all four sections even when one is emptied", () => {
+    const gutted = fromInstructionDraft({
+      ...toInstructionDraft(english),
+      breathing: "",
+    })
+
+    expect(Object.keys(gutted).sort()).toEqual([
+      "breathing",
+      "common_mistakes",
+      "movement",
+      "setup",
+    ])
+    expect(gutted.breathing).toEqual([])
+  })
+
+  it("offers four empty blocks for a row with no translation at all", () => {
+    expect(toInstructionDraft(null)).toEqual({
+      setup: "",
+      movement: "",
+      breathing: "",
+      common_mistakes: "",
+    })
   })
 })

--- a/src/lib/translationReview.ts
+++ b/src/lib/translationReview.ts
@@ -90,6 +90,56 @@ export function buildReviewSections(
  * "there is an objection you are not being shown" instead of swallowing it,
  * which is the failure a reviewer could never detect on their own.
  */
+/** One editable text block per section, sentences separated by newlines. */
+export type InstructionDraft = Record<InstructionSection, string>
+
+/**
+ * The English as plain text, one sentence per line.
+ *
+ * A line *is* a sentence here — that is the whole editing contract, and the
+ * reason it is a transform in this module rather than a `join` buried in the
+ * textarea's `value`: the round trip has to be lossless for the sentences a
+ * reviewer did not touch, which is a claim worth testing on its own.
+ */
+export function toInstructionDraft(
+  english: ExerciseInstructions | null | undefined,
+): InstructionDraft {
+  return Object.fromEntries(
+    INSTRUCTION_SECTIONS.map((section) => [
+      section,
+      (english?.[section] ?? []).join("\n"),
+    ]),
+  ) as InstructionDraft
+}
+
+const sentencesIn = (block: string): string[] =>
+  block
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+
+/**
+ * The inverse. Blank lines are dropped rather than written as empty sentences:
+ * a stray return at the end of a textarea is the most likely edit of all, and
+ * an empty string would render as a bullet with nothing in it.
+ *
+ * Written out section by section rather than mapped, so that all four keys are
+ * present by construction. A partial object would fail the resolver's
+ * section-parity check and the row would render French while reading
+ * `approved` — and adding a fifth section would break this line rather than
+ * quietly produce one.
+ */
+export function fromInstructionDraft(
+  draft: InstructionDraft,
+): ExerciseInstructions {
+  return {
+    setup: sentencesIn(draft.setup),
+    movement: sentencesIn(draft.movement),
+    breathing: sentencesIn(draft.breathing),
+    common_mistakes: sentencesIn(draft.common_mistakes),
+  }
+}
+
 export function orphanObjections(
   sections: readonly ReviewSection[],
   objections: readonly ReviewObjection[] = [],

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -35,6 +35,7 @@
     "revert": "Revert to French",
     "skip": "Skip",
     "cardLabel": "Reviewing {{name}} — press A to approve, E to edit, R to revert to French, arrow right to skip",
+    "cardLabelEditing": "Editing the English for {{name}} — press Escape to discard the correction",
     "orphanObjections_one": "{{count}} objection points at a sentence that does not exist and is not shown below.",
     "orphanObjections_other": "{{count}} objections point at sentences that do not exist and are not shown below.",
     "loggedSets_one": "{{count}} logged set",
@@ -58,7 +59,8 @@
     "toast": {
       "approved": "{{name}} approved in English",
       "flagged": "{{name}} reverted to French",
-      "error": "Decision not saved — the exercise stays in the queue"
+      "error": "Decision not saved — the exercise stays in the queue",
+      "refused": "Decision refused — your account may no longer have review access"
     }
   },
   "review": {

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -28,6 +28,13 @@
     "englishHeading": "English",
     "missingSentence": "no sentence at this position",
     "gateFlags": "Automatic checks:",
+    "approve": "Approve",
+    "edit": "Edit",
+    "cancelEdit": "Cancel edit",
+    "editSection": "Edit the English for {{section}} — one sentence per line",
+    "revert": "Revert to French",
+    "skip": "Skip",
+    "cardLabel": "Reviewing {{name}} — press A to approve, E to edit, R to revert to French, arrow right to skip",
     "orphanObjections_one": "{{count}} objection points at a sentence that does not exist and is not shown below.",
     "orphanObjections_other": "{{count}} objections point at sentences that do not exist and are not shown below.",
     "loggedSets_one": "{{count}} logged set",
@@ -47,6 +54,11 @@
     "audit": {
       "line": "Translated by {{model}} on {{date}} · cross-checked by {{checker}} · prompt v{{version}}",
       "checkerUnavailable": "no cross-checker"
+    },
+    "toast": {
+      "approved": "{{name}} approved in English",
+      "flagged": "{{name}} reverted to French",
+      "error": "Decision not saved — the exercise stays in the queue"
     }
   },
   "review": {

--- a/src/locales/fr/admin.json
+++ b/src/locales/fr/admin.json
@@ -35,6 +35,7 @@
     "revert": "Rendre au français",
     "skip": "Passer",
     "cardLabel": "Relecture de {{name}} — A pour approuver, E pour éditer, R pour rendre au français, flèche droite pour passer",
+    "cardLabelEditing": "Édition de l'anglais de {{name}} — Échap pour abandonner la correction",
     "orphanObjections_one": "{{count}} objection vise une phrase inexistante et n'est pas affichée ci-dessous.",
     "orphanObjections_other": "{{count}} objections visent des phrases inexistantes et ne sont pas affichées ci-dessous.",
     "loggedSets_one": "{{count}} série loguée",
@@ -58,7 +59,8 @@
     "toast": {
       "approved": "{{name}} approuvé en anglais",
       "flagged": "{{name}} rendu au français",
-      "error": "Décision non enregistrée — l'exercice reste dans la file"
+      "error": "Décision non enregistrée — l'exercice reste dans la file",
+      "refused": "Décision refusée — votre compte n'a peut-être plus accès à la revue"
     }
   },
   "review": {

--- a/src/locales/fr/admin.json
+++ b/src/locales/fr/admin.json
@@ -28,6 +28,13 @@
     "englishHeading": "Anglais",
     "missingSentence": "aucune phrase à cette position",
     "gateFlags": "Contrôles automatiques :",
+    "approve": "Approuver",
+    "edit": "Éditer",
+    "cancelEdit": "Annuler l'édition",
+    "editSection": "Corriger l'anglais de {{section}} — une phrase par ligne",
+    "revert": "Rendre au français",
+    "skip": "Passer",
+    "cardLabel": "Relecture de {{name}} — A pour approuver, E pour éditer, R pour rendre au français, flèche droite pour passer",
     "orphanObjections_one": "{{count}} objection vise une phrase inexistante et n'est pas affichée ci-dessous.",
     "orphanObjections_other": "{{count}} objections visent des phrases inexistantes et ne sont pas affichées ci-dessous.",
     "loggedSets_one": "{{count}} série loguée",
@@ -47,6 +54,11 @@
     "audit": {
       "line": "Traduit par {{model}} le {{date}} · contre-relu par {{checker}} · prompt v{{version}}",
       "checkerUnavailable": "aucun contre-relecteur"
+    },
+    "toast": {
+      "approved": "{{name}} approuvé en anglais",
+      "flagged": "{{name}} rendu au français",
+      "error": "Décision non enregistrée — l'exercice reste dans la file"
     }
   },
   "review": {

--- a/src/pages/AdminTranslationsPage.test.tsx
+++ b/src/pages/AdminTranslationsPage.test.tsx
@@ -1,12 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { screen } from "@testing-library/react"
+import { act, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { renderWithProviders, mockQueryResult } from "@/test/utils"
 import { AdminTranslationsPage } from "@/pages/AdminTranslationsPage"
 import { useTranslationReviewQueue } from "@/hooks/useTranslationReviewQueue"
 import type { TranslationReviewRow } from "@/hooks/useTranslationReviewQueue"
 
-vi.mock("@/lib/supabase", () => ({ supabase: { from: vi.fn(), rpc: vi.fn() } }))
+// A decision the test holds open, so the window between issuing a verdict and
+// the queue rebuilding can be inspected rather than raced.
+let settleWrite: (() => void) | null = null
+const select = vi.fn(
+  () =>
+    new Promise<{ data: { id: string }[]; error: null }>((resolve) => {
+      settleWrite = () => resolve({ data: [{ id: "flagged-never-logged" }], error: null })
+    }),
+)
+const update = vi.fn(() => ({ eq: () => ({ select }) }))
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: () => ({ update: () => update() }), rpc: vi.fn() },
+}))
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 vi.mock("@/hooks/useTranslationReviewQueue", () => ({
   useTranslationReviewQueue: vi.fn(),
   TRANSLATION_REVIEW_QUEUE_KEY: "translations-for-review",
@@ -52,6 +66,8 @@ const queueInRpcOrder: TranslationReviewRow[] = [
 const mockedQueue = vi.mocked(useTranslationReviewQueue)
 
 beforeEach(() => {
+  vi.clearAllMocks()
+  settleWrite = null
   mockedQueue.mockReturnValue(
     mockQueryResult(queueInRpcOrder) as ReturnType<
       typeof useTranslationReviewQueue
@@ -94,6 +110,32 @@ describe("AdminTranslationsPage", () => {
     renderWithProviders(<AdminTranslationsPage />)
 
     await user.keyboard("{ArrowRight}")
+
+    expect(
+      screen.getByRole("heading", { name: "Bench press" }),
+    ).toBeInTheDocument()
+  })
+
+  // The phantom skip, at the seam where it actually bites. Skip never goes
+  // through the mutation, so nothing about the write gates it: approve Cat-cow,
+  // press `→` before the write lands, and the index sits on 1 when the refetch
+  // drops the decided row and shifts the rest up by one. Bench press is then
+  // never shown, and the reviewer has no way to know it went past.
+  it("does not let a skip ride on top of a decision still in flight", async () => {
+    const user = userEvent.setup()
+    const { rerender } = renderWithProviders(<AdminTranslationsPage />)
+
+    await user.keyboard("a")
+    await user.keyboard("{ArrowRight}")
+
+    // What the refetch delivers once the write lands: the decided row is gone.
+    mockedQueue.mockReturnValue(
+      mockQueryResult(queueInRpcOrder.slice(1)) as ReturnType<
+        typeof useTranslationReviewQueue
+      >,
+    )
+    await act(async () => settleWrite?.())
+    rerender(<AdminTranslationsPage />)
 
     expect(
       screen.getByRole("heading", { name: "Bench press" }),

--- a/src/pages/AdminTranslationsPage.test.tsx
+++ b/src/pages/AdminTranslationsPage.test.tsx
@@ -87,6 +87,19 @@ describe("AdminTranslationsPage", () => {
     ).toBeInTheDocument()
   })
 
+  // The card owns the shortcut, the page owns the position. Neither test can
+  // see the seam on its own, so this one drives the real pair.
+  it("moves on when the reviewer skips from the keyboard", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<AdminTranslationsPage />)
+
+    await user.keyboard("{ArrowRight}")
+
+    expect(
+      screen.getByRole("heading", { name: "Bench press" }),
+    ).toBeInTheDocument()
+  })
+
   it("goes back the way it came", async () => {
     const user = userEvent.setup()
     renderWithProviders(<AdminTranslationsPage />)

--- a/src/pages/AdminTranslationsPage.tsx
+++ b/src/pages/AdminTranslationsPage.tsx
@@ -13,8 +13,9 @@ export function AdminTranslationsPage() {
   const [index, setIndex] = useState(0)
 
   const total = queue?.length ?? 0
-  // Clamped rather than reset: the queue is read-only in this ticket, so the
-  // only way the index can outrun it is a refetch shrinking the list.
+  // Clamped rather than reset, and deliberately not advanced after a decision:
+  // the decided row leaves the queue on the next fetch, so the same index lands
+  // on the row that followed it. Only the last row of the queue needs the clamp.
   const position = Math.min(index, Math.max(total - 1, 0))
   const row = total > 0 ? queue![position] : null
 
@@ -61,7 +62,11 @@ export function AdminTranslationsPage() {
             </Badge>
           </div>
 
-          <TranslationReviewCard key={row.id} row={row} />
+          <TranslationReviewCard
+            key={row.id}
+            row={row}
+            onSkip={() => setIndex(position + 1)}
+          />
 
           <div className="flex items-center justify-between gap-2">
             <Button


### PR DESCRIPTION
## What

- `useApproveTranslation` — a targeted `UPDATE` on `exercises` recording a reviewer's verdict: `instructions_en_status` plus `instructions_en_reviewed_at`, and the corrected English when there is one.
- Four affordances on `TranslationReviewCard`, each with a keyboard shortcut: `A` approve, `E` edit, `R` revert to French, `→` skip without deciding.
- Edit mode is one raw `Textarea` per section, one sentence per line — deliberately spartan. Structured correction, shape validation and the diff are T160.
- Full FR/EN strings for the new surface, and an `aria-label` on every textarea built from the section name.

## Why

T158 shipped a queue you could read but not act on. Stories 7 and 10 of the epic ask for a pass that is fast, keyboard-driven, and resumable in ten-minute chunks — with the decision timestamped so a second pass never re-presents what was already settled.

The ticket's *point de vigilance* is a single column. `reviewed_at` is shared between `/admin/review` content review and image enrichment; writing it here would retire an exercise from that queue without anyone having read a word of it. This mutation therefore cannot reuse `useAdminUpdateExercise`, which stamps `reviewed_at` and `reviewed_by` unconditionally, and spells out its own short column list instead.

## How

**No new RPC, no migration.** The existing `"Admins can update exercises"` RLS policy already covers this write from the browser with the admin's own session, so there is no `SECURITY DEFINER` function to guard — which is the direction of travel after #442 and #445. Nothing in `supabase/` changed.

**Reverting keeps the translation.** `R` writes `flagged` and the timestamp but never touches `instructions_en`: the row leaves the queue and the app falls back to French, while the English stays in the table for a future `--force` pass.

**Shortcuts are local `onKeyDown` handlers** on a `tabIndex={-1}` container that takes focus on mount, following `BuilderHeader`. The repo has no global shortcut hook and this does not invent one. Keystrokes whose target is a textarea are ignored, so typing a correction containing A, R or E does not decide the row.

**Cache invalidation** mirrors `useAdminUpdateExercise` — the catalog row is cached by id, by batch, by admin list and by library page — plus the queue key. The exercise id travels in the mutation variables rather than a hook argument, because the caller walks a queue.

### Decisions where the ticket was silent

- **`instructions_en_audit` on a manual edit: left untouched.** It records which model produced the draft and what the cross-checker objected to; a human fixing a sentence afterwards does not change either fact. The stale objection is never seen again since the row leaves the queue, and erasing provenance would make a future re-run undiffable — which story 12 exists to prevent.
- **No optimistic concurrency control.** The epic assumes a single reviewer; last write wins. A held key is guarded against separately: a second decision is ignored while the first is in flight, because the queue only rebuilds once the write lands.
- **The page does not advance its index after a decision.** The decided row leaves the queue on refetch, so the same index lands on the row that followed it. Only the tail of the queue needs the existing clamp.
- **An emptied section is written as `[]`, not dropped.** All four keys are always present — a partial object would fail the resolver's section-parity check and the row would render French while reading `approved`.

## Tests

+32, suite at 2089 passing across 214 files. `tsc -b` and `npm run lint` clean.

The load-bearing one is `src/hooks/translationReviewRoundTrip.test.ts`, which drives the real `useTranslationReviewQueue`, `useExercisesForReview` and `useApproveTranslation` against a fake `exercises` table whose two queue predicates are **lifted from the migrations themselves** and asserted against them, so the fakes cannot drift from the SQL:

- an approved row leaves the T158 queue, and so does a row reverted to `flagged` — which is the sharp version, since `flagged` is the status that queue ranks *first*, so departure has to come from the timestamp rather than the verdict;
- the same approval leaves the content-review queue at full length, with an explicit refetch so the assertion cannot pass off a stale cache.

Every assertion here was checked by breaking the implementation and watching it go red — removing the timestamp stamp, and adding a `reviewed_at` write. The content-review test caught the second one only after the read was fixed; in its first form it read a stale render and passed regardless.

---

Part of the English Exercise Instructions epic — #436, original report #417. Follows #437 (T156), #438 (T157), #439 (T158).

Made with [Cursor](https://cursor.com)