### PR TITLE
feat(i18n): review assist clipboard round-trip (T160)

### DIFF
--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { AlertTriangle, ChevronDown, ChevronUp, Copy } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
+import { copyToClipboard } from "@/lib/clipboard"
 import {
   buildErrorReport,
   formatReportAsMarkdown,
@@ -16,33 +17,6 @@ interface ErrorFallbackProps {
   caughtAt?: Date
   resetErrorBoundary?: () => void
   variant?: "page" | "inline"
-}
-
-async function copyToClipboard(text: string): Promise<boolean> {
-  try {
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(text)
-      return true
-    }
-  } catch {
-    // fall through to legacy path
-  }
-  const ta = document.createElement("textarea")
-  ta.value = text
-  ta.setAttribute("readonly", "")
-  ta.style.position = "fixed"
-  ta.style.opacity = "0"
-  document.body.appendChild(ta)
-  try {
-    ta.select()
-    return document.execCommand("copy")
-  } catch {
-    return false
-  } finally {
-    // Always detach the textarea — even if select()/execCommand throw,
-    // we don't want to leak a hidden node into the DOM.
-    ta.remove()
-  }
 }
 
 export function ErrorFallback({

--- a/src/components/admin/translations/ReviewAssistDialog.test.tsx
+++ b/src/components/admin/translations/ReviewAssistDialog.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from "vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { renderWithProviders } from "@/test/utils"
+import { ReviewAssistDialog } from "@/components/admin/translations/ReviewAssistDialog"
+import type { ReviewSubject } from "@/lib/reviewAssist"
+
+// The dialog itself never talks to Supabase — it hands the correction back to
+// the card, which owns the one write path — but the stub is what keeps the
+// module graph from reaching a client CI has no keys for.
+vi.mock("@/lib/supabase", () => ({ supabase: { from: vi.fn() } }))
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const SUBJECT: ReviewSubject = {
+  name: "Développé couché",
+  name_en: "Bench Press",
+  instructions: {
+    setup: ["Allongez-vous sur le banc.", "Écartez les mains à largeur d'épaules."],
+    movement: ["Poussez la barre vers le haut."],
+    breathing: ["Expirez à la poussée."],
+    common_mistakes: ["Dos creusé."],
+  },
+  instructions_en: {
+    setup: ["Lie back on the bench.", "Set your hands hip-width apart."],
+    movement: ["Press the bar upward."],
+    breathing: ["Exhale as you press."],
+    common_mistakes: ["Arched lower back."],
+  },
+  instructions_en_audit: null,
+}
+
+const CORRECTED = {
+  ...SUBJECT.instructions_en!,
+  setup: ["Lie back on the bench.", "Set your hands shoulder-width apart."],
+}
+
+function open(onApply = vi.fn()) {
+  const user = userEvent.setup()
+  renderWithProviders(
+    <ReviewAssistDialog
+      subject={SUBJECT}
+      open
+      onOpenChange={vi.fn()}
+      onApply={onApply}
+      disabled={false}
+    />,
+  )
+  return { user, onApply }
+}
+
+const paste = async (
+  user: ReturnType<typeof userEvent.setup>,
+  text: string,
+) => {
+  await user.click(screen.getByRole("textbox", { name: /corrected json/i }))
+  await user.paste(text)
+  await user.click(screen.getByRole("button", { name: /check the correction/i }))
+}
+
+describe("ReviewAssistDialog paste-back", () => {
+  // The whole point of the shape gate: an answer that is not an instruction
+  // block must not reach the card, and the reviewer has to be told what to do
+  // about it rather than watch the button do nothing.
+  it("refuses a truncated answer with a message and applies nothing", async () => {
+    const { user, onApply } = open()
+
+    await paste(user, '{"setup": ["Lie back on the bench.", "Set your')
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/valid JSON/i)
+    expect(onApply).not.toHaveBeenCalled()
+  })
+
+  // Checking is not applying. The reviewer is the last thing standing between
+  // an assistant's answer and the catalogue, and they cannot be that if the
+  // write happens as a side effect of looking.
+  it("shows what would change and writes nothing until it is confirmed", async () => {
+    const { user, onApply } = open()
+
+    await paste(user, JSON.stringify(CORRECTED))
+
+    const diff = await screen.findByRole("list", { name: /what would change/i })
+    expect(diff).toHaveTextContent("Set your hands hip-width apart.")
+    expect(diff).toHaveTextContent("Set your hands shoulder-width apart.")
+    expect(onApply).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: /approve this correction/i }))
+
+    expect(onApply).toHaveBeenCalledWith(CORRECTED)
+  })
+
+  // Well-formed JSON that would still poison the row: the resolver needs every
+  // section the French fills to be filled in English, and it fails silently, so
+  // this is the one refusal the reviewer could never diagnose on their own. The
+  // message names the section rather than saying "invalid".
+  it("names the section a correction would empty, and offers no way to apply it", async () => {
+    const { user, onApply } = open()
+
+    await paste(
+      user,
+      JSON.stringify({ ...SUBJECT.instructions_en, breathing: [] }),
+    )
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/Breathing/)
+    expect(
+      screen.queryByRole("button", { name: /approve this correction/i }),
+    ).toBeNull()
+    expect(onApply).not.toHaveBeenCalled()
+  })
+
+  it("says so in French too", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <ReviewAssistDialog
+        subject={SUBJECT}
+        open
+        onOpenChange={vi.fn()}
+        onApply={vi.fn()}
+        disabled={false}
+      />,
+      { locale: "fr" },
+    )
+
+    await user.click(screen.getByRole("textbox", { name: /json corrigé/i }))
+    await user.paste("pas du JSON")
+    await user.click(screen.getByRole("button", { name: /vérifier la correction/i }))
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/JSON valide/i)
+  })
+})

--- a/src/components/admin/translations/ReviewAssistDialog.tsx
+++ b/src/components/admin/translations/ReviewAssistDialog.tsx
@@ -1,0 +1,233 @@
+import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { AlertTriangle, Check, Clipboard, MessagesSquare } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { copyToClipboard } from "@/lib/clipboard"
+import {
+  buildReviewRequest,
+  diffCorrection,
+  readCorrection,
+  type CorrectionResult,
+  type DiffLine,
+  type ReviewSubject,
+} from "@/lib/reviewAssist"
+import { SECTION_LABEL_KEYS } from "@/lib/translationReview"
+import type { ExerciseInstructions } from "@/types/database"
+
+interface ReviewAssistDialogProps {
+  subject: ReviewSubject
+  /**
+   * Hands the accepted correction to the card, which records it through the
+   * one mutation. This dialog deliberately owns no write: a second path to the
+   * column would be a second place for the refused-write handling to be
+   * forgotten.
+   */
+  onApply: (instructions: ExerciseInstructions) => void
+  open: boolean
+  /**
+   * Reported to the card, which silences its own shortcuts while this is open:
+   * a portal keeps the dialog out of the card's DOM subtree but not out of its
+   * React tree, so a keystroke in the paste box still reaches the card's
+   * `onKeyDown` and would otherwise be read as a verdict.
+   */
+  onOpenChange: (open: boolean) => void
+  disabled: boolean
+}
+
+/**
+ * One sentence of the diff. Unchanged text stays plain so the eye skips it;
+ * anything else is boxed, and carries the verdict as text as well as colour —
+ * "the red one" is not a description a screen reader can give.
+ */
+function DiffLineRow({ line }: { line: DiffLine }) {
+  const { t } = useTranslation("admin")
+
+  if (line.status === "unchanged") {
+    return <p className="text-sm text-muted-foreground">{line.after}</p>
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5 rounded-md border border-border/60 bg-muted/30 p-2 text-sm">
+      <span className="sr-only">
+        {t(`translations.assist.change.${line.status}`)}
+      </span>
+      {line.before !== null ? (
+        <p className="text-destructive line-through decoration-destructive/60">
+          {line.before}
+        </p>
+      ) : null}
+      {line.after !== null ? (
+        <p className="text-emerald-600 dark:text-emerald-400">{line.after}</p>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * What the write would do to the stored English, before it is offered. The
+ * unchanged sentences are shown too: a diff of only the changes hides whether
+ * the assistant returned the whole block or a fragment of it, which is exactly
+ * the thing the reviewer is here to notice.
+ */
+function CorrectionDiff({
+  current,
+  proposed,
+}: {
+  current: ExerciseInstructions | null
+  proposed: ExerciseInstructions
+}) {
+  const { t } = useTranslation("admin")
+
+  return (
+    <ul
+      aria-label={t("translations.assist.diffLabel")}
+      className="flex flex-col gap-3"
+    >
+      {diffCorrection(current, proposed).map(({ section, lines }) => (
+        <li key={section} className="flex flex-col gap-1">
+          <h3 className="text-sm font-semibold">
+            {t(SECTION_LABEL_KEYS[section])}
+          </h3>
+          {lines.map((line) => (
+            <DiffLineRow key={line.index} line={line} />
+          ))}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+/**
+ * Why the paste was refused, in terms of what to do about it. `role="alert"`
+ * because the message appears in response to a click somewhere else on the
+ * dialog and would otherwise go unannounced.
+ */
+function CorrectionRefusal({
+  problem,
+}: {
+  problem: Extract<CorrectionResult, { ok: false }>
+}) {
+  const { t } = useTranslation("admin")
+  const sections =
+    problem.problem === "blanked"
+      ? problem.sections.map((section) => t(SECTION_LABEL_KEYS[section])).join(", ")
+      : ""
+
+  return (
+    <p
+      role="alert"
+      className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+    >
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+      {t(`translations.assist.problem.${problem.problem}`, { sections })}
+    </p>
+  )
+}
+
+export function ReviewAssistDialog({
+  subject,
+  onApply,
+  open,
+  onOpenChange,
+  disabled,
+}: ReviewAssistDialogProps) {
+  const { t } = useTranslation("admin")
+  // Derived, not stored: keeping it in state would let it go stale against the
+  // row, and it is a pure string build over eight columns.
+  const request = useMemo(() => buildReviewRequest(subject), [subject])
+  const [pasted, setPasted] = useState("")
+  // `null` is "not checked yet", which is not the same as "checked and fine":
+  // the apply button only exists in the second case.
+  const [result, setResult] = useState<CorrectionResult | null>(null)
+
+  const copy = async () => {
+    if (await copyToClipboard(request)) {
+      toast.success(t("translations.assist.copied"))
+      return
+    }
+    // Not a dead end: the text goes into the toast so a reviewer on an insecure
+    // context can still select it by hand, the way the enrichment toolbar does
+    // with its illustration prompts.
+    toast.error(t("translations.assist.copyFailed"), {
+      description: request,
+      duration: 20000,
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline" className="gap-2" disabled={disabled}>
+          <MessagesSquare className="h-4 w-4" />
+          {t("translations.assist.open")}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[85vh] max-w-3xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{t("translations.assist.title")}</DialogTitle>
+          <DialogDescription>
+            {t("translations.assist.description")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Button variant="outline" className="gap-2 self-start" onClick={copy}>
+          <Clipboard className="h-4 w-4" />
+          {t("translations.assist.copy")}
+        </Button>
+
+        <div className="flex flex-col gap-2">
+          <Textarea
+            value={pasted}
+            aria-label={t("translations.assist.pasteLabel")}
+            placeholder={t("translations.assist.pastePlaceholder")}
+            // Editing after a check invalidates it: leaving the old verdict on
+            // screen would let the reviewer apply a diff of text that is no
+            // longer in the box.
+            onChange={(event) => {
+              setPasted(event.target.value)
+              setResult(null)
+            }}
+            rows={6}
+            className="font-mono text-xs"
+          />
+          <Button
+            variant="secondary"
+            className="self-start"
+            disabled={pasted.trim() === ""}
+            onClick={() => setResult(readCorrection(pasted, subject.instructions))}
+          >
+            {t("translations.assist.check")}
+          </Button>
+        </div>
+
+        {result === null ? null : result.ok ? (
+          <>
+            <CorrectionDiff
+              current={subject.instructions_en}
+              proposed={result.instructions}
+            />
+            <DialogFooter>
+              <Button className="gap-2" onClick={() => onApply(result.instructions)}>
+                <Check className="h-4 w-4" />
+                {t("translations.assist.apply")}
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <CorrectionRefusal problem={result} />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/admin/translations/TranslationReviewCard.test.tsx
+++ b/src/components/admin/translations/TranslationReviewCard.test.tsx
@@ -106,6 +106,26 @@ const row: TranslationReviewRow = {
 const lineContaining = (text: string): HTMLElement =>
   screen.getByText(text).closest("li")!
 
+/** The corrected block an arbiter hands back: one sentence rewritten. */
+const CORRECTED = {
+  setup: ["Lie back on the bench.", "Set your hands shoulder-width apart."],
+  movement: ["Press the bar upward."],
+  breathing: ["Exhale as you press."],
+  common_mistakes: ["Arched lower back."],
+}
+
+/** The whole round trip, from opening the dialog to confirming the diff. */
+const adjudicate = async (
+  user: ReturnType<typeof userEvent.setup>,
+  block: unknown,
+) => {
+  await user.click(screen.getByRole("button", { name: /review assist/i }))
+  await user.click(screen.getByRole("textbox", { name: /corrected json/i }))
+  await user.paste(JSON.stringify(block))
+  await user.click(screen.getByRole("button", { name: /check the correction/i }))
+  await user.click(screen.getByRole("button", { name: /approve this correction/i }))
+}
+
 describe("TranslationReviewCard", () => {
   it("shows both names, the status and the reading exposure", () => {
     renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
@@ -581,29 +601,93 @@ describe("TranslationReviewCard decisions", () => {
     const user = userEvent.setup()
     renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
 
-    await user.click(screen.getByRole("button", { name: /review assist/i }))
-    await user.click(screen.getByRole("textbox", { name: /corrected json/i }))
-    await user.paste(
-      JSON.stringify({
-        setup: ["Lie back on the bench.", "Set your hands shoulder-width apart."],
-        movement: ["Press the bar upward."],
-        breathing: ["Exhale as you press."],
-        common_mistakes: ["Arched lower back."],
-      }),
-    )
-    await user.click(screen.getByRole("button", { name: /check the correction/i }))
-    await user.click(screen.getByRole("button", { name: /approve this correction/i }))
+    await adjudicate(user, CORRECTED)
 
-    await waitFor(() =>
-      expect(lastPayload().instructions_en).toEqual({
-        setup: ["Lie back on the bench.", "Set your hands shoulder-width apart."],
-        movement: ["Press the bar upward."],
-        breathing: ["Exhale as you press."],
-        common_mistakes: ["Arched lower back."],
-      }),
-    )
+    await waitFor(() => expect(lastPayload().instructions_en).toEqual(CORRECTED))
     expect(lastPayload()).toMatchObject({ instructions_en_status: "approved" })
     expect(update).toHaveBeenCalledTimes(1)
+    // Written, so there is nothing left to adjudicate and the diff goes away.
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+  })
+
+  /**
+   * The failure path, which is the only way to reach it and therefore the way
+   * it would have reached production.
+   *
+   * A correction that fails to write used to leave the reviewer in front of a
+   * closed dialog with the gate reopened, one keystroke from approving the
+   * machine English they had just adjudicated *against* — marked reviewed by a
+   * human who reviewed something else. So the write and the diff share a
+   * lifetime: nothing is dismissed until something is written, and while the
+   * diff is up the card answers no keys at all.
+   */
+  it("keeps the diff on screen when the write fails, and answers no retry key", async () => {
+    select.mockResolvedValue({ data: [], error: null })
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await adjudicate(user, CORRECTED)
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+
+    await user.keyboard("a")
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(
+      within(screen.getByRole("dialog")).getByRole("list", {
+        name: /what would change/i,
+      }),
+    ).toHaveTextContent("Set your hands shoulder-width apart.")
+  })
+
+  // And the retry writes the correction, not a bare approval: the reviewer
+  // clicks the same button under the same diff, so the second attempt cannot
+  // mean something different from the first.
+  it("resubmits the adjudicated block when the reviewer retries", async () => {
+    select.mockResolvedValueOnce({ data: [], error: null })
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await adjudicate(user, CORRECTED)
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+
+    await user.click(screen.getByRole("button", { name: /approve this correction/i }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(2))
+    expect(lastPayload().instructions_en).toEqual(CORRECTED)
+    expect(lastPayload()).toMatchObject({ instructions_en_status: "approved" })
+  })
+
+  /**
+   * Two proposals cannot coexist. A reviewer who was midway through a manual
+   * edit and then adjudicated has said which one they mean, and the abandoned
+   * draft must not be able to win a later approval — a stale draft written
+   * under `approved` is the same defect as the machine English, in a costume.
+   */
+  it("drops a manual draft the correction supersedes", async () => {
+    select.mockResolvedValue({ data: [], error: null })
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("e")
+    await user.type(
+      screen.getByRole("textbox", { name: /edit the english for setup/i }),
+      "Draft nobody adjudicated.",
+    )
+    await adjudicate(user, CORRECTED)
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+
+    // Dismissing the diff abandons the correction with it, so the card is back
+    // to proposing nothing — and approving writes the row as it stands.
+    await user.keyboard("{Escape}")
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+    // Clicked rather than typed: the keyboard is already deaf while the editors
+    // are open, so the button is the only way the stale draft could reach the
+    // column, and therefore the only place worth asserting.
+    await user.click(screen.getByRole("button", { name: /^approve/i }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(2))
+    expect(lastPayload().instructions_en).toBeUndefined()
+    expect(screen.queryByRole("textbox", { name: /edit the english/i })).toBeNull()
   })
 
   // The T159 defect wearing a different hat. Radix portals the dialog out of
@@ -668,19 +752,16 @@ describe("TranslationReviewCard decisions", () => {
     const user = userEvent.setup()
     renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
 
-    await user.click(screen.getByRole("button", { name: /review assist/i }))
-    await user.click(screen.getByRole("textbox", { name: /corrected json/i }))
-    await user.paste(JSON.stringify(row.instructions_en))
-    await user.click(screen.getByRole("button", { name: /check the correction/i }))
-    await user.click(screen.getByRole("button", { name: /approve this correction/i }))
+    await adjudicate(user, row.instructions_en)
 
     await waitFor(() =>
       expect(toastError).toHaveBeenCalledWith(expect.stringContaining("refused")),
     )
     expect(toastSuccess).not.toHaveBeenCalled()
-    expect(
-      screen.getByRole("heading", { name: "Développé couché" }),
-    ).toBeInTheDocument()
+    // Queried by text, not by role: the open modal marks the card `aria-hidden`
+    // for everyone outside it, which is correct and is not the claim here — the
+    // claim is that the row did not go anywhere.
+    expect(screen.getByText("Développé couché")).toBeInTheDocument()
   })
 
   it("skips from the button too", async () => {

--- a/src/components/admin/translations/TranslationReviewCard.test.tsx
+++ b/src/components/admin/translations/TranslationReviewCard.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { renderWithProviders } from "@/test/utils"
@@ -30,9 +30,39 @@ vi.mock("sonner", () => ({
 
 const lastPayload = (): Payload => update.mock.calls.at(-1)?.[0] ?? {}
 
+// jsdom exposes no clipboard, so every test that copies has to say what the
+// browser is offering — and restore it, or the stub decides the outcome of
+// whichever file runs next in the same worker.
+const originalClipboard = Object.getOwnPropertyDescriptor(
+  Navigator.prototype,
+  "clipboard",
+)
+
+const stubClipboard = (value: unknown) =>
+  Object.defineProperty(navigator, "clipboard", { value, configurable: true })
+
 beforeEach(() => {
   vi.clearAllMocks()
   select.mockResolvedValue({ data: [{ id: "row-1" }], error: null })
+})
+
+const originalExecCommand = Object.getOwnPropertyDescriptor(
+  Document.prototype,
+  "execCommand",
+)
+
+const restore = (
+  target: object,
+  property: string,
+  descriptor: PropertyDescriptor | undefined,
+) => {
+  delete (target as Record<string, unknown>)[property]
+  if (descriptor) Object.defineProperty(target, property, descriptor)
+}
+
+afterEach(() => {
+  restore(navigator, "clipboard", originalClipboard)
+  restore(document, "execCommand", originalExecCommand)
 })
 
 const row: TranslationReviewRow = {
@@ -501,6 +531,156 @@ describe("TranslationReviewCard decisions", () => {
 
     expect(onSkip).not.toHaveBeenCalled()
     expect(screen.getByRole("button", { name: /skip/i })).toBeDisabled()
+  })
+
+  it("puts the adjudication request on the clipboard", async () => {
+    const user = userEvent.setup()
+    // After `setup()`, which installs a clipboard stub of its own that would
+    // otherwise swallow the write.
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stubClipboard({ writeText })
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: /review assist/i }))
+    await user.click(screen.getByRole("button", { name: /copy the request/i }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    const request: string = writeText.mock.calls[0][0]
+    expect(request).toContain("Développé couché")
+    expect(request).toContain("Set your hands hip-width apart.")
+    expect(request).toContain("measurement-changed")
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  // An insecure context is where this screen is most likely to be used from a
+  // phone, and a copy button that does nothing there is a dead end. The text
+  // has to end up somewhere the reviewer can still select it.
+  it("hands the request over in a toast when the clipboard is unreachable", async () => {
+    const user = userEvent.setup()
+    stubClipboard(undefined)
+    Object.defineProperty(document, "execCommand", {
+      value: () => false,
+      configurable: true,
+    })
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: /review assist/i }))
+    await user.click(screen.getByRole("button", { name: /copy the request/i }))
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+    const [message, options] = toastError.mock.calls[0]
+    expect(message).toMatch(/clipboard/i)
+    expect(options.description).toContain("Set your hands hip-width apart.")
+  })
+
+  // The end of the round trip, through the one write path T159 built: the
+  // payload has to carry all four sections, because a partial block fails the
+  // resolver's parity check and the row would render French while reading
+  // `approved`.
+  it("writes an approved correction through the same mutation as the buttons", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: /review assist/i }))
+    await user.click(screen.getByRole("textbox", { name: /corrected json/i }))
+    await user.paste(
+      JSON.stringify({
+        setup: ["Lie back on the bench.", "Set your hands shoulder-width apart."],
+        movement: ["Press the bar upward."],
+        breathing: ["Exhale as you press."],
+        common_mistakes: ["Arched lower back."],
+      }),
+    )
+    await user.click(screen.getByRole("button", { name: /check the correction/i }))
+    await user.click(screen.getByRole("button", { name: /approve this correction/i }))
+
+    await waitFor(() =>
+      expect(lastPayload().instructions_en).toEqual({
+        setup: ["Lie back on the bench.", "Set your hands shoulder-width apart."],
+        movement: ["Press the bar upward."],
+        breathing: ["Exhale as you press."],
+        common_mistakes: ["Arched lower back."],
+      }),
+    )
+    expect(lastPayload()).toMatchObject({ instructions_en_status: "approved" })
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  // The T159 defect wearing a different hat. Radix portals the dialog out of
+  // this card's DOM, but a React portal still propagates events up the React
+  // tree, so every keystroke in the dialog reaches the card's handler.
+  //
+  // The keys are pressed with focus wherever the dialog put it — a button, not
+  // a textbox — because that is the hole the existing typing-target check does
+  // not cover: `A` on the copy button would approve the row from inside a
+  // dialog the reviewer opened to read.
+  it("answers no shortcut while the assist dialog is open", async () => {
+    const user = userEvent.setup()
+    const onSkip = vi.fn()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={onSkip} />)
+
+    await user.click(screen.getByRole("button", { name: /review assist/i }))
+    await user.keyboard("ar{ArrowRight}")
+
+    expect(update).not.toHaveBeenCalled()
+    expect(onSkip).not.toHaveBeenCalled()
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+
+  // And the paste box itself, which is the same claim one layer in: the letters
+  // have to land in the text.
+  it("keeps a shortcut letter typed into the paste box as text", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: /review assist/i }))
+    await user.type(
+      screen.getByRole("textbox", { name: /corrected json/i }),
+      "a rack",
+    )
+
+    expect(update).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole("textbox", { name: /corrected json/i }),
+    ).toHaveValue("a rack")
+  })
+
+  // Opening the dialog to read is not a verdict, but a decided row has nothing
+  // left to adjudicate: it leaves the queue on the next refetch, and the write
+  // behind the dialog is gated anyway. Disabling it is the same argument T159
+  // made for the edit button — a correction that can no longer be submitted is
+  // an invitation to waste typing.
+  it("closes the assist off once a verdict has been issued", async () => {
+    select.mockReturnValue(new Promise(() => {}))
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.keyboard("a")
+
+    expect(screen.getByRole("button", { name: /review assist/i })).toBeDisabled()
+  })
+
+  // The refusal handling is inherited rather than reimplemented, and this is
+  // what says so: a second write path added later would pass every other test
+  // in this file and fail this one.
+  it("reports a refused correction as a refusal", async () => {
+    select.mockResolvedValue({ data: [], error: null })
+    const user = userEvent.setup()
+    renderWithProviders(<TranslationReviewCard row={row} onSkip={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: /review assist/i }))
+    await user.click(screen.getByRole("textbox", { name: /corrected json/i }))
+    await user.paste(JSON.stringify(row.instructions_en))
+    await user.click(screen.getByRole("button", { name: /check the correction/i }))
+    await user.click(screen.getByRole("button", { name: /approve this correction/i }))
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(expect.stringContaining("refused")),
+    )
+    expect(toastSuccess).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole("heading", { name: "Développé couché" }),
+    ).toBeInTheDocument()
   })
 
   it("skips from the button too", async () => {

--- a/src/components/admin/translations/TranslationReviewCard.tsx
+++ b/src/components/admin/translations/TranslationReviewCard.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
+import { ReviewAssistDialog } from "@/components/admin/translations/ReviewAssistDialog"
 import {
   TranslationWriteRefusedError,
   useApproveTranslation,
@@ -12,6 +13,7 @@ import {
 } from "@/hooks/useApproveTranslation"
 import { formatDate } from "@/lib/formatters"
 import {
+  SECTION_LABEL_KEYS,
   buildReviewSections,
   fromInstructionDraft,
   orphanObjections,
@@ -20,16 +22,8 @@ import {
   type ReviewLine,
   type ReviewObjection,
 } from "@/lib/translationReview"
-import type { InstructionSection } from "@/lib/instructionQuality"
 import type { ExerciseInstructions } from "@/types/database"
 import type { TranslationReviewRow } from "@/hooks/useTranslationReviewQueue"
-
-const SECTION_KEYS: Record<InstructionSection, string> = {
-  setup: "translations.sections.setup",
-  movement: "translations.sections.movement",
-  breathing: "translations.sections.breathing",
-  common_mistakes: "translations.sections.commonMistakes",
-}
 
 const STATUS_VARIANT: Record<string, "secondary" | "destructive" | "default"> = {
   clean: "secondary",
@@ -137,6 +131,15 @@ export function TranslationReviewCard({
    * database rejected, which leaves it genuinely undecided.
    */
   const [verdictIssued, setVerdictIssued] = useState(false)
+  /**
+   * Whether the assist dialog is up. Held here rather than inside the dialog
+   * because the card has to go deaf while it is: Radix portals the dialog out
+   * of this article's DOM subtree, but a React portal still propagates events
+   * through the React tree, so a keystroke in the paste box arrives at the
+   * handler below. That is the "typing bar approves the row" defect again, with
+   * a different textarea.
+   */
+  const [assistOpen, setAssistOpen] = useState(false)
 
   const isEditing = draft !== null
 
@@ -202,6 +205,17 @@ export function TranslationReviewCard({
   const revert = () => record("flagged")
 
   /**
+   * An adjudicated correction is a verdict like any other, so it goes through
+   * `record` — same gate, same toast, same refusal handling. The dialog closes
+   * first but keeps its pasted text, which is what a reviewer needs if the
+   * database refuses the write and they have to try again.
+   */
+  const applyCorrection = (instructionsEn: ExerciseInstructions) => {
+    setAssistOpen(false)
+    record("approved", instructionsEn)
+  }
+
+  /**
    * Skip never touches the mutation — it moves the page index — so it is the
    * one action the write gates by accident, not by design. Left ungated, a skip
    * issued after a verdict advances the index by one and the refetch then drops
@@ -239,6 +253,11 @@ export function TranslationReviewCard({
   }
 
   function handleKeyDown(event: React.KeyboardEvent) {
+    // The assist dialog silences every key including `Escape`, which Radix
+    // already answers by closing the dialog — handling it here as well would
+    // discard a pending edit the reviewer never asked to lose.
+    if (assistOpen) return
+
     // Edit mode silences the whole set, and deliberately not by relying on
     // focus: a reviewer can click the card background and a browser can restore
     // focus anywhere, and then typing the word "bar" approves the translation
@@ -343,7 +362,7 @@ export function TranslationReviewCard({
 
       {sections.map(({ section, lines }, index) => (
         <section key={section} className="flex flex-col gap-1">
-          <h3 className="text-sm font-semibold">{t(SECTION_KEYS[section])}</h3>
+          <h3 className="text-sm font-semibold">{t(SECTION_LABEL_KEYS[section])}</h3>
           <div className="grid gap-2 text-xs uppercase tracking-wide text-muted-foreground sm:grid-cols-2 sm:gap-4">
             <span>{t("translations.frenchHeading")}</span>
             <span>{t("translations.englishHeading")}</span>
@@ -362,7 +381,7 @@ export function TranslationReviewCard({
               ref={index === 0 ? firstEditorRef : undefined}
               value={draft[section]}
               aria-label={t("translations.editSection", {
-                section: t(SECTION_KEYS[section]),
+                section: t(SECTION_LABEL_KEYS[section]),
               })}
               onChange={(event) =>
                 setDraft((current) =>
@@ -409,6 +428,13 @@ export function TranslationReviewCard({
           {t("translations.revert")}
           <Shortcut>R</Shortcut>
         </Button>
+        <ReviewAssistDialog
+          subject={row}
+          open={assistOpen}
+          onOpenChange={setAssistOpen}
+          onApply={applyCorrection}
+          disabled={verdictIssued}
+        />
         <Button
           size="sm"
           variant="ghost"

--- a/src/components/admin/translations/TranslationReviewCard.tsx
+++ b/src/components/admin/translations/TranslationReviewCard.tsx
@@ -133,11 +133,21 @@ export function TranslationReviewCard({
   const [verdictIssued, setVerdictIssued] = useState(false)
   /**
    * Whether the assist dialog is up. Held here rather than inside the dialog
-   * because the card has to go deaf while it is: Radix portals the dialog out
-   * of this article's DOM subtree, but a React portal still propagates events
-   * through the React tree, so a keystroke in the paste box arrives at the
-   * handler below. That is the "typing bar approves the row" defect again, with
-   * a different textarea.
+   * for two reasons.
+   *
+   * The card has to go deaf while it is: Radix portals the dialog out of this
+   * article's DOM subtree, but a React portal still propagates events through
+   * the React tree, so a keystroke in the paste box arrives at the handler
+   * below. That is the "typing bar approves the row" defect again, with a
+   * different textarea.
+   *
+   * And the dialog closes on a successful write and on the reviewer dismissing
+   * it, never on submitting. An adjudicated correction lives in the dialog and
+   * nowhere else, so closing it on submit would put the reviewer in front of a
+   * card that no longer holds what they approved — one keystroke from approving
+   * the machine English they had just adjudicated against, if the write failed.
+   * The correction and the diff share a lifetime, which is what lets `approve`
+   * mean one thing.
    */
   const [assistOpen, setAssistOpen] = useState(false)
 
@@ -179,10 +189,13 @@ export function TranslationReviewCard({
         ...(instructionsEn ? { instructionsEn } : {}),
       },
       {
-        onSuccess: () =>
-          toast.success(
-            t(`translations.toast.${status}`, { name: row.name }),
-          ),
+        onSuccess: () => {
+          // The diff is dismissed by the write landing and by nothing else, so
+          // an adjudicated correction is never out of sight while it is still
+          // the thing an approval would submit.
+          setAssistOpen(false)
+          toast.success(t(`translations.toast.${status}`, { name: row.name }))
+        },
         onError: (error) => {
           // Nothing was written, so the row is still undecided and the reviewer
           // has to be able to try again from the card in front of them.
@@ -199,6 +212,12 @@ export function TranslationReviewCard({
     )
   }
 
+  /**
+   * Approve submits whatever this card is displaying: the draft when the
+   * editors are open, the stored English otherwise. That is the whole rule, and
+   * it is only true because no other proposed translation is allowed to outlive
+   * the surface showing it — see `applyCorrection` and the dialog's lifetime.
+   */
   const approve = () =>
     record("approved", draft ? fromInstructionDraft(draft) : undefined)
 
@@ -206,12 +225,15 @@ export function TranslationReviewCard({
 
   /**
    * An adjudicated correction is a verdict like any other, so it goes through
-   * `record` — same gate, same toast, same refusal handling. The dialog closes
-   * first but keeps its pasted text, which is what a reviewer needs if the
-   * database refuses the write and they have to try again.
+   * `record` — same gate, same toast, same refusal handling.
+   *
+   * It also supersedes any manual edit in progress. Two proposed translations
+   * cannot both be live: the reviewer who adjudicated has said which one they
+   * mean, and a draft left behind would be what `approve` submitted the next
+   * time it ran, under a status claiming a human had settled on it.
    */
   const applyCorrection = (instructionsEn: ExerciseInstructions) => {
-    setAssistOpen(false)
+    setDraft(null)
     record("approved", instructionsEn)
   }
 

--- a/src/lib/catalogLabels.test.ts
+++ b/src/lib/catalogLabels.test.ts
@@ -4,6 +4,7 @@ import source from "./catalogLabels.ts?raw"
 import { importsOf } from "@/test/imports"
 import {
   equipmentLabelKey,
+  filledInstructionSections,
   isEnglish,
   muscleLabelKey,
   resolveExerciseInstructions,
@@ -105,6 +106,30 @@ describe("resolveExerciseName", () => {
 
   it("treats a region-tagged English locale as English", () => {
     expect(resolveExerciseName(row(), "en-US")).toBe("Bench Press")
+  })
+})
+
+describe("filledInstructionSections", () => {
+  it("answers with the sections holding a non-blank step", () => {
+    const filled = filledInstructionSections({ ...ENGLISH, breathing: ["  "] })
+
+    expect([...filled]).toEqual(["setup", "movement", "common_mistakes"])
+  })
+
+  /**
+   * The set exists to be asked "does the English fill what the French fills",
+   * and both sides of that question are section keys. Widened to `string` it
+   * would answer `false` to a typo or a renamed key with a straight face, and
+   * the parity check reads a `false` as "the correction empties this section" —
+   * the exported callers get a compile error instead.
+   *
+   * This assertion is a type-level one: it fails `tsc -b`, not the runner.
+   */
+  it("cannot be asked about a string that is not a section", () => {
+    const filled = filledInstructionSections(ENGLISH)
+
+    // @ts-expect-error — "notes" is not a section of an instruction block.
+    expect(filled.has("notes")).toBe(false)
   })
 })
 

--- a/src/lib/catalogLabels.ts
+++ b/src/lib/catalogLabels.ts
@@ -87,10 +87,14 @@ const SECTIONS = [
  * empty a section the French fills. That guard is only worth anything if it
  * agrees with the resolver's own idea of "filled" — a second definition over
  * there could accept a block this one then renders as French.
+ *
+ * Narrow on the way out as well as in: a parity check that can be asked about
+ * any string will answer `false` to a misspelt or renamed one, and `false`
+ * there reads as "that section is empty".
  */
 export const filledInstructionSections = (
   block: ExerciseInstructions | null | undefined,
-): ReadonlySet<string> =>
+): ReadonlySet<keyof ExerciseInstructions> =>
   new Set(
     SECTIONS.filter((section) =>
       (block?.[section] ?? []).some((step) => clean(step)),

--- a/src/lib/catalogLabels.ts
+++ b/src/lib/catalogLabels.ts
@@ -80,8 +80,15 @@ const SECTIONS = [
   "common_mistakes",
 ] as const satisfies readonly (keyof ExerciseInstructions)[]
 
-/** Sections holding at least one step that isn't blank. */
-const filledSections = (
+/**
+ * Sections holding at least one step that isn't blank.
+ *
+ * Exported for the review screen, which refuses a pasted correction that would
+ * empty a section the French fills. That guard is only worth anything if it
+ * agrees with the resolver's own idea of "filled" — a second definition over
+ * there could accept a block this one then renders as French.
+ */
+export const filledInstructionSections = (
   block: ExerciseInstructions | null | undefined,
 ): ReadonlySet<string> =>
   new Set(
@@ -119,15 +126,15 @@ export function resolveExerciseInstructions(
       : null
 
   const french = source.instructions ?? null
-  const frenchSections = filledSections(french)
-  const englishSections = filledSections(candidate)
+  const frenchSections = filledInstructionSections(french)
+  const englishSections = filledInstructionSections(candidate)
   const hasParity = [...frenchSections].every((section) =>
     englishSections.has(section),
   )
 
   const resolved = candidate && hasParity ? candidate : french
 
-  return filledSections(resolved).size > 0 ? resolved : null
+  return filledInstructionSections(resolved).size > 0 ? resolved : null
 }
 
 const MUSCLES: ReadonlySet<string> = new Set(MUSCLE_TAXONOMY)

--- a/src/lib/clipboard.test.ts
+++ b/src/lib/clipboard.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+
+import { copyToClipboard } from "./clipboard"
+
+// Restored after every test: a leaked stub makes another file in the same
+// Vitest worker pass or fail depending on the order it ran in.
+const originalClipboard = Object.getOwnPropertyDescriptor(
+  Navigator.prototype,
+  "clipboard",
+)
+const originalExecCommand = Object.getOwnPropertyDescriptor(
+  Document.prototype,
+  "execCommand",
+)
+
+const restore = (
+  target: object,
+  property: string,
+  descriptor: PropertyDescriptor | undefined,
+) => {
+  delete (target as Record<string, unknown>)[property]
+  if (descriptor) Object.defineProperty(target, property, descriptor)
+}
+
+const stub = (target: object, property: string, value: unknown) =>
+  Object.defineProperty(target, property, { value, configurable: true })
+
+afterEach(() => {
+  restore(navigator, "clipboard", originalClipboard)
+  restore(document, "execCommand", originalExecCommand)
+})
+
+describe("copyToClipboard", () => {
+  it("writes through the clipboard API when the browser offers one", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stub(navigator, "clipboard", { writeText })
+
+    await expect(copyToClipboard("the request")).resolves.toBe(true)
+    expect(writeText).toHaveBeenCalledWith("the request")
+  })
+
+  // An insecure context — the app opened over the LAN on a phone — either hides
+  // the API entirely or exposes it and rejects. Both have to reach the legacy
+  // path, or the reviewer's only way to move the text is to select it by hand.
+  it.each([
+    ["there is no clipboard API", undefined],
+    ["the clipboard API refuses", { writeText: () => Promise.reject(new Error("denied")) }],
+  ])("falls back to the legacy copy when %s", async (_case, clipboard) => {
+    stub(navigator, "clipboard", clipboard)
+    const execCommand = vi.fn().mockReturnValue(true)
+    stub(document, "execCommand", execCommand)
+
+    await expect(copyToClipboard("the request")).resolves.toBe(true)
+    expect(execCommand).toHaveBeenCalledWith("copy")
+  })
+
+  it("reports failure when both paths refuse", async () => {
+    stub(navigator, "clipboard", undefined)
+    stub(document, "execCommand", () => false)
+
+    await expect(copyToClipboard("the request")).resolves.toBe(false)
+  })
+
+  // The carrier is appended to the body, so a leak is one hidden node per
+  // attempt — invisible until a reviewer has pressed the button forty times.
+  it("leaves no carrier behind, even when the legacy copy throws", async () => {
+    stub(navigator, "clipboard", undefined)
+    stub(document, "execCommand", () => {
+      throw new Error("not supported")
+    })
+
+    await expect(copyToClipboard("the request")).resolves.toBe(false)
+    expect(document.querySelectorAll("textarea")).toHaveLength(0)
+  })
+})

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,37 @@
+/**
+ * Copying text out of the app, with the fallbacks a PWA actually needs.
+ *
+ * `navigator.clipboard` is undefined outside a secure context and can reject on
+ * a denied permission, and neither is rare on a phone opened over the LAN. The
+ * legacy `execCommand` path is the only thing that still works there.
+ *
+ * Extracted from `ErrorFallback`, which had the only copy of it, so the review
+ * screen does not become the second.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    // Denied, or an insecure context that exposes the API but refuses it.
+  }
+
+  const carrier = document.createElement("textarea")
+  carrier.value = text
+  carrier.setAttribute("readonly", "")
+  carrier.style.position = "fixed"
+  carrier.style.opacity = "0"
+  document.body.appendChild(carrier)
+  try {
+    carrier.select()
+    return document.execCommand("copy")
+  } catch {
+    return false
+  } finally {
+    // Even when select() or execCommand throw: a hidden node left in the DOM
+    // would accumulate one per attempt.
+    carrier.remove()
+  }
+}

--- a/src/lib/instructionPrompt.ts
+++ b/src/lib/instructionPrompt.ts
@@ -124,24 +124,56 @@ ${JSON.stringify(subject.instructions, null, 2)}`
 }
 
 /**
- * The JSON object buried in a model answer, or `undefined` when there is none.
- * Models wrap their block in prose or in a fence often enough that refusing
- * would throw away good translations.
- *
- * Exported because the review screen has to tell "that is not JSON" from "that
- * is JSON of the wrong shape" to say anything useful to the reviewer, and a
- * second extraction over there would be a second opinion on what counts as an
- * answer at all.
+ * Boxed, so that a model answering `null` is distinguishable from a model
+ * answering something no parser can read. The review screen turns exactly that
+ * distinction into two different sentences for the reviewer.
  */
-export function extractJsonObject(raw: string | null | undefined): unknown {
-  if (typeof raw !== "string") return undefined
-  const match = raw.match(/\{[\s\S]*\}/)
-  if (!match) return undefined
+interface JsonValue {
+  value: unknown
+}
+
+const parsedOrNothing = (text: string): JsonValue | undefined => {
   try {
-    return JSON.parse(match[0])
+    return { value: JSON.parse(text) }
   } catch {
     return undefined
   }
+}
+
+/**
+ * The structure inside a prose or fenced answer, greedily — first delimiter to
+ * last.
+ *
+ * A brace anywhere means the answer is an object answer, however broken, and
+ * the array *inside* a malformed object is not a second candidate: reading
+ * `["Lie back"]` out of `{"setup": ["Lie back"],}` would report a paste with a
+ * trailing comma as having parsed, and send the reviewer looking for the wrong
+ * mistake.
+ */
+const structureIn = (raw: string): string | undefined =>
+  raw.match(raw.includes("{") ? /\{[\s\S]*\}/ : /\[[\s\S]*\]/)?.[0]
+
+/**
+ * The JSON value buried in a model answer, or `undefined` when nothing in it
+ * parses. Models wrap their block in prose or in a fence often enough that
+ * refusing would throw away good translations, so the whole text is tried
+ * first and then the structures inside it.
+ *
+ * Deliberately says nothing about *shape* — an array, a number and a bare
+ * string are all values it finds. Exported because the review screen has to
+ * tell "I could not parse this" from "I parsed it and it is not an instruction
+ * block" to say anything useful, and a second extractor over there would be a
+ * second opinion on what counts as an answer at all.
+ */
+export function extractJsonValue(
+  raw: string | null | undefined,
+): JsonValue | undefined {
+  if (typeof raw !== "string") return undefined
+
+  return [raw.trim(), structureIn(raw)]
+    .flatMap((text) => text ?? [])
+    .map(parsedOrNothing)
+    .find((found) => found !== undefined)
 }
 
 const isStringArray = (value: unknown): value is string[] =>
@@ -169,7 +201,8 @@ const sentencesAt = (
 export function parseInstructions(
   raw: string | null | undefined,
 ): ExerciseInstructions | null {
-  const parsed = extractJsonObject(raw)
+  const found = extractJsonValue(raw)
+  const parsed = found?.value
   if (typeof parsed !== "object" || parsed === null) return null
 
   const sections = new Map<string, unknown>(Object.entries(parsed))

--- a/src/lib/instructionPrompt.ts
+++ b/src/lib/instructionPrompt.ts
@@ -36,6 +36,50 @@ export interface Prompt {
 }
 
 /**
+ * The rules that do not depend on which exercise is being translated.
+ *
+ * Extracted from `buildPrompt`'s system message, and quoted verbatim by the
+ * adjudication request the reviewer copies in `src/lib/reviewAssist.ts`. An
+ * arbiter working from paraphrased rules "corrects" faithful sentences — an
+ * imperative under `common_mistakes` reads like better English right up until
+ * you remember it orders the reader to commit the fault — so the two surfaces
+ * share the strings rather than each keeping their own copy.
+ *
+ * Editing any of these edits the translation prompt, and needs a
+ * `PROMPT_VERSION` bump. The clauses naming the exercise, its muscle and its
+ * equipment stay in `buildPrompt`: they are not house rules, they are the
+ * subject.
+ */
+export const HOUSE_RULES = {
+  meaning:
+    "Translate meaning, not words. The result must read like it was written by an English-speaking coach, not translated.",
+  structure:
+    "Preserve the structure EXACTLY: same keys, same number of items in each array, same order. One French sentence maps to one English sentence.",
+  detail:
+    'Preserve EVERY concrete detail: durations, angles, tempos, degrees, parenthetical anatomical notes. "1-2 secondes" stays "1-2 seconds"; "30-45°" stays "30-45°". Dropping a number is a failure.',
+  equipmentGlossary:
+    'The French source deliberately used French equipment words. Map them back: "haltère" → dumbbell, "barre" → barbell, "poulie" → pulley, "câble" → cable, "élastique" → band, "banc" → bench, "barre de traction" → pull-up bar, "barre EZ" → EZ bar.',
+  /** Lower-cased because both callers place it after a clause naming the subject. */
+  equipmentFidelity:
+    "do not introduce equipment the French source does not mention.",
+  incline: '"décliné" means declined and "incliné" means inclined. Never swap them.',
+  anatomy:
+    'Anatomy glossary, apply exactly. These two are distinct and must never be swapped: "épaules" → shoulders; "omoplates" → shoulder blades. Also: "hanches" → hips (note "largeur de hanches" is hip-width, NOT shoulder-width), "ischios" → hamstrings, "lombaires" → lower back, "gainage" → bracing or plank depending on context.',
+  secondPerson:
+    'Address the reader in the second person throughout, consistently: "your back", "your hips", never "the back" or "the hips". Do not switch register between sentences.',
+  commonMistakes:
+    'The "common_mistakes" entries NAME an error; they are not instructions. Each one MUST stay a noun phrase in English, normally a gerund. "Arrondir le dos pendant le tirage" → "Rounding your back during the pull", NEVER "Round your back during the pull". An imperative here tells the reader to commit the mistake, which is the opposite of the intent. This applies to every entry in that array without exception.',
+  casing:
+    "Write equipment and muscle names in normal lowercase sentence case, never Title Case, unless they are proper nouns (Smith machine, EZ bar).",
+  gymTerms:
+    "Keep standard gym terms as they already are in English (squat, curl, pull-up, deadlift, hip thrust, face pull, plank...).",
+  noInvention:
+    'Never introduce a number of reps or sets that the French does not state. Never start a sentence with "Repeat" or "Remember".',
+  fidelity:
+    "Do not add, remove, soften or improve any cue. If the French is wrong, translate it faithfully — correctness is reviewed separately.",
+} as const
+
+/**
  * The translation prompt, unchanged from the spike that measured Gemini 2.5
  * Flash at 29/30 clean rows over a seeded sample of 30. Every rule in it
  * answers a defect that was actually observed, so edits here need their own
@@ -54,19 +98,19 @@ export function buildPrompt(subject: PromptSubject): Prompt {
   const system = `You are an expert strength coach translating exercise coaching cues from French to English. You reply with valid JSON only, no commentary.
 
 Strict rules:
-- Translate meaning, not words. The result must read like it was written by an English-speaking coach, not translated.
-- Preserve the structure EXACTLY: same keys, same number of items in each array, same order. One French sentence maps to one English sentence.
-- Preserve EVERY concrete detail: durations, angles, tempos, degrees, parenthetical anatomical notes. "1-2 secondes" stays "1-2 seconds"; "30-45°" stays "30-45°". Dropping a number is a failure.
-- The French source deliberately used French equipment words. Map them back: "haltère" → dumbbell, "barre" → barbell, "poulie" → pulley, "câble" → cable, "élastique" → band, "banc" → bench, "barre de traction" → pull-up bar, "barre EZ" → EZ bar. This exercise's equipment is "${equipmentLabel}"; do not introduce equipment the French source does not mention.
-- "décliné" means declined and "incliné" means inclined. Never swap them.
-- Anatomy glossary, apply exactly. These two are distinct and must never be swapped: "épaules" → shoulders; "omoplates" → shoulder blades. Also: "hanches" → hips (note "largeur de hanches" is hip-width, NOT shoulder-width), "ischios" → hamstrings, "lombaires" → lower back, "gainage" → bracing or plank depending on context. The target muscle is "${muscleLabel}".
-- Address the reader in the second person throughout, consistently: "your back", "your hips", never "the back" or "the hips". Do not switch register between sentences.
-- The "common_mistakes" entries NAME an error; they are not instructions. Each one MUST stay a noun phrase in English, normally a gerund. "Arrondir le dos pendant le tirage" → "Rounding your back during the pull", NEVER "Round your back during the pull". An imperative here tells the reader to commit the mistake, which is the opposite of the intent. This applies to every entry in that array without exception.
-- Write equipment and muscle names in normal lowercase sentence case, never Title Case, unless they are proper nouns (Smith machine, EZ bar).
+- ${HOUSE_RULES.meaning}
+- ${HOUSE_RULES.structure}
+- ${HOUSE_RULES.detail}
+- ${HOUSE_RULES.equipmentGlossary} This exercise's equipment is "${equipmentLabel}"; ${HOUSE_RULES.equipmentFidelity}
+- ${HOUSE_RULES.incline}
+- ${HOUSE_RULES.anatomy} The target muscle is "${muscleLabel}".
+- ${HOUSE_RULES.secondPerson}
+- ${HOUSE_RULES.commonMistakes}
+- ${HOUSE_RULES.casing}
 - Refer to the exercise as "${subject.name_en ?? subject.name}" if you name it at all.
-- Keep standard gym terms as they already are in English (squat, curl, pull-up, deadlift, hip thrust, face pull, plank...).
-- Never introduce a number of reps or sets that the French does not state. Never start a sentence with "Repeat" or "Remember".
-- Do not add, remove, soften or improve any cue. If the French is wrong, translate it faithfully — correctness is reviewed separately.`
+- ${HOUSE_RULES.gymTerms}
+- ${HOUSE_RULES.noInvention}
+- ${HOUSE_RULES.fidelity}`
 
   const user = `Exercise: ${subject.name}${subject.name_en ? ` (${subject.name_en})` : ""}
 Muscle group: ${subject.muscle_group} (English: ${MUSCLE_LABELS[subject.muscle_group] ?? subject.muscle_group})
@@ -80,29 +124,63 @@ ${JSON.stringify(subject.instructions, null, 2)}`
 }
 
 /**
+ * The JSON object buried in a model answer, or `undefined` when there is none.
+ * Models wrap their block in prose or in a fence often enough that refusing
+ * would throw away good translations.
+ *
+ * Exported because the review screen has to tell "that is not JSON" from "that
+ * is JSON of the wrong shape" to say anything useful to the reviewer, and a
+ * second extraction over there would be a second opinion on what counts as an
+ * answer at all.
+ */
+export function extractJsonObject(raw: string | null | undefined): unknown {
+  if (typeof raw !== "string") return undefined
+  const match = raw.match(/\{[\s\S]*\}/)
+  if (!match) return undefined
+  try {
+    return JSON.parse(match[0])
+  } catch {
+    return undefined
+  }
+}
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string")
+
+/** One section's sentences, or `null` when that key is absent or not sentences. */
+const sentencesAt = (
+  parsed: ReadonlyMap<string, unknown>,
+  section: InstructionSection,
+): string[] | null => {
+  const value = parsed.get(section)
+  return isStringArray(value) ? value : null
+}
+
+/**
  * Reads a model response into an instruction block, or `null` when it cannot be
- * trusted. Tolerates prose around the JSON — models wrap it in prose or in a
- * fence often enough that refusing would throw away good translations — but not
- * a missing key or a non-string entry: a partial block must never reach the
- * database.
+ * trusted. A missing key, a section that is not an array, or an entry that is
+ * not a string all fail: a partial block must never reach the database.
+ *
+ * The four sections are read out one by one rather than mapped, for the same
+ * reason `fromInstructionDraft` writes them out: the result has all four keys
+ * and no others by construction, so a model that helpfully adds a `notes` field
+ * cannot get it written to the column.
  */
 export function parseInstructions(
   raw: string | null | undefined,
 ): ExerciseInstructions | null {
-  if (typeof raw !== "string") return null
-  const match = raw.match(/\{[\s\S]*\}/)
-  if (!match) return null
-  try {
-    const parsed = JSON.parse(match[0]) as ExerciseInstructions
-    const wellFormed = INSTRUCTION_SECTIONS.every(
-      (section) =>
-        Array.isArray(parsed[section]) &&
-        parsed[section].every((entry) => typeof entry === "string"),
-    )
-    return wellFormed ? parsed : null
-  } catch {
-    return null
-  }
+  const parsed = extractJsonObject(raw)
+  if (typeof parsed !== "object" || parsed === null) return null
+
+  const sections = new Map<string, unknown>(Object.entries(parsed))
+  const setup = sentencesAt(sections, "setup")
+  const movement = sentencesAt(sections, "movement")
+  const breathing = sentencesAt(sections, "breathing")
+  const commonMistakes = sentencesAt(sections, "common_mistakes")
+
+  return setup && movement && breathing && commonMistakes
+    ? { setup, movement, breathing, common_mistakes: commonMistakes }
+    : null
 }
 
 /** Sentence pairs the cross-checker is asked to rule on, in a stable order. */

--- a/src/lib/reviewAssist.test.ts
+++ b/src/lib/reviewAssist.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect } from "vitest"
+
+import source from "./reviewAssist.ts?raw"
+import { importsOf } from "@/test/imports"
+import {
+  buildReviewRequest,
+  diffCorrection,
+  readCorrection,
+  type ReviewSubject,
+} from "./reviewAssist"
+import { buildPrompt, type PromptSubject } from "@/lib/instructionPrompt"
+import type { ExerciseInstructions, TranslationAudit } from "@/types/database"
+
+const FRENCH: ExerciseInstructions = {
+  setup: [
+    "Allongez-vous sur le banc.",
+    "Écartez les mains à largeur d'épaules.",
+  ],
+  movement: ["Poussez la barre vers le haut."],
+  breathing: ["Expirez à la poussée."],
+  common_mistakes: ["Dos creusé."],
+}
+
+const ENGLISH: ExerciseInstructions = {
+  setup: ["Lie back on the bench.", "Set your hands hip-width apart."],
+  movement: ["Press the bar upward."],
+  breathing: ["Exhale as you press."],
+  common_mistakes: ["Arched lower back."],
+}
+
+const AUDIT: TranslationAudit = {
+  model: "gemini-2.5-flash",
+  prompt_version: 1,
+  translated_at: "2026-08-02T12:26:44.264Z",
+  checker_model: "llama-3.3-70b-versatile",
+  gate_flags: ["calques: lumbar"],
+  objections: [
+    {
+      section: "setup",
+      index: 1,
+      verdict: "measurement-changed",
+      note: "'largeur des épaules' rendered as 'hip-width'",
+    },
+  ],
+}
+
+/** The same movement, seen by the translation prompt, which needs two more columns. */
+const PROMPT_SUBJECT: PromptSubject = {
+  name: "Développé couché",
+  name_en: "Bench Press",
+  muscle_group: "Pectoraux",
+  equipment: "barbell",
+  instructions: FRENCH,
+}
+
+const makeSubject = (overrides: Partial<ReviewSubject> = {}): ReviewSubject => ({
+  name: "Développé couché",
+  name_en: "Bench Press",
+  instructions: FRENCH,
+  instructions_en: ENGLISH,
+  instructions_en_audit: null,
+  ...overrides,
+})
+
+describe("purity", () => {
+  it.each(["react", "i18next", "@/lib/supabase", "@supabase"])(
+    "does not import %s",
+    (module) => {
+      expect(importsOf(source, module)).toEqual([])
+    },
+  )
+})
+
+describe("buildReviewRequest", () => {
+  it("names the movement in both languages", () => {
+    const request = buildReviewRequest(makeSubject())
+
+    expect(request).toContain("Développé couché")
+    expect(request).toContain("Bench Press")
+  })
+
+  // The answer has to be realignable without guessing, so every sentence
+  // carries the address the audit already uses: section plus index.
+  it("numbers every sentence and pairs it with its French source", () => {
+    const request = buildReviewRequest(makeSubject())
+
+    expect(request).toContain(
+      "[setup 1]\n  FR: Écartez les mains à largeur d'épaules.\n  EN: Set your hands hip-width apart.",
+    )
+    expect(request).toContain(
+      "[common_mistakes 0]\n  FR: Dos creusé.\n  EN: Arched lower back.",
+    )
+  })
+
+  // A dropped sentence is the defect most worth adjudicating, so the pair is
+  // still emitted with the hole named rather than silently skipped — which is
+  // where this differs from the cross-check prompt, whose job is only to judge
+  // pairs that exist.
+  it("shows the hole when one side has no sentence at that index", () => {
+    const request = buildReviewRequest(
+      makeSubject({ instructions_en: { ...ENGLISH, setup: ENGLISH.setup.slice(0, 1) } }),
+    )
+
+    expect(request).toContain(
+      "[setup 1]\n  FR: Écartez les mains à largeur d'épaules.\n  EN: (missing)",
+    )
+  })
+
+  // The objection is what makes this an adjudication rather than a re-read, and
+  // it has to sit on the sentence it names — the same claim the card makes on
+  // screen, restated in text the arbiter reads top to bottom.
+  it("attaches the cross-checker's objection to the sentence it named", () => {
+    const request = buildReviewRequest(makeSubject({ instructions_en_audit: AUDIT }))
+
+    expect(request).toContain(
+      "[setup 1]\n  FR: Écartez les mains à largeur d'épaules.\n  EN: Set your hands hip-width apart.\n  OBJECTION (measurement-changed): 'largeur des épaules' rendered as 'hip-width'",
+    )
+    expect(request).not.toContain(
+      "[setup 0]\n  FR: Allongez-vous sur le banc.\n  EN: Lie back on the bench.\n  OBJECTION",
+    )
+  })
+
+  // An arbiter judging by different rules than the translator was given
+  // "corrects" faithful sentences: an imperative under common_mistakes reads
+  // like better English until you remember it tells the reader to commit the
+  // fault. So the request has to quote the rules, not paraphrase them — and
+  // asserting the same fragment on both sides is what fails if either drifts.
+  it.each([
+    "MUST stay a noun phrase in English",
+    "Address the reader in the second person throughout",
+    "Preserve EVERY concrete detail",
+    "do not introduce equipment the French source does not mention",
+    "Do not add, remove, soften or improve any cue",
+  ])("states the translation prompt's own rule: %s", (rule) => {
+    expect(buildReviewRequest(makeSubject())).toContain(rule)
+    expect(buildPrompt(PROMPT_SUBJECT).system).toContain(rule)
+  })
+
+  // "Tell me if this is right" comes back as prose the reviewer then applies by
+  // hand, which is the work the screen exists to remove. The request has to ask
+  // for something pasteable, in the shape the paste is validated against.
+  it("asks for the whole corrected block as JSON rather than for an opinion", () => {
+    const request = buildReviewRequest(makeSubject())
+
+    expect(request).toMatch(/Reply with the complete corrected block as JSON/)
+    expect(request).toContain("and nothing else")
+    expect(request).toContain('"common_mistakes": ["..."]')
+  })
+
+  // The queue can hand over a row with no English at all, or no audit: the
+  // request is still the fastest way to get one, so it must not throw.
+  it("builds for a row with no translation and no audit", () => {
+    const request = buildReviewRequest(
+      makeSubject({ name_en: null, instructions_en: null }),
+    )
+
+    expect(request).toContain("Exercise: Développé couché")
+    expect(request).not.toContain("(English:")
+    expect(request).toContain("[setup 0]\n  FR: Allongez-vous sur le banc.\n  EN: (missing)")
+  })
+})
+
+describe("readCorrection", () => {
+  it("reads a corrected block the assistant wrapped in prose and a fence", () => {
+    const corrected = {
+      ...ENGLISH,
+      setup: ["Lie back on the bench.", "Set your hands shoulder-width apart."],
+    }
+    const raw = `Sure — here is the corrected JSON:\n\`\`\`json\n${JSON.stringify(corrected)}\n\`\`\`\nLet me know if you want more.`
+
+    expect(readCorrection(raw, FRENCH)).toEqual({
+      ok: true,
+      instructions: corrected,
+    })
+  })
+
+  // Two different mistakes for the reviewer: one means "you did not copy the
+  // whole block", the other means "the assistant answered something that is not
+  // an instruction block". Telling them apart is the difference between a
+  // message they can act on and one they can only stare at.
+  it.each([
+    ["a trailing comma", '{"setup": ["Lie back"],}'],
+    ["smart quotes around the keys", '{\u201Csetup\u201D: [\u201CLie back\u201D]}'],
+    ["a truncated answer", '{"setup": ["Lie back", "Set your'],
+    ["no JSON at all", "Yes, the translation looks fine to me."],
+  ])("refuses %s as unreadable", (_case, raw) => {
+    expect(readCorrection(raw, FRENCH)).toEqual({ ok: false, problem: "unreadable" })
+  })
+
+  // Well-formed JSON saying the wrong thing is the dangerous half: it looks
+  // like an answer. Every one of these would write a block the resolver reads
+  // as partial, and the row would render French under an `approved` status.
+  it.each([
+    ["a missing section", { ...ENGLISH, breathing: undefined }],
+    ["a section renamed", { ...ENGLISH, breathing: undefined, breath: ENGLISH.breathing }],
+    ["a string where the array belongs", { ...ENGLISH, movement: "Press the bar upward." }],
+    ["a nested array", { ...ENGLISH, movement: [["Press the bar upward."]] }],
+    ["a number", { ...ENGLISH, movement: [90] }],
+    ["a null", { ...ENGLISH, movement: [null] }],
+    ["an object", { ...ENGLISH, movement: [{ text: "Press the bar upward." }] }],
+    ["a null section", { ...ENGLISH, movement: null }],
+  ])("refuses %s as the wrong shape", (_case, body) => {
+    expect(readCorrection(JSON.stringify(body), FRENCH)).toEqual({
+      ok: false,
+      problem: "shape",
+    })
+  })
+
+  // A field the assistant added is not a reason to make the reviewer go back
+  // and ask again — but it must not reach the column either, where nothing
+  // would ever read it and the next diff would show it as content.
+  it("drops a field the assistant invented rather than writing it", () => {
+    const raw = JSON.stringify({
+      ...ENGLISH,
+      notes: "I fixed the hip-width one.",
+      confidence: 0.9,
+    })
+
+    expect(readCorrection(raw, FRENCH)).toEqual({ ok: true, instructions: ENGLISH })
+  })
+
+  // Same repair the textarea editor makes: a blank entry would render as a
+  // bullet with nothing in it, and leading whitespace is an artefact of the
+  // assistant's formatting, not a correction anyone made.
+  it("trims each sentence and drops the blank ones", () => {
+    const raw = JSON.stringify({
+      ...ENGLISH,
+      movement: ["  Press the bar upward.  ", "", "   "],
+    })
+
+    expect(readCorrection(raw, FRENCH)).toEqual({
+      ok: true,
+      instructions: { ...ENGLISH, movement: ["Press the bar upward."] },
+    })
+  })
+
+  // The failure the whole ticket is guarding against. Every key is present and
+  // every entry is a string, so the shape validator is satisfied — but the
+  // resolver requires a section the French fills to be filled in English, and a
+  // row written like this reads `approved` while rendering French. Nothing
+  // downstream would ever say so.
+  it("refuses a correction that empties a section the French fills", () => {
+    const raw = JSON.stringify({ ...ENGLISH, breathing: [], common_mistakes: [""] })
+
+    expect(readCorrection(raw, FRENCH)).toEqual({
+      ok: false,
+      problem: "blanked",
+      sections: ["breathing", "common_mistakes"],
+    })
+  })
+
+  // Parity runs one way only, exactly as the resolver checks it: a French
+  // section nobody wrote does not oblige the English to invent one.
+  it("accepts an empty section when the French has nothing there either", () => {
+    const french = { ...FRENCH, breathing: [] }
+    const raw = JSON.stringify({ ...ENGLISH, breathing: [] })
+
+    expect(readCorrection(raw, french)).toEqual({
+      ok: true,
+      instructions: { ...ENGLISH, breathing: [] },
+    })
+  })
+
+  it("refuses a block with nothing left in it at all", () => {
+    const raw = JSON.stringify({
+      setup: [],
+      movement: [],
+      breathing: [],
+      common_mistakes: [],
+    })
+
+    expect(readCorrection(raw, null)).toEqual({ ok: false, problem: "empty" })
+  })
+})
+
+describe("diffCorrection", () => {
+  it("says which sentence changed, and to what", () => {
+    const proposed = {
+      ...ENGLISH,
+      setup: ["Lie back on the bench.", "Set your hands shoulder-width apart."],
+    }
+
+    expect(diffCorrection(ENGLISH, proposed)).toContainEqual({
+      section: "setup",
+      lines: [
+        {
+          index: 0,
+          before: "Lie back on the bench.",
+          after: "Lie back on the bench.",
+          status: "unchanged",
+        },
+        {
+          index: 1,
+          before: "Set your hands hip-width apart.",
+          after: "Set your hands shoulder-width apart.",
+          status: "changed",
+        },
+      ],
+    })
+  })
+
+  // A correction that splits or merges a sentence changes the count, and that
+  // is the one thing the reviewer most needs to see before writing: the count
+  // is what the objections are addressed by.
+  it("marks a sentence the correction adds and one it drops", () => {
+    const proposed = {
+      ...ENGLISH,
+      movement: ["Press the bar upward.", "Lock your elbows out."],
+      common_mistakes: [],
+    }
+
+    const lines = (section: string) =>
+      diffCorrection(ENGLISH, proposed).find((entry) => entry.section === section)
+        ?.lines
+
+    expect(lines("movement")).toContainEqual({
+      index: 1,
+      before: null,
+      after: "Lock your elbows out.",
+      status: "added",
+    })
+    expect(lines("common_mistakes")).toContainEqual({
+      index: 0,
+      before: "Arched lower back.",
+      after: null,
+      status: "removed",
+    })
+  })
+
+  // No phantom changes: a reviewer who is shown a highlighted line that is not
+  // actually a change learns to stop reading the highlights, and the diff is
+  // the only thing standing between a bad paste and the catalogue.
+  it("reports no change at all when the correction is the current text", () => {
+    const diff = diffCorrection(ENGLISH, ENGLISH)
+
+    expect(
+      diff.flatMap(({ lines }) => lines).every(({ status }) => status === "unchanged"),
+    ).toBe(true)
+  })
+})

--- a/src/lib/reviewAssist.test.ts
+++ b/src/lib/reviewAssist.test.ts
@@ -178,13 +178,35 @@ describe("readCorrection", () => {
   // whole block", the other means "the assistant answered something that is not
   // an instruction block". Telling them apart is the difference between a
   // message they can act on and one they can only stare at.
+  //
+  // The trailing comma is the awkward one: `["Lie back"]` inside it is perfectly
+  // good JSON on its own, and an extractor that goes looking for any parseable
+  // structure finds it and reports a syntax error as a shape problem.
   it.each([
     ["a trailing comma", '{"setup": ["Lie back"],}'],
     ["smart quotes around the keys", '{\u201Csetup\u201D: [\u201CLie back\u201D]}'],
     ["a truncated answer", '{"setup": ["Lie back", "Set your'],
     ["no JSON at all", "Yes, the translation looks fine to me."],
+    ["an unterminated array", '["Lie back on the bench.", "Set your'],
   ])("refuses %s as unreadable", (_case, raw) => {
     expect(readCorrection(raw, FRENCH)).toEqual({ ok: false, problem: "unreadable" })
+  })
+
+  // The line between the two refusals is `JSON.parse`, and nothing else. A
+  // reviewer told "that is not valid JSON" about something that demonstrably
+  // is goes looking for a syntax error that does not exist; every one of these
+  // parsed fine and simply is not an instruction block, which is a different
+  // sentence and a different next move.
+  it.each([
+    ["a bare array of sentences", '["Lie back on the bench.", "Press upward."]'],
+    ["an array of blocks", '[{"setup": [], "movement": []}]'],
+    ["a fenced array", '```json\n["Lie back on the bench."]\n```'],
+    ["a bare string", '"The translation looks fine to me."'],
+    ["a number", "42"],
+    ["a boolean", "true"],
+    ["a literal null", "null"],
+  ])("refuses %s as the wrong shape, not as unreadable", (_case, raw) => {
+    expect(readCorrection(raw, FRENCH)).toEqual({ ok: false, problem: "shape" })
   })
 
   // Well-formed JSON saying the wrong thing is the dangerous half: it looks

--- a/src/lib/reviewAssist.ts
+++ b/src/lib/reviewAssist.ts
@@ -1,0 +1,262 @@
+/**
+ * The clipboard round trip of the translation review screen (#417, T160).
+ *
+ * Pure by construction — no React, no i18next, no Supabase — so the payload the
+ * reviewer pastes into an assistant and the answer they paste back are both
+ * testable without rendering anything.
+ */
+import {
+  HOUSE_RULES,
+  extractJsonObject,
+  parseInstructions,
+} from "@/lib/instructionPrompt"
+import { filledInstructionSections } from "@/lib/catalogLabels"
+import {
+  INSTRUCTION_SECTIONS,
+  type InstructionSection,
+} from "@/lib/instructionQuality"
+import { buildReviewSections } from "@/lib/translationReview"
+import type { ExerciseInstructions, TranslationAudit } from "@/types/database"
+
+/**
+ * The columns of a queue row the round trip reads. Declared here rather than
+ * imported from the queue hook so this module stays a leaf: a lib that reaches
+ * up into a hook for a type is a lib that will eventually reach up for a value.
+ */
+export interface ReviewSubject {
+  name: string
+  name_en: string | null
+  instructions: ExerciseInstructions | null
+  instructions_en: ExerciseInstructions | null
+  instructions_en_audit: TranslationAudit | null
+}
+
+/** What a side reads as when it has no sentence at that index. */
+const MISSING = "(missing)"
+
+/**
+ * The pairs, addressed exactly the way the audit addresses them.
+ *
+ * Aligned by `buildReviewSections`, which is what the card renders from too, so
+ * the numbering the arbiter answers against is the numbering the reviewer is
+ * looking at — one alignment, not two that can disagree.
+ */
+const pairsOf = (subject: ReviewSubject): string =>
+  buildReviewSections(
+    subject.instructions,
+    subject.instructions_en,
+    subject.instructions_en_audit?.objections ?? [],
+  )
+    .map(({ section, lines }) =>
+      lines
+        .map(({ index, fr, en, objections }) =>
+          [
+            `[${section} ${index}]`,
+            `  FR: ${fr ?? MISSING}`,
+            `  EN: ${en ?? MISSING}`,
+            ...objections.map(
+              ({ verdict, note }) =>
+                `  OBJECTION (${verdict})${note ? `: ${note}` : ""}`,
+            ),
+          ].join("\n"),
+        )
+        .join("\n"),
+    )
+    .join("\n")
+
+/**
+ * The rules the translation was produced under, quoted from the prompt itself.
+ *
+ * The equipment clause loses the sentence naming this exercise's equipment: the
+ * review queue projects eight columns and `equipment` is not one of them, and
+ * the fidelity half — the half that matters to an arbiter — is the source's own
+ * mentions anyway.
+ */
+const HOUSE_RULE_LINES: readonly string[] = [
+  HOUSE_RULES.meaning,
+  HOUSE_RULES.structure,
+  HOUSE_RULES.detail,
+  `${HOUSE_RULES.equipmentGlossary} Take the equipment from the French sentence itself, and ${HOUSE_RULES.equipmentFidelity}`,
+  HOUSE_RULES.incline,
+  HOUSE_RULES.anatomy,
+  HOUSE_RULES.secondPerson,
+  HOUSE_RULES.commonMistakes,
+  HOUSE_RULES.casing,
+  HOUSE_RULES.gymTerms,
+  HOUSE_RULES.noInvention,
+  HOUSE_RULES.fidelity,
+]
+
+/**
+ * Asking for a correction, not an opinion.
+ *
+ * "Tell me whether this is right" comes back as prose the reviewer then has to
+ * apply by hand, which is the work this whole screen exists to remove. Asking
+ * for the corrected block means the answer is pasteable, and the shape is
+ * spelled out because the paste is validated on exactly that shape.
+ */
+const REPLY_INSTRUCTION = `Correct the English above where it breaks one of the house rules or says something the French does not, and leave it alone everywhere else. Judge only the English: the French source is out of scope, even where it is wrong.
+
+Reply with the complete corrected block as JSON — all four keys, every sentence, including the ones you did not change — and nothing else:
+
+{
+  "setup": ["..."],
+  "movement": ["..."],
+  "breathing": ["..."],
+  "common_mistakes": ["..."]
+}`
+
+export function buildReviewRequest(subject: ReviewSubject): string {
+  return `Exercise: ${subject.name}${
+    subject.name_en ? ` (English: ${subject.name_en})` : ""
+  }
+
+You are a bilingual French/English strength-coaching editor. Below is a French coaching text and its machine translation into English, sentence by sentence, with the objections a second model raised against it.
+
+## House rules the translation was produced under
+
+${HOUSE_RULE_LINES.map((rule) => `- ${rule}`).join("\n")}
+
+## Sentence pairs
+
+${pairsOf(subject)}
+
+## What to reply
+
+${REPLY_INSTRUCTION}`
+}
+
+/**
+ * Four refusals rather than one, because the reviewer's next move differs for
+ * each: `unreadable` means the answer never made it onto the clipboard whole,
+ * `shape` means the assistant replied with something that is not an instruction
+ * block, `blanked` means it dropped a section the French fills, and `empty`
+ * means it dropped all of them.
+ */
+export type CorrectionResult =
+  | { ok: true; instructions: ExerciseInstructions }
+  | { ok: false; problem: "unreadable" | "shape" | "empty" }
+  | { ok: false; problem: "blanked"; sections: InstructionSection[] }
+
+const trimmed = (sentences: readonly string[]): string[] =>
+  sentences.map((sentence) => sentence.trim()).filter((sentence) => sentence !== "")
+
+/**
+ * The same repair the textarea editor makes on its way out: surrounding
+ * whitespace is the assistant's formatting rather than anyone's correction, and
+ * an empty entry renders as a bullet with nothing in it.
+ *
+ * Written out section by section, like `fromInstructionDraft`, so the result
+ * cannot lose a key on the way through.
+ */
+const tidied = (block: ExerciseInstructions): ExerciseInstructions => ({
+  setup: trimmed(block.setup),
+  movement: trimmed(block.movement),
+  breathing: trimmed(block.breathing),
+  common_mistakes: trimmed(block.common_mistakes),
+})
+
+/**
+ * The sections a block fills, in the four-section order, using the resolver's
+ * own definition of "filled".
+ */
+const sectionsFilledBy = (
+  block: ExerciseInstructions | null | undefined,
+): InstructionSection[] => {
+  const filled = filledInstructionSections(block)
+  return INSTRUCTION_SECTIONS.filter((section) => filled.has(section))
+}
+
+/**
+ * Reads a pasted answer into an instruction block, or says why it will not.
+ *
+ * The well-formedness verdict is `parseInstructions`' and nothing else's — the
+ * same function the backfill script trusts, so "well formed" means the same
+ * thing at both ends of the pipeline. `extractJsonObject` is consulted only
+ * once that verdict is already "no", and only to choose the wording.
+ *
+ * Well formed is not sufficient, though. `resolveExerciseInstructions` renders
+ * the English only when every section the French fills is filled in English
+ * too, and it makes that decision silently: a correction that drops a section
+ * would be written under an `approved` status and then read back as French,
+ * with nothing anywhere saying why. So the French is checked against the
+ * correction here, before the reviewer is ever offered the write.
+ */
+export function readCorrection(
+  raw: string,
+  french: ExerciseInstructions | null | undefined,
+): CorrectionResult {
+  const parsed = parseInstructions(raw)
+  if (!parsed) {
+    return {
+      ok: false,
+      problem: extractJsonObject(raw) === undefined ? "unreadable" : "shape",
+    }
+  }
+
+  const instructions = tidied(parsed)
+  const filled = new Set(sectionsFilledBy(instructions))
+  if (filled.size === 0) return { ok: false, problem: "empty" }
+
+  const blanked = sectionsFilledBy(french).filter(
+    (section) => !filled.has(section),
+  )
+
+  return blanked.length > 0
+    ? { ok: false, problem: "blanked", sections: blanked }
+    : { ok: true, instructions }
+}
+
+export type DiffStatus = "unchanged" | "changed" | "added" | "removed"
+
+export interface DiffLine {
+  index: number
+  /** `null` when the correction adds a sentence at this position. */
+  before: string | null
+  /** `null` when the correction drops it. */
+  after: string | null
+  status: DiffStatus
+}
+
+export interface DiffSection {
+  section: InstructionSection
+  lines: DiffLine[]
+}
+
+const statusOf = (before: string | null, after: string | null): DiffStatus => {
+  if (before === null) return "added"
+  if (after === null) return "removed"
+  return before === after ? "unchanged" : "changed"
+}
+
+/**
+ * What the write would change, sentence by sentence, before it is offered.
+ *
+ * Aligned by index rather than by a longest-common-subsequence: the request
+ * asks for one English sentence per French sentence in the same order, so the
+ * index *is* the identity of a sentence throughout this epic — the objections
+ * in the audit address sentences that way too. A subsequence diff would find a
+ * plausible mapping for a correction that broke that contract, and present an
+ * insertion as a rewrite; index alignment shows the break for what it is.
+ */
+export function diffCorrection(
+  current: ExerciseInstructions | null | undefined,
+  proposed: ExerciseInstructions,
+): DiffSection[] {
+  return INSTRUCTION_SECTIONS.map((section) => {
+    const before = current?.[section] ?? []
+    const after = proposed[section]
+
+    return {
+      section,
+      lines: Array.from(
+        { length: Math.max(before.length, after.length) },
+        (_, index): DiffLine => {
+          const from = before[index] ?? null
+          const to = after[index] ?? null
+          return { index, before: from, after: to, status: statusOf(from, to) }
+        },
+      ),
+    }
+  })
+}

--- a/src/lib/reviewAssist.ts
+++ b/src/lib/reviewAssist.ts
@@ -7,7 +7,7 @@
  */
 import {
   HOUSE_RULES,
-  extractJsonObject,
+  extractJsonValue,
   parseInstructions,
 } from "@/lib/instructionPrompt"
 import { filledInstructionSections } from "@/lib/catalogLabels"
@@ -172,8 +172,11 @@ const sectionsFilledBy = (
  *
  * The well-formedness verdict is `parseInstructions`' and nothing else's — the
  * same function the backfill script trusts, so "well formed" means the same
- * thing at both ends of the pipeline. `extractJsonObject` is consulted only
- * once that verdict is already "no", and only to choose the wording.
+ * thing at both ends of the pipeline. `extractJsonValue` is consulted only once
+ * that verdict is already "no", and only to choose the wording: anything a
+ * parser accepts is a `shape` refusal, however far from an instruction block it
+ * lands. Telling a reviewer their array is "not valid JSON" sends them hunting
+ * for a syntax error that is not there.
  *
  * Well formed is not sufficient, though. `resolveExerciseInstructions` renders
  * the English only when every section the French fills is filled in English
@@ -190,7 +193,7 @@ export function readCorrection(
   if (!parsed) {
     return {
       ok: false,
-      problem: extractJsonObject(raw) === undefined ? "unreadable" : "shape",
+      problem: extractJsonValue(raw) === undefined ? "unreadable" : "shape",
     }
   }
 

--- a/src/lib/translationReview.ts
+++ b/src/lib/translationReview.ts
@@ -18,6 +18,18 @@ import type {
 
 export type ReviewObjection = TranslationAudit["objections"][number]
 
+/**
+ * i18n key per section, in the `admin` namespace. Here rather than in one of
+ * the two components that render section headings, so the review card and the
+ * assist dialog cannot end up naming the same section differently.
+ */
+export const SECTION_LABEL_KEYS: Record<InstructionSection, string> = {
+  setup: "translations.sections.setup",
+  movement: "translations.sections.movement",
+  breathing: "translations.sections.breathing",
+  common_mistakes: "translations.sections.commonMistakes",
+}
+
 export interface ReviewLine {
   /** Position inside the section — what an objection points at. */
   index: number

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -56,6 +56,30 @@
       "line": "Translated by {{model}} on {{date}} · cross-checked by {{checker}} · prompt v{{version}}",
       "checkerUnavailable": "no cross-checker"
     },
+    "assist": {
+      "open": "Review assist",
+      "title": "Adjudicate with an assistant",
+      "description": "Copy the request, hand it to an assistant, then paste its corrected JSON back here. Nothing is written until you have read the diff.",
+      "copy": "Copy the request",
+      "copied": "Adjudication request copied to the clipboard",
+      "copyFailed": "Could not reach the clipboard — copy the request from this message",
+      "pasteLabel": "Corrected JSON from the assistant",
+      "pastePlaceholder": "{ \"setup\": [...], \"movement\": [...], \"breathing\": [...], \"common_mistakes\": [...] }",
+      "check": "Check the correction",
+      "diffLabel": "What would change",
+      "apply": "Approve this correction",
+      "change": {
+        "changed": "Rewritten:",
+        "added": "Added:",
+        "removed": "Removed:"
+      },
+      "problem": {
+        "unreadable": "That is not valid JSON. Copy the assistant's whole reply, braces included, and paste it again.",
+        "shape": "That JSON is not an instruction block. It needs the four keys — setup, movement, breathing, common_mistakes — each holding a list of sentences. Ask the assistant to reply with the block and nothing else.",
+        "blanked": "That correction leaves {{sections}} empty while the French has sentences there. The exercise would be shown in French despite being approved — ask the assistant for the complete block.",
+        "empty": "That correction has no sentence left in it."
+      }
+    },
     "toast": {
       "approved": "{{name}} approved in English",
       "flagged": "{{name}} reverted to French",

--- a/src/locales/fr/admin.json
+++ b/src/locales/fr/admin.json
@@ -56,6 +56,30 @@
       "line": "Traduit par {{model}} le {{date}} · contre-relu par {{checker}} · prompt v{{version}}",
       "checkerUnavailable": "aucun contre-relecteur"
     },
+    "assist": {
+      "open": "Assistance à l'arbitrage",
+      "title": "Arbitrer avec un agent",
+      "description": "Copiez la demande, soumettez-la à un agent, puis recollez ici le JSON corrigé. Rien n'est écrit tant que vous n'avez pas lu le diff.",
+      "copy": "Copier la demande",
+      "copied": "Demande d'arbitrage copiée dans le presse-papier",
+      "copyFailed": "Presse-papier inaccessible — copiez la demande depuis ce message",
+      "pasteLabel": "JSON corrigé renvoyé par l'agent",
+      "pastePlaceholder": "{ \"setup\": [...], \"movement\": [...], \"breathing\": [...], \"common_mistakes\": [...] }",
+      "check": "Vérifier la correction",
+      "diffLabel": "Ce qui changerait",
+      "apply": "Approuver cette correction",
+      "change": {
+        "changed": "Réécrit :",
+        "added": "Ajouté :",
+        "removed": "Supprimé :"
+      },
+      "problem": {
+        "unreadable": "Ce n'est pas du JSON valide. Copiez toute la réponse de l'agent, accolades comprises, et recollez-la.",
+        "shape": "Ce JSON n'est pas un bloc d'instructions. Il lui faut les quatre clés — setup, movement, breathing, common_mistakes — contenant chacune une liste de phrases. Redemandez à l'agent le bloc et rien d'autre.",
+        "blanked": "Cette correction laisse {{sections}} vide alors que le français y a des phrases. L'exercice s'afficherait en français bien qu'approuvé — redemandez le bloc complet à l'agent.",
+        "empty": "Cette correction ne contient plus aucune phrase."
+      }
+    },
     "toast": {
       "approved": "{{name}} approuvé en anglais",
       "flagged": "{{name}} rendu au français",

--- a/src/test/instructionResolution.arch.test.ts
+++ b/src/test/instructionResolution.arch.test.ts
@@ -33,16 +33,19 @@ const code = (source: string) =>
 
 /**
  * The files that legitimately read the raw blocks. The first two edit or count
- * the *source* content in admin. The third is the translation review card,
- * which is the one screen whose job is to show both sides unresolved: running
- * it through the resolver would render a `flagged` row as French and hide the
- * very translation the reviewer was summoned to arbitrate.
+ * the *source* content in admin. The last two are the translation review
+ * screen, the one place whose job is to show both sides unresolved: running it
+ * through the resolver would render a `flagged` row as French and hide the very
+ * translation the reviewer was summoned to arbitrate. The assist dialog is on
+ * that screen for the same reason — it diffs the stored English against a
+ * proposed correction, and a resolved block would diff the French.
  *
  * Listed rather than pattern-matched so that adding one is a deliberate act.
  */
 const FRENCH_SOURCE_READERS = [
   "src/components/admin/exercise-form/transforms.ts",
   "src/components/admin/exercises-table/columns.tsx",
+  "src/components/admin/translations/ReviewAssistDialog.tsx",
   "src/components/admin/translations/TranslationReviewCard.tsx",
 ]
 


### PR DESCRIPTION
## What

- **Review assist** button on each translation review card. It builds an adjudication request — the exercise name in both languages, the house rules the translation was produced under quoted verbatim from the prompt, every sentence pair addressed `[section index]`, and the cross-checker's objections attached to the sentences they name — and copies it to the clipboard. If the clipboard is unreachable the request goes into a long-lived toast so it can still be selected by hand.
- A paste box for the corrected JSON that comes back, a **Check** step that validates it, an index-aligned **diff** of what the write would change, and an **Approve this correction** button that is the only thing that writes.
- Four distinct refusals with actionable messages, in `en` and `fr`: not JSON, not an instruction block, empties a section the French fills, empty altogether.

## Why

The expensive part of #417 is a human reading ~300 translations, not the machine producing them. This is the affordance that makes that reading faster: paste the request into an assistant, argue with it in that conversation, paste the corrected block back.

The round trip goes through the clipboard **deliberately** — no model key ships to the browser, per the tech plan — and the human stays the transport, which is also what keeps them in the loop.

## How

- `src/lib/reviewAssist.ts` is pure (a test asserts it imports no React, no i18next, no Supabase): `buildReviewRequest`, `readCorrection`, `diffCorrection`. It pairs sentences through `buildReviewSections`, the same alignment the card renders, so the numbering the arbiter answers against is the numbering on screen.
- The house rules are now `HOUSE_RULES` in `instructionPrompt.ts`, quoted by both the translation prompt and the request. An arbiter judging by paraphrased rules "corrects" faithful sentences — an imperative under `common_mistakes` reads like better English until you remember it orders the reader to commit the fault. `buildPrompt`'s output is unchanged, so no `PROMPT_VERSION` bump.
- **Validation.** Well-formedness is `parseInstructions`' verdict and nothing else's — the same function the backfill trusts. It now reads the four keys out one by one, so a `notes` field the assistant added is dropped rather than written. Accepted: prose and fences around the JSON, extra keys, untrimmed and blank entries (trimmed and dropped, as the textarea editor does). Rejected: anything `JSON.parse` refuses, a missing or renamed section, a non-array section, a non-string entry.
- On top of shape, a correction that would **empty a section the French fills** is refused by name. `resolveExerciseInstructions` requires section parity and falls back to French *silently*, so such a row would read `approved` and render French with nothing anywhere saying why. The check uses the resolver's own `filledInstructionSections`, now exported, rather than a second opinion on what "filled" means.
- **No second write path.** The dialog owns no mutation; it hands the accepted block to the card, which records it through the same `useApproveTranslation` call as the buttons — same `verdictIssued` gate, same `TranslationWriteRefusedError` toast. The assist button is disabled once a verdict is issued: opening it to read is not a verdict, but a decided row has nothing left to adjudicate.
- **Keyboard.** Radix portals the dialog out of the card's DOM but not out of its React tree, so keystrokes still reach the card's `onKeyDown`. The card goes deaf while the dialog is open — otherwise `A` on the copy button approves the row, which is the T159 "typing bar approved it" defect wearing a different hat. Two tests cover it, one with focus on a button and one in the paste box.

Part of #436 · epic #417 · ticket `docs/T160_—_Review_assist_clipboard_round-trip.md`

Made with [Cursor](https://cursor.com)