### PR TITLE
fix(session): confirm finish when circuits remain ahead

### DIFF
--- a/src/components/workout/SessionNav.test.tsx
+++ b/src/components/workout/SessionNav.test.tsx
@@ -91,7 +91,7 @@ describe("SessionNav", () => {
     expect(onFinish).not.toHaveBeenCalled()
   })
 
-  it("calls onFinish directly when clicking finish early with all sets done", async () => {
+  it("asks for confirmation when finishing early with all sets done but items ahead", async () => {
     const user = userEvent.setup()
     const onFinish = vi.fn()
     const { store } = renderWithProviders(
@@ -112,7 +112,120 @@ describe("SessionNav", () => {
 
     await user.click(screen.getByText("Finish workout early"))
 
+    expect(screen.getByText("Finish session?")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "You still have exercises or circuits left. Finish anyway?",
+      ),
+    ).toBeInTheDocument()
+    expect(onFinish).not.toHaveBeenCalled()
+  })
+
+  // Repro: circuit → plank → circuit. User finishes plank sets, taps FR
+  // "Terminer la séance" (finishEarly). Solo sets are all done so the guard
+  // used to skip confirmation and drop the trailing circuit silently.
+  it("asks for confirmation when finishing early with items still ahead (all solo sets done)", async () => {
+    const user = userEvent.setup()
+    const onFinish = vi.fn()
+    const plank = makeExercise("plank")
+    const { store } = renderWithProviders(
+      <SessionNav exercises={[plank]} itemCount={3} onFinish={onFinish} />,
+    )
+
+    act(() => {
+      store.set(sessionAtom, {
+        ...BASE_SESSION,
+        exerciseIndex: 1,
+        setsData: {
+          plank: [
+            {
+              kind: "duration",
+              targetSeconds: 45,
+              weight: "0",
+              done: true,
+              timerStartedAt: null,
+            },
+            {
+              kind: "duration",
+              targetSeconds: 45,
+              weight: "0",
+              done: true,
+              timerStartedAt: null,
+            },
+            {
+              kind: "duration",
+              targetSeconds: 45,
+              weight: "0",
+              done: true,
+              timerStartedAt: null,
+            },
+          ],
+        },
+      })
+    })
+
+    await user.click(screen.getByText("Finish workout early"))
+
+    expect(screen.getByText("Finish session?")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "You still have exercises or circuits left. Finish anyway?",
+      ),
+    ).toBeInTheDocument()
+    expect(onFinish).not.toHaveBeenCalled()
+  })
+
+  it("calls onFinish directly from Finish on last item when nothing is left", async () => {
+    const user = userEvent.setup()
+    const onFinish = vi.fn()
+    const { store } = renderWithProviders(
+      <SessionNav exercises={EXERCISES} onFinish={onFinish} />,
+    )
+
+    act(() => {
+      store.set(sessionAtom, {
+        ...BASE_SESSION,
+        exerciseIndex: 2,
+        setsData: {
+          "ex-1": [{ kind: "reps", reps: "10", weight: "60", done: true }],
+          "ex-2": [{ kind: "reps", reps: "10", weight: "60", done: true }],
+          "ex-3": [{ kind: "reps", reps: "10", weight: "60", done: true }],
+        },
+      })
+    })
+
+    await user.click(screen.getByText("Finish"))
+
     expect(onFinish).toHaveBeenCalledOnce()
+  })
+
+  it("asks for confirmation on last item when a circuit is still incomplete", async () => {
+    const user = userEvent.setup()
+    const onFinish = vi.fn()
+    const { store } = renderWithProviders(
+      <SessionNav
+        exercises={EXERCISES}
+        incompleteBlockCount={1}
+        onFinish={onFinish}
+      />,
+    )
+
+    act(() => {
+      store.set(sessionAtom, {
+        ...BASE_SESSION,
+        exerciseIndex: 2,
+        setsData: {
+          "ex-1": [{ kind: "reps", reps: "10", weight: "60", done: true }],
+          "ex-2": [{ kind: "reps", reps: "10", weight: "60", done: true }],
+          "ex-3": [{ kind: "reps", reps: "10", weight: "60", done: true }],
+        },
+      })
+    })
+
+    await user.click(screen.getByText("Finish"))
+
+    expect(screen.getByText("Finish session?")).toBeInTheDocument()
+    expect(onFinish).not.toHaveBeenCalled()
   })
 
   it("treats the last solo as non-final when blocks extend the sequence (itemCount)", () => {

--- a/src/components/workout/SessionNav.test.tsx
+++ b/src/components/workout/SessionNav.test.tsx
@@ -88,6 +88,40 @@ describe("SessionNav", () => {
     await user.click(screen.getByText("Finish workout early"))
 
     expect(screen.getByText("Finish session?")).toBeInTheDocument()
+    // Not last + skipped set → combined copy (items still ahead).
+    expect(
+      screen.getByText(
+        "You have 1 skipped set and still have exercises or circuits left. Finish anyway?",
+      ),
+    ).toBeInTheDocument()
+    expect(onFinish).not.toHaveBeenCalled()
+  })
+
+  it("mentions only skipped sets when finishing on the last item with no circuits left", async () => {
+    const user = userEvent.setup()
+    const onFinish = vi.fn()
+    const { store } = renderWithProviders(
+      <SessionNav exercises={EXERCISES} onFinish={onFinish} />,
+    )
+
+    act(() => {
+      store.set(sessionAtom, {
+        ...BASE_SESSION,
+        exerciseIndex: 2,
+        setsData: {
+          "ex-1": [{ kind: "reps", reps: "10", weight: "60", done: true }],
+          "ex-2": [{ kind: "reps", reps: "10", weight: "60", done: true }],
+          "ex-3": [{ kind: "reps", reps: "10", weight: "60", done: false }],
+        },
+      })
+    })
+
+    await user.click(screen.getByText("Finish"))
+
+    expect(screen.getByText("Finish session?")).toBeInTheDocument()
+    expect(
+      screen.getByText("You have 1 skipped set. Finish anyway?"),
+    ).toBeInTheDocument()
     expect(onFinish).not.toHaveBeenCalled()
   })
 

--- a/src/components/workout/SessionNav.tsx
+++ b/src/components/workout/SessionNav.tsx
@@ -23,8 +23,8 @@ interface SessionNavProps {
    */
   itemCount?: number
   /**
-   * Blocks in the day that are not yet in `completedBlockIds`. Finish must
-   * confirm when this is > 0 — block work is invisible to solo `setsData`.
+   * Number of incomplete circuits remaining in the workout day. Finish must
+   * confirm when this is > 0 — circuit progress is invisible to solo `setsData`.
    */
   incompleteBlockCount?: number
   onFinish: () => void
@@ -92,10 +92,13 @@ export function SessionNav({
   }
 
   const skippedCount = daySets().filter((s) => !s.done).length
+  const hasRemainingAhead = !isLast || incompleteBlockCount > 0
   const confirmBody =
-    skippedCount > 0
-      ? t("skippedSets", { count: skippedCount })
-      : t("finishEarlyRemaining")
+    skippedCount > 0 && hasRemainingAhead
+      ? t("finishEarlySkippedAndRemaining", { count: skippedCount })
+      : skippedCount > 0
+        ? t("skippedSets", { count: skippedCount })
+        : t("finishEarlyRemaining")
 
   return (
     <>

--- a/src/components/workout/SessionNav.tsx
+++ b/src/components/workout/SessionNav.tsx
@@ -22,6 +22,11 @@ interface SessionNavProps {
    * Defaults to `exercises.length` when the day has no blocks.
    */
   itemCount?: number
+  /**
+   * Blocks in the day that are not yet in `completedBlockIds`. Finish must
+   * confirm when this is > 0 — block work is invisible to solo `setsData`.
+   */
+  incompleteBlockCount?: number
   onFinish: () => void
   /** When the workout timer is paused, forward/next/finish attempts call this instead. */
   onBlockedByPause?: () => void
@@ -30,6 +35,7 @@ interface SessionNavProps {
 export function SessionNav({
   exercises,
   itemCount,
+  incompleteBlockCount = 0,
   onFinish,
   onBlockedByPause,
 }: SessionNavProps) {
@@ -68,7 +74,12 @@ export function SessionNav({
       return
     }
     const skipped = daySets().filter((s) => !s.done).length
-    if (skipped > 0) {
+    // Items still ahead (e.g. trailing circuit after a solo), or unfinished
+    // blocks skipped via the strip, are not reflected in solo set rows — so
+    // "all sets done" must not silently end the session.
+    const leavingWork =
+      skipped > 0 || !isLast || incompleteBlockCount > 0
+    if (leavingWork) {
       setConfirmOpen(true)
     } else {
       onFinish()
@@ -81,6 +92,10 @@ export function SessionNav({
   }
 
   const skippedCount = daySets().filter((s) => !s.done).length
+  const confirmBody =
+    skippedCount > 0
+      ? t("skippedSets", { count: skippedCount })
+      : t("finishEarlyRemaining")
 
   return (
     <>
@@ -123,9 +138,7 @@ export function SessionNav({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t("finishSessionTitle")}</DialogTitle>
-            <DialogDescription>
-              {t("skippedSets", { count: skippedCount })}
-            </DialogDescription>
+            <DialogDescription>{confirmBody}</DialogDescription>
           </DialogHeader>
           <DialogFooter className="flex gap-2">
             <Button variant="outline" onClick={() => setConfirmOpen(false)}>

--- a/src/lib/sessionFinishStats.test.ts
+++ b/src/lib/sessionFinishStats.test.ts
@@ -3,6 +3,7 @@ import {
   countBlockSetsDone,
   countSessionSlots,
   countSoloSetsDone,
+  sessionHasSkippedSets,
 } from "@/lib/sessionFinishStats"
 import type { SetLog, WorkoutExercise } from "@/types/database"
 
@@ -92,5 +93,91 @@ describe("sessionFinishStats", () => {
         },
       ]),
     ).toBe(2)
+  })
+
+  // Repro: circuit → plank → circuit. All solo plank sets done, trailing
+  // Finisher never started → sessions.has_skipped_sets must be true.
+  it("is true when all solo sets are done but a circuit remains incomplete", () => {
+    const plank = solo({ id: "plank" })
+    expect(
+      sessionHasSkippedSets(
+        [plank],
+        {
+          plank: [
+            {
+              kind: "duration",
+              targetSeconds: 45,
+              weight: "0",
+              done: true,
+              timerStartedAt: null,
+            },
+            {
+              kind: "duration",
+              targetSeconds: 45,
+              weight: "0",
+              done: true,
+              timerStartedAt: null,
+            },
+            {
+              kind: "duration",
+              targetSeconds: 45,
+              weight: "0",
+              done: true,
+              timerStartedAt: null,
+            },
+          ],
+        },
+        1,
+      ),
+    ).toBe(true)
+  })
+
+  it("is false when every solo set is done and no circuit is incomplete", () => {
+    const plank = solo({ id: "plank" })
+    expect(
+      sessionHasSkippedSets(
+        [plank],
+        {
+          plank: [
+            {
+              kind: "duration",
+              targetSeconds: 45,
+              weight: "0",
+              done: true,
+              timerStartedAt: null,
+            },
+          ],
+        },
+        0,
+      ),
+    ).toBe(false)
+  })
+
+  it("is true when a solo set is left undone", () => {
+    const plank = solo({ id: "plank" })
+    expect(
+      sessionHasSkippedSets(
+        [plank],
+        {
+          plank: [
+            {
+              kind: "duration",
+              targetSeconds: 45,
+              weight: "0",
+              done: true,
+              timerStartedAt: null,
+            },
+            {
+              kind: "duration",
+              targetSeconds: 45,
+              weight: "0",
+              done: false,
+              timerStartedAt: null,
+            },
+          ],
+        },
+        0,
+      ),
+    ).toBe(true)
   })
 })

--- a/src/lib/sessionFinishStats.ts
+++ b/src/lib/sessionFinishStats.ts
@@ -55,3 +55,19 @@ export function countSessionSlots(
 ): number {
   return exercises.length + blocks.length
 }
+
+/**
+ * True when the finish payload should set `sessions.has_skipped_sets`.
+ * Solo set rows alone are not enough: an unfinished circuit never appears
+ * in `setsData`, so incomplete blocks must count as skipped work too.
+ */
+export function sessionHasSkippedSets(
+  exercises: WorkoutExercise[],
+  setsData: Record<string, SessionSetRow[]>,
+  incompleteBlockCount: number,
+): boolean {
+  const hasIncompleteSoloSets = exercises
+    .flatMap((ex) => setsData[ex.id] ?? [])
+    .some((s) => !s.done)
+  return hasIncompleteSoloSets || incompleteBlockCount > 0
+}

--- a/src/locales/en/workout.json
+++ b/src/locales/en/workout.json
@@ -58,6 +58,7 @@
   "holdOverNotif": "Hold complete!",
   "holdOverBody": "Time to log your set",
   "finishEarly": "Finish workout early",
+  "finishEarlyRemaining": "You still have exercises or circuits left. Finish anyway?",
   "weightPerArm": "{{unit}}/arm",
   "addedWeight": "+{{unit}}",
   "rir.title": "Reps in Reserve",

--- a/src/locales/en/workout.json
+++ b/src/locales/en/workout.json
@@ -59,6 +59,8 @@
   "holdOverBody": "Time to log your set",
   "finishEarly": "Finish workout early",
   "finishEarlyRemaining": "You still have exercises or circuits left. Finish anyway?",
+  "finishEarlySkippedAndRemaining_one": "You have {{count}} skipped set and still have exercises or circuits left. Finish anyway?",
+  "finishEarlySkippedAndRemaining_other": "You have {{count}} skipped sets and still have exercises or circuits left. Finish anyway?",
   "weightPerArm": "{{unit}}/arm",
   "addedWeight": "+{{unit}}",
   "rir.title": "Reps in Reserve",

--- a/src/locales/fr/workout.json
+++ b/src/locales/fr/workout.json
@@ -59,6 +59,8 @@
   "holdOverBody": "Log ta série",
   "finishEarly": "Terminer la séance",
   "finishEarlyRemaining": "Il reste des exercices ou circuits dans cette séance. Terminer quand même ?",
+  "finishEarlySkippedAndRemaining_one": "Vous avez {{count}} série non complétée et il reste des exercices ou circuits. Terminer quand même ?",
+  "finishEarlySkippedAndRemaining_other": "Vous avez {{count}} séries non complétées et il reste des exercices ou circuits. Terminer quand même ?",
   "weightPerArm": "{{unit}}/bras",
   "addedWeight": "+{{unit}}",
   "rir.title": "Répétitions en réserve",

--- a/src/locales/fr/workout.json
+++ b/src/locales/fr/workout.json
@@ -58,6 +58,7 @@
   "holdOverNotif": "Hold terminé !",
   "holdOverBody": "Log ta série",
   "finishEarly": "Terminer la séance",
+  "finishEarlyRemaining": "Il reste des exercices ou circuits dans cette séance. Terminer quand même ?",
   "weightPerArm": "{{unit}}/bras",
   "addedWeight": "+{{unit}}",
   "rir.title": "Répétitions en réserve",

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -1161,6 +1161,9 @@ export function WorkoutPage() {
                 <SessionNav
                   exercises={exercises}
                   itemCount={items.length}
+                  incompleteBlockCount={
+                    dayBlocks.filter((b) => !completedBlockIds.has(b.id)).length
+                  }
                   onFinish={handleFinish}
                   onBlockedByPause={openPauseBlocked}
                 />

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -77,6 +77,7 @@ import {
   countSessionSlots,
   countSoloExercisesCompleted,
   countSoloSetsDone,
+  sessionHasSkippedSets,
 } from "@/lib/sessionFinishStats"
 import { WorkoutDayCarousel } from "@/components/workout/WorkoutDayCarousel"
 import { CycleProgressHeader } from "@/components/workout/CycleProgressHeader"
@@ -787,9 +788,18 @@ export function WorkoutPage() {
       }))
   }, [exercises, prFlags])
 
+  // Circuits not yet in completedBlockIds — shared by SessionNav confirm +
+  // sessions.has_skipped_sets on finish (block work never lands in setsData).
+  const incompleteBlockCount = dayBlocks.filter(
+    (b) => !completedBlockIds.has(b.id),
+  ).length
+
   function handleFinish() {
-    const daySets = exercises.flatMap((ex) => session.setsData[ex.id] ?? [])
-    const hasSkipped = daySets.some((s) => !s.done)
+    const hasSkipped = sessionHasSkippedSets(
+      exercises,
+      session.setsData,
+      incompleteBlockCount,
+    )
 
     const realId =
       user != null ? peekSessionRealId(user.id, sessionId) : null
@@ -1161,9 +1171,7 @@ export function WorkoutPage() {
                 <SessionNav
                   exercises={exercises}
                   itemCount={items.length}
-                  incompleteBlockCount={
-                    dayBlocks.filter((b) => !completedBlockIds.has(b.id)).length
-                  }
+                  incompleteBlockCount={incompleteBlockCount}
                   onFinish={handleFinish}
                   onBlockedByPause={openPauseBlocked}
                 />


### PR DESCRIPTION
## What

- `SessionNav` now confirms finish when items remain ahead or circuits are still incomplete, not only when solo sets are unchecked
- Passes `incompleteBlockCount` from `WorkoutPage` (blocks outside solo `setsData`)
- Adds i18n copy for the remaining-work confirmation (EN/FR) and regression tests for the circuit → solo → circuit path

## Why

Finishing mid-session after completing a solo (e.g. planks) could silently drop a trailing circuit: FR « Terminer la séance » is `finishEarly`, and with all solo sets done the guard skipped the dialog because block progress is invisible to `setsData`.

## How

Treat finish as “leaving work” when `skipped sets > 0`, `!isLast`, or `incompleteBlockCount > 0`. Show `finishEarlyRemaining` when the skipped-set count is zero so the dialog still explains why confirmation is needed.


Made with [Cursor](https://cursor.com)