### PR TITLE
fix(ui): show Circuits in Library program detail

### DIFF
--- a/src/components/library/DayCard.test.tsx
+++ b/src/components/library/DayCard.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest"
 import { screen } from "@testing-library/react"
 import { renderWithProviders } from "@/test/utils"
-import { DayCard } from "./DayCard"
-import type { DayExercise } from "./DayCard"
+import { DayCard, type DayCardItem, type DayExercise } from "./DayCard"
+
+function asItems(exercises: DayExercise[]): DayCardItem[] {
+  return exercises.map((ex) => ({ kind: "solo" as const, ...ex }))
+}
 
 const EXERCISES: DayExercise[] = [
   { id: "ex-1", emoji: "💪", name: "Bench Press", sets: 3, reps: "8-12", restSeconds: 90, sortOrder: 0 },
@@ -11,33 +14,55 @@ const EXERCISES: DayExercise[] = [
 
 describe("DayCard", () => {
   it("renders day label", () => {
-    renderWithProviders(<DayCard label="Day 1 — Push" exerciseCount={2} exercises={EXERCISES} />)
+    renderWithProviders(
+      <DayCard label="Day 1 — Push" exerciseCount={2} items={asItems(EXERCISES)} />,
+    )
     expect(screen.getByText("Day 1 — Push")).toBeInTheDocument()
   })
 
   it("renders exercise count badge", () => {
-    renderWithProviders(<DayCard label="Day 1" exerciseCount={2} exercises={EXERCISES} />)
+    renderWithProviders(
+      <DayCard label="Day 1" exerciseCount={2} items={asItems(EXERCISES)} />,
+    )
     expect(screen.getByText("2 exercises")).toBeInTheDocument()
   })
 
   it("renders muscle focus when provided", () => {
-    renderWithProviders(<DayCard label="Day 1" exerciseCount={2} muscleFocus="Chest" exercises={EXERCISES} />)
+    renderWithProviders(
+      <DayCard
+        label="Day 1"
+        exerciseCount={2}
+        muscleFocus="Chest"
+        items={asItems(EXERCISES)}
+      />,
+    )
     expect(screen.getByText("Chest")).toBeInTheDocument()
   })
 
   it("does not render muscle focus when null", () => {
-    renderWithProviders(<DayCard label="Day 1" exerciseCount={2} muscleFocus={null} exercises={EXERCISES} />)
+    renderWithProviders(
+      <DayCard
+        label="Day 1"
+        exerciseCount={2}
+        muscleFocus={null}
+        items={asItems(EXERCISES)}
+      />,
+    )
     expect(screen.queryByText("Chest")).not.toBeInTheDocument()
   })
 
   it("renders exercise names with emojis", () => {
-    renderWithProviders(<DayCard label="Day 1" exerciseCount={2} exercises={EXERCISES} />)
+    renderWithProviders(
+      <DayCard label="Day 1" exerciseCount={2} items={asItems(EXERCISES)} />,
+    )
     expect(screen.getByText(/Bench Press/)).toBeInTheDocument()
     expect(screen.getByText(/Squat/)).toBeInTheDocument()
   })
 
   it("renders sets × reps and rest for each exercise", () => {
-    renderWithProviders(<DayCard label="Day 1" exerciseCount={2} exercises={EXERCISES} />)
+    renderWithProviders(
+      <DayCard label="Day 1" exerciseCount={2} items={asItems(EXERCISES)} />,
+    )
     expect(screen.getByText(/3 × 8-12/)).toBeInTheDocument()
     expect(screen.getByText(/90s rest/)).toBeInTheDocument()
     expect(screen.getByText(/4 × 6-8/)).toBeInTheDocument()
@@ -49,9 +74,46 @@ describe("DayCard", () => {
       { id: "ex-2", emoji: "🔥", name: "Squat", sets: 4, reps: "6-8", restSeconds: 120, sortOrder: 1 },
       { id: "ex-1", emoji: "💪", name: "Bench Press", sets: 3, reps: "8-12", restSeconds: 90, sortOrder: 0 },
     ]
-    renderWithProviders(<DayCard label="Day 1" exerciseCount={2} exercises={reversed} />)
+    renderWithProviders(
+      <DayCard label="Day 1" exerciseCount={2} items={asItems(reversed)} />,
+    )
     const items = screen.getAllByText(/Press|Squat/)
     expect(items[0].textContent).toContain("Bench Press")
     expect(items[1].textContent).toContain("Squat")
+  })
+
+  it("#454: renders Circuit summary lines and counts Circuit as one item", () => {
+    renderWithProviders(
+      <DayCard
+        label="🔥 Jour A"
+        exerciseCount={2}
+        items={[
+          {
+            kind: "solo",
+            id: "solo-1",
+            emoji: "🔥",
+            name: "Gainage planche",
+            sets: 3,
+            reps: "0",
+            restSeconds: 30,
+            sortOrder: 0,
+          },
+          {
+            kind: "circuit",
+            id: "block-1",
+            label: "Finisher",
+            rounds: 5,
+            exerciseCount: 3,
+            sortOrder: 1,
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText("2 exercises")).toBeInTheDocument()
+    expect(screen.getByTestId("day-card-circuit")).toBeInTheDocument()
+    expect(screen.getByText("Finisher")).toBeInTheDocument()
+    expect(screen.getByText(/3 exercises · 5 rounds/i)).toBeInTheDocument()
+    expect(screen.getByText(/Gainage planche/)).toBeInTheDocument()
   })
 })

--- a/src/components/library/DayCard.test.tsx
+++ b/src/components/library/DayCard.test.tsx
@@ -111,7 +111,7 @@ describe("DayCard", () => {
     )
 
     expect(screen.getByText("2 exercises")).toBeInTheDocument()
-    expect(screen.getByTestId("day-card-circuit")).toBeInTheDocument()
+    expect(screen.getByTestId("day-card-circuit-block-1")).toBeInTheDocument()
     expect(screen.getByText("Finisher")).toBeInTheDocument()
     expect(screen.getByText(/3 exercises · 5 rounds/i)).toBeInTheDocument()
     expect(screen.getByText(/Gainage planche/)).toBeInTheDocument()

--- a/src/components/library/DayCard.tsx
+++ b/src/components/library/DayCard.tsx
@@ -60,7 +60,7 @@ export function DayCard({ label, exerciseCount, muscleFocus, items }: DayCardPro
             <div
               key={item.id}
               className="flex items-center justify-between gap-2 text-sm"
-              data-testid="day-card-circuit"
+              data-testid={`day-card-circuit-${item.id}`}
             >
               <span className="flex min-w-0 items-center gap-1.5 truncate">
                 <Layers className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />

--- a/src/components/library/DayCard.tsx
+++ b/src/components/library/DayCard.tsx
@@ -1,7 +1,9 @@
 import { useTranslation } from "react-i18next"
+import { Layers } from "lucide-react"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 
+/** Solo line in a library day summary. */
 export interface DayExercise {
   id: string
   emoji: string
@@ -12,15 +14,30 @@ export interface DayExercise {
   sortOrder: number
 }
 
-interface DayCardProps {
-  label: string
+/** Circuit line in a library day summary (#454). */
+export interface DayCircuitSummary {
+  id: string
+  label: string | null
+  rounds: number
   exerciseCount: number
-  muscleFocus?: string | null
-  exercises: DayExercise[]
+  sortOrder: number
 }
 
-export function DayCard({ label, exerciseCount, muscleFocus, exercises }: DayCardProps) {
+export type DayCardItem =
+  | ({ kind: "solo" } & DayExercise)
+  | ({ kind: "circuit" } & DayCircuitSummary)
+
+interface DayCardProps {
+  label: string
+  /** Total Unified Day Sequence slots (solo + Circuit). */
+  exerciseCount: number
+  muscleFocus?: string | null
+  items: DayCardItem[]
+}
+
+export function DayCard({ label, exerciseCount, muscleFocus, items }: DayCardProps) {
   const { t } = useTranslation("library")
+  const ordered = [...items].sort((a, b) => a.sortOrder - b.sortOrder)
 
   return (
     <Card>
@@ -38,20 +55,39 @@ export function DayCard({ label, exerciseCount, muscleFocus, exercises }: DayCar
         )}
       </CardHeader>
       <CardContent className="flex flex-col gap-1.5 pt-0">
-        {[...exercises]
-          .sort((a, b) => a.sortOrder - b.sortOrder)
-          .map((ex) => (
-            <div key={ex.id} className="flex items-center justify-between text-sm">
-              <span className="truncate">
-                {ex.emoji} {ex.name}
+        {ordered.map((item) =>
+          item.kind === "circuit" ? (
+            <div
+              key={item.id}
+              className="flex items-center justify-between gap-2 text-sm"
+              data-testid="day-card-circuit"
+            >
+              <span className="flex min-w-0 items-center gap-1.5 truncate">
+                <Layers className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />
+                <span className="truncate">
+                  {item.label?.trim() || t("circuit.fallbackLabel")}
+                </span>
               </span>
               <span className="shrink-0 text-xs text-muted-foreground">
-                {t("setsReps", { sets: ex.sets, reps: ex.reps })}
-                {" · "}
-                {t("restSeconds", { seconds: ex.restSeconds })}
+                {t("circuit.summary", {
+                  count: item.exerciseCount,
+                  rounds: item.rounds,
+                })}
               </span>
             </div>
-          ))}
+          ) : (
+            <div key={item.id} className="flex items-center justify-between text-sm">
+              <span className="truncate">
+                {item.emoji} {item.name}
+              </span>
+              <span className="shrink-0 text-xs text-muted-foreground">
+                {t("setsReps", { sets: item.sets, reps: item.reps })}
+                {" · "}
+                {t("restSeconds", { seconds: item.restSeconds })}
+              </span>
+            </div>
+          ),
+        )}
       </CardContent>
     </Card>
   )

--- a/src/components/library/ProgramDetailSheet.test.tsx
+++ b/src/components/library/ProgramDetailSheet.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { screen, waitFor } from "@testing-library/react"
+import { renderWithProviders } from "@/test/utils"
+import { ProgramDetailSheet } from "./ProgramDetailSheet"
+import type { Program } from "@/types/onboarding"
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: vi.fn() },
+}))
+
+import { supabase } from "@/lib/supabase"
+
+const PROGRAM: Program = {
+  id: "prog-1",
+  name: "HIIT Bodyweight 2J",
+  created_at: "2026-08-04T10:00:00Z",
+  archived_at: null,
+  is_active: true,
+  user_id: "u1",
+  template_id: null,
+}
+
+function mockDaysQuery(days: unknown[]) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockResolvedValue({ data: days, error: null }),
+  }
+  vi.mocked(supabase.from).mockReturnValue(chain as never)
+  return chain
+}
+
+describe("ProgramDetailSheet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("#454: renders Circuits from exercise_blocks in program day cards", async () => {
+    mockDaysQuery([
+      {
+        id: "day-a",
+        emoji: "🔥",
+        label: "Jour A — Haut",
+        sort_order: 0,
+        workout_exercises: [
+          {
+            id: "we-1",
+            emoji_snapshot: "🔥",
+            name_snapshot: "Gainage planche",
+            sets: 3,
+            reps: "0",
+            rest_seconds: 30,
+            sort_order: 1,
+            exercise: null,
+          },
+        ],
+        exercise_blocks: [
+          {
+            id: "blk-1",
+            label: "Force Haut",
+            rounds: 4,
+            sort_order: 0,
+            rest_seconds: 90,
+            transition_seconds: 0,
+            workout_day_id: "day-a",
+            created_at: "",
+            exercises: [
+              {
+                id: "be-1",
+                position: 0,
+                exercise_id: "ex-1",
+                name_snapshot: "Pompes",
+                emoji_snapshot: "💪",
+                muscle_snapshot: "chest",
+                per_round: [],
+                block_id: "blk-1",
+                exercise: null,
+              },
+              {
+                id: "be-2",
+                position: 1,
+                exercise_id: "ex-2",
+                name_snapshot: "Row",
+                emoji_snapshot: "💪",
+                muscle_snapshot: "back",
+                per_round: [],
+                block_id: "blk-1",
+                exercise: null,
+              },
+            ],
+          },
+        ],
+      },
+    ])
+
+    renderWithProviders(
+      <ProgramDetailSheet
+        program={PROGRAM}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("Force Haut")).toBeInTheDocument()
+    })
+    expect(screen.getByTestId("day-card-circuit")).toBeInTheDocument()
+    expect(screen.getByText(/2 exercises · 4 rounds/i)).toBeInTheDocument()
+    expect(screen.getByText(/Gainage planche/)).toBeInTheDocument()
+    // Circuit + solo = 2 items on the day badge
+    expect(screen.getByText("2 exercises")).toBeInTheDocument()
+
+    const selectArg = vi.mocked(supabase.from).mock.results[0]?.value?.select
+      ?.mock?.calls?.[0]?.[0] as string | undefined
+    expect(selectArg).toContain("exercise_blocks")
+  })
+})

--- a/src/components/library/ProgramDetailSheet.test.tsx
+++ b/src/components/library/ProgramDetailSheet.test.tsx
@@ -104,7 +104,7 @@ describe("ProgramDetailSheet", () => {
     await waitFor(() => {
       expect(screen.getByText("Force Haut")).toBeInTheDocument()
     })
-    expect(screen.getByTestId("day-card-circuit")).toBeInTheDocument()
+    expect(screen.getByTestId("day-card-circuit-blk-1")).toBeInTheDocument()
     expect(screen.getByText(/2 exercises · 4 rounds/i)).toBeInTheDocument()
     expect(screen.getByText(/Gainage planche/)).toBeInTheDocument()
     // Circuit + solo = 2 items on the day badge

--- a/src/components/library/ProgramDetailSheet.tsx
+++ b/src/components/library/ProgramDetailSheet.tsx
@@ -11,22 +11,25 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/supabase"
 import { LABEL_EXERCISE_SELECT } from "@/lib/exerciseSelects"
-import { buildDayItems } from "@/lib/dayItems"
 import { DayCard, type DayCardItem } from "@/components/library/DayCard"
 import type { Program } from "@/types/onboarding"
 import type {
-  ExerciseBlockWithExercises,
-  ExerciseLabelFields,
   WorkoutDay,
-  WorkoutExercise,
-  WorkoutExerciseWithExercise,
+  WorkoutExerciseWithLabel,
 } from "@/types/database"
 
+/** Block shape from the LABEL-select embed — only summary fields are used. */
+type BlockSummaryRow = {
+  id: string
+  label: string | null
+  rounds: number
+  sort_order: number
+  exercises: Array<{ id: string; position: number }>
+}
+
 type DayWithSequence = WorkoutDay & {
-  workout_exercises: (WorkoutExercise & {
-    exercise: ExerciseLabelFields | null
-  })[]
-  exercise_blocks: ExerciseBlockWithExercises[] | null
+  workout_exercises: WorkoutExerciseWithLabel[]
+  exercise_blocks: BlockSummaryRow[] | null
 }
 
 interface ProgramDetailSheetProps {
@@ -37,32 +40,28 @@ interface ProgramDetailSheetProps {
 }
 
 function toDayCardItems(
-  exercises: WorkoutExerciseWithExercise[],
-  blocks: ExerciseBlockWithExercises[],
+  exercises: WorkoutExerciseWithLabel[],
+  blocks: BlockSummaryRow[],
 ): DayCardItem[] {
-  return buildDayItems(exercises, blocks).map((item): DayCardItem => {
-    if (item.kind === "solo") {
-      const ex = item.exercise
-      return {
-        kind: "solo",
-        id: ex.id,
-        emoji: ex.emoji_snapshot,
-        name: ex.name_snapshot,
-        sets: ex.sets,
-        reps: ex.reps,
-        restSeconds: ex.rest_seconds,
-        sortOrder: item.sort_order,
-      }
-    }
-    return {
-      kind: "circuit",
-      id: item.block.id,
-      label: item.block.label,
-      rounds: item.block.rounds,
-      exerciseCount: item.block.exercises.length,
-      sortOrder: item.sort_order,
-    }
-  })
+  const solos: DayCardItem[] = exercises.map((ex) => ({
+    kind: "solo",
+    id: ex.id,
+    emoji: ex.emoji_snapshot,
+    name: ex.name_snapshot,
+    sets: ex.sets,
+    reps: ex.reps,
+    restSeconds: ex.rest_seconds,
+    sortOrder: ex.sort_order,
+  }))
+  const circuits: DayCardItem[] = blocks.map((block) => ({
+    kind: "circuit",
+    id: block.id,
+    label: block.label,
+    rounds: block.rounds,
+    exerciseCount: block.exercises.length,
+    sortOrder: block.sort_order,
+  }))
+  return [...solos, ...circuits].sort((a, b) => a.sortOrder - b.sortOrder)
 }
 
 export function ProgramDetailSheet({ program, open, onOpenChange, onEdit }: ProgramDetailSheetProps) {
@@ -81,6 +80,8 @@ export function ProgramDetailSheet({ program, open, onOpenChange, onEdit }: Prog
         .order("sort_order")
 
       if (error) throw error
+      // Supabase client returns a loosely typed embed payload; DayWithSequence
+      // matches LABEL_EXERCISE_SELECT (WorkoutExerciseWithLabel), not full Exercise.
       return (data ?? []) as DayWithSequence[]
     },
   })
@@ -120,14 +121,11 @@ export function ProgramDetailSheet({ program, open, onOpenChange, onEdit }: Prog
             {(days ?? []).map((day) => {
               const blocks = (day.exercise_blocks ?? []).map((block) => ({
                 ...block,
-                exercises: [...(block.exercises ?? [])].sort(
+                exercises: [...block.exercises].sort(
                   (a, b) => a.position - b.position,
                 ),
               }))
-              const items = toDayCardItems(
-                day.workout_exercises as WorkoutExerciseWithExercise[],
-                blocks,
-              )
+              const items = toDayCardItems(day.workout_exercises, blocks)
               return (
                 <DayCard
                   key={day.id}

--- a/src/components/library/ProgramDetailSheet.tsx
+++ b/src/components/library/ProgramDetailSheet.tsx
@@ -11,18 +11,22 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/supabase"
 import { LABEL_EXERCISE_SELECT } from "@/lib/exerciseSelects"
-import { DayCard } from "@/components/library/DayCard"
+import { buildDayItems } from "@/lib/dayItems"
+import { DayCard, type DayCardItem } from "@/components/library/DayCard"
 import type { Program } from "@/types/onboarding"
 import type {
+  ExerciseBlockWithExercises,
   ExerciseLabelFields,
   WorkoutDay,
   WorkoutExercise,
+  WorkoutExerciseWithExercise,
 } from "@/types/database"
 
-type DayWithExercises = WorkoutDay & {
+type DayWithSequence = WorkoutDay & {
   workout_exercises: (WorkoutExercise & {
     exercise: ExerciseLabelFields | null
   })[]
+  exercise_blocks: ExerciseBlockWithExercises[] | null
 }
 
 interface ProgramDetailSheetProps {
@@ -32,23 +36,52 @@ interface ProgramDetailSheetProps {
   onEdit?: (programId: string) => void
 }
 
+function toDayCardItems(
+  exercises: WorkoutExerciseWithExercise[],
+  blocks: ExerciseBlockWithExercises[],
+): DayCardItem[] {
+  return buildDayItems(exercises, blocks).map((item): DayCardItem => {
+    if (item.kind === "solo") {
+      const ex = item.exercise
+      return {
+        kind: "solo",
+        id: ex.id,
+        emoji: ex.emoji_snapshot,
+        name: ex.name_snapshot,
+        sets: ex.sets,
+        reps: ex.reps,
+        restSeconds: ex.rest_seconds,
+        sortOrder: item.sort_order,
+      }
+    }
+    return {
+      kind: "circuit",
+      id: item.block.id,
+      label: item.block.label,
+      rounds: item.block.rounds,
+      exerciseCount: item.block.exercises.length,
+      sortOrder: item.sort_order,
+    }
+  })
+}
+
 export function ProgramDetailSheet({ program, open, onOpenChange, onEdit }: ProgramDetailSheetProps) {
   const { t } = useTranslation("library")
 
-  const { data: days, isLoading } = useQuery<DayWithExercises[]>({
+  const { data: days, isLoading } = useQuery<DayWithSequence[]>({
     queryKey: ["program-detail", program?.id],
     enabled: !!program && open,
     queryFn: async () => {
       const { data, error } = await supabase
         .from("workout_days")
         .select(
-          `*, workout_exercises(*, exercise:exercises(${LABEL_EXERCISE_SELECT}))`,
+          `*, workout_exercises(*, exercise:exercises(${LABEL_EXERCISE_SELECT})), exercise_blocks(*, exercises:block_exercises(*, exercise:exercises(${LABEL_EXERCISE_SELECT})))`,
         )
         .eq("program_id", program!.id)
         .order("sort_order")
 
       if (error) throw error
-      return data as DayWithExercises[]
+      return (data ?? []) as DayWithSequence[]
     },
   })
 
@@ -84,22 +117,26 @@ export function ProgramDetailSheet({ program, open, onOpenChange, onEdit }: Prog
           </div>
         ) : (
           <div className="mt-4 grid gap-3">
-            {(days ?? []).map((day) => (
+            {(days ?? []).map((day) => {
+              const blocks = (day.exercise_blocks ?? []).map((block) => ({
+                ...block,
+                exercises: [...(block.exercises ?? [])].sort(
+                  (a, b) => a.position - b.position,
+                ),
+              }))
+              const items = toDayCardItems(
+                day.workout_exercises as WorkoutExerciseWithExercise[],
+                blocks,
+              )
+              return (
                 <DayCard
                   key={day.id}
                   label={`${day.emoji} ${day.label}`}
-                  exerciseCount={day.workout_exercises.length}
-                  exercises={day.workout_exercises.map((ex) => ({
-                    id: ex.id,
-                    emoji: ex.emoji_snapshot,
-                    name: ex.name_snapshot,
-                    sets: ex.sets,
-                    reps: ex.reps,
-                    restSeconds: ex.rest_seconds,
-                    sortOrder: ex.sort_order,
-                  }))}
+                  exerciseCount={items.length}
+                  items={items}
                 />
-              ))}
+              )
+            })}
           </div>
         )}
       </SheetContent>

--- a/src/components/library/TemplateDetailSheet.tsx
+++ b/src/components/library/TemplateDetailSheet.tsx
@@ -58,7 +58,8 @@ export function TemplateDetailSheet({
                 label={day.day_label}
                 exerciseCount={day.template_exercises.length}
                 muscleFocus={day.muscle_focus}
-                exercises={day.template_exercises.map((te) => ({
+                items={day.template_exercises.map((te) => ({
+                  kind: "solo" as const,
                   id: te.id,
                   emoji: te.exercise?.emoji ?? "🏋️",
                   name: te.exercise?.name ?? "Exercise",

--- a/src/locales/en/library.json
+++ b/src/locales/en/library.json
@@ -38,6 +38,10 @@
   "exerciseCount": "{{count}} exercises",
   "setsReps": "{{sets}} × {{reps}}",
   "restSeconds": "{{seconds}}s rest",
+  "circuit": {
+    "fallbackLabel": "Circuit",
+    "summary": "{{count}} exercises · {{rounds}} rounds"
+  },
 
   "savingProgram": "Saving program…",
   "startingProgram": "Starting program…",

--- a/src/locales/fr/library.json
+++ b/src/locales/fr/library.json
@@ -38,6 +38,10 @@
   "exerciseCount": "{{count}} exercices",
   "setsReps": "{{sets}} × {{reps}}",
   "restSeconds": "{{seconds}}s repos",
+  "circuit": {
+    "fallbackLabel": "Circuit",
+    "summary": "{{count}} exercices · {{rounds}} tours"
+  },
 
   "savingProgram": "Sauvegarde du programme…",
   "startingProgram": "Démarrage du programme…",


### PR DESCRIPTION
## What

- `ProgramDetailSheet` fetches `exercise_blocks` alongside solos and merges via `buildDayItems`.
- `DayCard` renders Circuit summary lines (label · N exercises · M rounds) and counts Circuit as one item.

## Why

After #452 Circuits persist and show in the Builder, but Library program detail still looked solos-only (under-counted HIIT days).

## How

Embed both relations on `workout_days`, map to `DayCardItem` (solo | circuit). Templates stay solo-only via the same `items` API.

Closes #454

Made with [Cursor](https://cursor.com)