### PR TITLE
Add Five Circuit Achievement Tracks with Shared Metrics Engine

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -188,10 +188,10 @@ Wall-clock time to grind through one run of an **Exercise Block** in a session, 
 A **named, reusable, catalog-level circuit** — its own entity (`benchmark_circuits`), not a promoted **Exercise Block**. Its public machine handle is an immutable ASCII `slug`; its display name is the `label` (`Zeus ⚡`). The GymLogic roster is Cindy plus eight Pantheon seeds (`zeus`, `heracles`, `ares`, `theseus`, `athena`, `atlas`, `hades`, `achilles`), all flat bodyweight **AMRAP** prescriptions in this wave. Dropping one onto a **workout day** snapshot-copies its fixed Rx into a day-scoped **Exercise Block** and stamps `benchmark_circuit_id`; catalog Rx wins over caller- or LLM-reconstructed exercises. A generic Circuit with no seed name stays jetable. Comparability uses `templateFingerprint`; history / PR reads the GO snapshot in `block_runs.benchmark_circuit_id`, not the live day FK. Canonical Rx is JSONB; a different Rx is a different catalog row, while label, tagline, story, and other editorial metadata may be patched. Breaking a seed's Rx contract creates a **Circuit Fork**. A Tours or pyramidal benchmark catalog is deferred; see ADR `file:docs/adr/0017-pantheon-amrap-seeds-and-label.md`.
 
 **Olympien**:
-Editorial cast for the four 20-minute Pantheon **Benchmark Circuits** (Zeus, Ares, Athena, Hades). It is roster language, not a database column.
+Editorial cast for the four 20-minute Pantheon **Benchmark Circuits** (Zeus, Ares, Athena, Hades). It is roster language, not a database column. The achievement group that scores this cast is **Olympians**.
 
 **Héros**:
-Editorial cast for the four 10-minute Pantheon **Benchmark Circuits** (Heracles, Theseus, Atlas, Achilles). It is roster language, not a database column.
+Editorial cast for the four 10-minute Pantheon **Benchmark Circuits** (Heracles, Theseus, Atlas, Achilles). It is roster language, not a database column. The achievement group that scores this cast is **Heroes**.
 
 **Specialty**:
 The canonical tagline category assigned to one Pantheon matrix column: Full body, Upper-body strength, Core, or Legs. Each Specialty pairs one **Olympien** with one **Héros** and lives in localized tagline copy, not a dedicated column.
@@ -244,6 +244,33 @@ The condition `workout_exercises.template_updated_at > last_session.finished_at`
 **Last Performance**:
 The `set_logs` rows from the most recent session that logged a given **Exercise Slot** (keyed by `workout_exercise_id` + catalog `exercise_id`), carrying both actuals (`reps_logged`, `weight_logged`, `duration_seconds`) and the **Prescription Snapshot** (`prescribed_*`) captured at log-time. Source of the engine's `volume.current` and `currentWeight` on subsequent sessions, unless the **Manual Override Window** applies. **Exercise Block** logs stay out (`block_exercise_id` set / `workout_exercise_id` null — ADR 0007). Legacy or orphaned rows with null `workout_exercise_id` do not anchor — the engine bootstraps from **Template Prescription**. Athlete-level history, trends, and PRs remain catalog-global; only session prescription / prefill follows the slot (#463). Filtered by `logged_at < sessionStartedAt` when called in-session (so the live session's own logs don't pollute the comparison) or unfiltered pre-session.
 → `file:src/hooks/useLastSessionDetail.ts`, `file:src/hooks/useProgressionSuggestionsForDay.ts`, ADR `file:docs/adr/0012-slot-scoped-last-performance.md`
+
+---
+
+## Achievements
+
+**Circuit Achievement Run**:
+One finished **Block Run** on a GymLogic **Benchmark Circuit** seed (`owner_id` NULL) whose AMRAP score has `fullRounds ≥ 1`. TIME-empty closes (`0+0`) and **Circuit Fork** / jetable Circuits do not qualify. Each qualifying run increments that seed's ledger by one. Shared unit for **Circuit runner**, **Cast Clearing**, and the collection tracks below.
+→ `file:src/lib/amrapScore.ts`, `file:supabase/migrations/20260802170000_secure_definer_rpcs.sql` (RPC shape; #482 branches TBD)
+
+**Circuit runner**:
+Achievement group `circuit_runner` (accordion *Circuit runner* / *Circuit Runner*). Metric: count of **Circuit Achievement Run**s across all GymLogic seeds (Cindy included). Thresholds 1 / 5 / 15 / 40 / 100. Surfaces: `/achievements` + session unlock overlay — not the **Circuit Catalog** (ADR 0018).
+
+**Spidey**:
+Achievement group `spidey` (accordion *L’Araignée* / *Spidey*). Metric: personal-best Cindy score in **full rounds only** (same run identity as history / `amrapScore`; leftover does not cross a tier). Thresholds 1 / 10 / 18 / 23 / 27; diamond equals Holland (`reference` 27), not 28+. Catalog label stays **Cindy**; Holland remains editorial `reference`, not the group name.
+
+**Cast Clearing**:
+Progress on a collection track: `MIN` of **Circuit Achievement Run** counts over that track's hardcoded seed cast. Surplus runs on one seed are advance toward later tiers, not wasted. Accordion v1 shows the numeric `MIN` only; naming the bottleneck seed is a follow-up.
+→ ADR `file:docs/adr/0019-circuit-achievement-cast-clearing-and-spidey.md`
+
+**Olympians** (achievement group):
+Group `olympians` (accordion *Au sommet de l’Olympe* / *Olympus Summit*). **Cast Clearing** over the four **Olympien** seeds (`zeus`, `ares`, `athena`, `hades`). Thresholds 1 / 5 / 10 / 50 / 100. Distinct from the editorial cast term **Olympien**.
+
+**Heroes** (achievement group):
+Group `heroes` (accordion *Le tour des Héros* / *Heroes’ Tour*). **Cast Clearing** over the four **Héros** seeds (`heracles`, `theseus`, `atlas`, `achilles`). Same thresholds as **Olympians**. Distinct from the editorial cast term **Héros**.
+
+**Pantheoniste**:
+Achievement group `pantheoniste` (accordion *Le Pantheoniste* / *Pantheoniste*). **Cast Clearing** over all eight Greek Pantheon seeds (Cindy excluded). Same thresholds as **Olympians** / **Heroes**. A single seed run can feed **Circuit runner** plus the matching quatuor plus this capstone.
 
 ---
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -251,7 +251,7 @@ The `set_logs` rows from the most recent session that logged a given **Exercise 
 
 **Circuit Achievement Run**:
 One finished **Block Run** on a GymLogic **Benchmark Circuit** seed (`owner_id` NULL) whose AMRAP score has `fullRounds ≥ 1`. TIME-empty closes (`0+0`) and **Circuit Fork** / jetable Circuits do not qualify. Each qualifying run increments that seed's ledger by one. Shared unit for **Circuit runner**, **Cast Clearing**, and the collection tracks below.
-→ `file:src/lib/amrapScore.ts`, `file:supabase/migrations/20260802170000_secure_definer_rpcs.sql` (RPC shape; #482 branches TBD)
+→ `file:src/lib/amrapScore.ts`, `file:supabase/migrations/20260817120000_circuit_achievement_tracks.sql`
 
 **Circuit runner**:
 Achievement group `circuit_runner` (accordion *Circuit runner* / *Circuit Runner*). Metric: count of **Circuit Achievement Run**s across all GymLogic seeds (Cindy included). Thresholds 1 / 5 / 15 / 40 / 100. Surfaces: `/achievements` + session unlock overlay — not the **Circuit Catalog** (ADR 0018).

--- a/docs/Epic_Brief_—_Benchmark_Circuit_achievement_tracks_#482.md
+++ b/docs/Epic_Brief_—_Benchmark_Circuit_achievement_tracks_#482.md
@@ -1,0 +1,129 @@
+# Epic Brief — Benchmark Circuit achievement tracks (#482)
+
+## Summary
+
+Finishing GymLogic **Benchmark Circuits** finally feeds `/achievements`. Five new groups — **Circuit runner**, **L’Araignée** (*Spidey*), **Au sommet de l’Olympe**, **Le tour des Héros**, **Le Pantheoniste** — grant Bronze→Diamant from **Circuit Achievement Run**s and Cindy’s round PB, via the existing `check_and_grant_achievements` / `get_badge_status` RPCs and the session-finish overlay. The **Circuit Catalog** stays browse-only (ADR 0018 / 0019); no new React surface beyond the data-driven accordion.
+
+---
+
+## Context & Problem
+
+**Who is affected:** Athletes who run Cindy or Pantheon seeds and open Succès; returning athletes whose history already sits on `block_runs`.
+
+**Current state:**
+- Nine GymLogic seeds on `main` (#398, #480 / #481). History / PB key on `block_runs.benchmark_circuit_id` and `templateFingerprint`.
+- Achievements (#129 / #218): tables `achievement_groups` (slug + `metric_type`), `achievement_tiers` (Bronze→Diamant, `threshold_value`), `user_achievements`. 11 groups; each `metric_type` is one `UNION ALL` branch in **both** RPCs (`file:supabase/migrations/20260802170000_secure_definer_rpcs.sql`).
+- Grant path: session finish → `syncService` RPC → overlay queue + `lastSessionBadgesAtom`. Accordion (`file:src/components/achievements/AchievementAccordion.tsx`) is data-driven — N groups, no new component for a generic track.
+- No existing metric joins `block_runs` / `benchmark_circuits`. Completing Zeus is invisible to `/achievements`.
+
+**Pain points:**
+| Pain | Impact |
+|---|---|
+| Catalog identity without achievement identity | Pantheon / Cindy work never shows on Succès |
+| Naive "1 god = next rank" ladder | Third seed would "cost" gold; diamond nowhere honest |
+| Score leftover vs badge SQL | Risk of Spidey disagreeing with the history PB |
+| Badge chrome on the Library shelf | Would turn the encyclopedia into a leaderboard (ADR 0018) |
+
+**Decision record:** all forks are resolved in ADR `file:docs/adr/0019-circuit-achievement-cast-clearing-and-spidey.md`. Glossary terms **Circuit Achievement Run**, **Cast Clearing**, **Circuit runner**, **Spidey**, **Olympians**, **Heroes**, **Pantheoniste** live in `file:docs/CONTEXT.md`.
+
+---
+
+## User Stories
+
+1. As an athlete on `/achievements`, I want five new accordion rows at `sort_order` 12–16 with the locked FR/EN titles, so that circuit work has a home next to the existing 11 tracks.
+2. As an athlete, I want **Circuit runner** progress = count of **Circuit Achievement Run**s across all GymLogic seeds (Cindy included), thresholds 1 / 5 / 15 / 40 / 100, so that any finished seed feeds a volume track.
+3. As an athlete, I want **L’Araignée** progress = my Cindy PB in **full rounds only** (1 / 10 / 18 / 23 / 27), so that diamond means equaling Holland (27), not beating him (28+), and leftover reps never cross a tier.
+4. As an athlete, I want **Au sommet de l’Olympe** / **Le tour des Héros** / **Le Pantheoniste** progress = **Cast Clearing** (`MIN` of per-seed run ledgers) with thresholds 1 / 5 / 10 / 50 / 100, so that spam on one seed cannot buy the next tier.
+5. As an athlete with surplus Zeus runs, I want those runs kept on Zeus’s ledger as advance, so that when other cast seeds catch up the clearing count rises without re-running Zeus.
+6. As an athlete, I want Pantheoniste’s cast to be the eight Greek seeds only (Cindy excluded), so that Spidey stays Cindy’s track and the capstone stays Greek.
+7. As an athlete who GO + TIME with `fullRounds = 0` (empty `0+0`), I want that close to count for **zero** across all five metrics, so that an empty finish cannot bronze anything.
+8. As an athlete on a **Circuit Fork** or jetable Create-circuit block, I want those runs ignored by all five groups (`owner_id` NULL seeds only), so that only GymLogic catalog work grants.
+9. As an athlete who finishes a session after ship, I want `check_and_grant_achievements` to evaluate my **full history** and unlock every tier already earned, so that early Cindy / Pantheon athletes are not punished.
+10. As an athlete unlocking several tiers at once on the first post-ship finish, I want the existing overlay / `SessionBadges` queue to surface them, so that retroactive grants still feel earned.
+11. As an athlete under Bibliothèque → Circuits, I never want achievement chips or progress on the catalog list or seed detail, so that the **Circuit Catalog** stays browse-only (ADR 0018).
+12. As an athlete viewing collection progress, I want the same numeric `current / threshold` treatment as other groups (the `MIN` value), so that v1 needs no bottleneck UI.
+13. As an athlete with Display Locale FR or EN, I want group names, descriptions, ranks, and tier titles localized, so that Succès stays bilingual like #218.
+14. As an athlete offline or when the grant RPC fails, I want session finish to still succeed and achievements to reconcile on a later sync, so that badges never block training.
+15. As an athlete opening Succès with no circuit history, I want the five groups visible but locked at bronze with 0 progress, so that empty state matches the other tracks.
+16. As an athlete, I want tier `icon_asset_url` nullable like other groups, so that missing art is not a blocker for #482.
+17. As a Cindy run that also touches the runner track, I want a single finished run counted for **Circuit runner** and **Spidey** (and, for a Pantheon seed, its quatuor plus **Le Pantheoniste**), so that one session correctly advances every track it belongs to.
+
+### Success measures
+
+| Story # | Measure |
+|---|---|
+| 9 | After one finished session post-migrate, every historically earned tier for the five groups appears in `user_achievements` / `get_badge_status` |
+| 3 | Spidey diamond unlocks at PB `fullRounds ≥ 27`; a `26+N` leftover never unlocks diamond |
+| 4 | Zeus×100 with the other three Olympiens at 4 reports `olympians.current_value = 4` |
+| 7 | A run with `fullRounds = 0` changes no `current_value` across the five groups |
+
+---
+
+## Scope
+
+**In scope:**
+- Seed 5 `achievement_groups` + 25 `achievement_tiers` (slugs, titles, thresholds, `sort_order` 12–16) in one migration.
+- Extend **both** RPCs with metric branches for the five new `metric_type`s (identical SQL in grant + status), reading `block_runs` joined to `benchmark_circuits` on the GO-snapshot FK, filtered to `owner_id IS NULL` and `fullRounds ≥ 1`.
+- **Cast Clearing** = `MIN` over per-seed run counts for a hardcoded slug cast; **Circuit runner** = total run count; **Spidey** = Cindy PB full-rounds.
+- i18n: `groups.*`, `groupDescriptions.*`, tier titles in `fr` / `en` `achievements.json`.
+- Test hygiene: local `Local seed circuit%` history must not inflate production-shaped assertions (script vs prod boundary).
+
+**Locked tier titles** (thresholds Bronze / Argent / Or / Platine / Diamant):
+
+| Slug | Thresholds | Bronze | Argent | Or | Platine | Diamant |
+|---|---|---|---|---|---|---|
+| `circuit_runner` | 1 / 5 / 15 / 40 / 100 | Premier tour · First Lap | En rythme · In Cadence | Sans relâche · No Break | Workout machine · Workout Machine | Star des circuits · Circuit Star |
+| `spidey` | 1 / 10 / 18 / 23 / 27 | Baby Spidey · Baby Spidey | Side-kick · Sidekick | Araignée du quotidien · Everyday Spidey | Au bord du 27 · Edge of 27 | À la table de Holland · Holland’s Table |
+| `olympians` | 1 / 5 / 10 / 50 / 100 | Selfie avec Zeus · Zeus Selfie | Nectar gratis · Free Nectar | Banquet divin · Divine Banquet | VIP Olympe · Olympus VIP | PDG de l’Olympe · Olympus CEO |
+| `heroes` | 1 / 5 / 10 / 50 / 100 | Stage chez Héraclès · Intern for Heracles | GPS de Thésée · Theseus GPS | Atlas porte tes courses · Atlas Holds Your Bags | Achille sans talon · Achilles, No Heel | DRH des héros · Heroes’ HR |
+| `pantheoniste` | 1 / 5 / 10 / 50 / 100 | Badge d’entrée · Pantheon Guest Pass | Collectionneur de statues · Statue Collector | Guide du musée grec · Greek Museum Guide | Conservateur du temple · Temple Curator | Le 9e du Panthéon · Ninth of the Pantheon |
+
+**Group titles / order:**
+
+| `sort_order` | Slug | FR | EN |
+|---|---|---|---|
+| 12 | `circuit_runner` | Circuit runner | Circuit Runner |
+| 13 | `spidey` | L’Araignée | Spidey |
+| 14 | `olympians` | Au sommet de l’Olympe | Olympus Summit |
+| 15 | `heroes` | Le tour des Héros | Heroes’ Tour |
+| 16 | `pantheoniste` | Le Pantheoniste | Pantheoniste |
+
+**Casts (hardcoded slug lists in the RPC CTE):**
+- Olympiens: `zeus`, `ares`, `athena`, `hades`
+- Héros: `heracles`, `theseus`, `atlas`, `achilles`
+- Pantheoniste: the eight above (Cindy excluded)
+- Circuit runner: all `owner_id IS NULL` seeds (Cindy + eight)
+- Spidey: `cindy` only
+
+**Out of scope:**
+- `groupDescriptions.*` final copy (drafted in tickets, per C2).
+- Equip / showcase behavior for circuit tiers beyond default (per C3).
+- Badge UI on the **Circuit Catalog** / history-sheet chrome beyond the existing overlay.
+- Bottleneck-seed progress ("Athena 4") — follow-up.
+- Per-seed accordion rows (one row per WOD).
+- Live leaderboards, share, `visibility`.
+- Tours / pyramidal benchmark achievements.
+- Badge art / icon assets.
+- The product line "3+ diamonds ⇒ transformé" as a coded cross-group rule (marketing copy only).
+- New achievement **tables** if a CTE branch + seed rows suffice.
+
+---
+
+## Success Criteria
+
+- **Numeric:** 5 groups × 5 tiers seeded; both RPCs return coherent `current_value` and unlocks for fixtures covering Circuit runner count, Spidey 27, Cast Clearing `MIN`, fork exclusion, and `fullRounds = 0` exclusion.
+- **Qualitative:** An athlete with mixed Pantheon + Cindy history sees correct locked/unlocked state on Succès after one finish; Library circuit pages render unchanged (no badge chrome).
+- **Contract:** Spidey diamond ↔ Holland 27 (full rounds); collection diamond ↔ 100 **Cast Clearing**s; no grant from forks, jetable circuits, or empty-TIME closes.
+
+---
+
+## References
+
+- Decision record: ADR `file:docs/adr/0019-circuit-achievement-cast-clearing-and-spidey.md`
+- Encyclopedia boundary: ADR `file:docs/adr/0018-circuit-catalog-encyclopedia-under-library.md`
+- Glossary: `file:docs/CONTEXT.md` (**Circuit Achievement Run**, **Cast Clearing**, **Circuit runner**, **Spidey**, **Olympians**, **Heroes**, **Pantheoniste**)
+- RPCs: `file:supabase/migrations/20260802170000_secure_definer_rpcs.sql`
+- Score: `file:src/lib/amrapScore.ts`
+- Grant path: `file:src/lib/syncService.ts`, `file:src/components/achievements/AchievementUnlockOverlay.tsx`
+- Roster / identity: #398, #480 / #481; achievement foundation: #129, tracks: #218, UI: #174
+- Issue: [#482](https://github.com/PierreTsia/workout-app/issues/482)

--- a/docs/T208_—_Pin_AMRAP_score_contract.md
+++ b/docs/T208_—_Pin_AMRAP_score_contract.md
@@ -1,0 +1,57 @@
+# T208 — Pin AMRAP score contract
+
+## Goal
+
+Lock the **Circuit Achievement Run** / Spidey round formula in Vitest so the #482 SQL CTE cannot silently diverge from `amrapScore`. Addresses Epic stories 3 and 7 (fullRounds gate, Holland tiers) as a test oracle before the migration lands. Stories: 3, 7 (contract only).
+
+## Mode
+
+AFK — mechanical fixtures; no product judgment.
+
+## Slice
+
+`amrapScore.test.ts` → documented SQL parity comments (no UI)
+
+## Dependencies
+
+None.
+
+## Scope
+
+### Fixtures to pin (or strengthen if already present)
+
+| Case | Expected |
+|---|---|
+| Finished run, leftover on set_number N | `fullRounds = N - 1` |
+| Unfinished (`finished_at` null) | `amrapScore` → `null` |
+| Finished with max set_number = 1 only | `fullRounds = 0` (excluded from qualifying in T209) |
+| Cindy-shaped 27+3 | `fullRounds = 27`, leftover ignored for tier identity |
+| Tie on set_number | leftover cell = max `logged_at` (existing behavior; document for SQL authors that **tiers** only need `MAX(set_number)-1`) |
+
+### Files
+
+| File | Change |
+|---|---|
+| `file:src/lib/amrapScore.test.ts` | Add/strengthen cases above; short comment block: “#482 RPC `qualifying_runs` must match `fullRounds = MAX(set_number) - 1`” |
+| `file:supabase/functions/mcp/lib/amrapScore.ts` | **Do not** change unless a fixture proves drift — out of scope to re-sync Edge here |
+
+## Out of Scope
+
+- Any SQL / migration (→ T209)
+- i18n, accordion, retroactive grant
+- Changing `amrapScore` production behavior
+
+## Acceptance Criteria
+
+- [ ] Vitest covers finished → `fullRounds = max(set_number) - 1`
+- [ ] Vitest covers unfinished → `null`
+- [ ] Vitest covers `fullRounds === 0` for a finished single-set leftover round
+- [ ] Comment in the test file points T209 authors at the SQL contract
+- [ ] `VITE_SUPABASE_URL= VITE_SUPABASE_ANON_KEY= npx vitest run src/lib/amrapScore.test.ts` green
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_Benchmark_Circuit_achievement_tracks_#482.md` (stories 3, 7)
+- Tech Plan: `file:docs/Tech_Plan_—_Benchmark_Circuit_achievement_tracks_#482.md` (fullRounds inline CTE)
+- ADR: `file:docs/adr/0019-circuit-achievement-cast-clearing-and-spidey.md`
+- Score: `file:src/lib/amrapScore.ts`

--- a/docs/T209_—_Seed_+_RPCs_+_i18n_(5_circuit_tracks).md
+++ b/docs/T209_—_Seed_+_RPCs_+_i18n_(5_circuit_tracks).md
@@ -1,0 +1,79 @@
+# T209 — Seed + RPCs + i18n (5 circuit tracks)
+
+## Goal
+
+Ship the five circuit achievement groups end-to-end: seed rows, `qualifying_runs` + five metric branches in **both** achievement RPCs, and FR/EN i18n placeholders so `/achievements` shows the new accordion rows with correct progress after migrate. Addresses Epic stories 1–10, 12–17 (product surface). Stories: 1–10, 12–17.
+
+## Mode
+
+AFK — titles, thresholds, casts, and SQL shape are locked in the Epic Brief / Tech Plan.
+
+## Slice
+
+`migration (seed + both RPCs)` → `achievements.json` → Succès accordion (data-driven) → vitest/type-check
+
+## Dependencies
+
+T208 (score contract fixtures as oracle for `fullRounds`).
+
+## Scope
+
+### Migration (one file, #218 shape)
+
+| Step | Detail |
+|---|---|
+| Seed groups | `circuit_runner`, `spidey`, `olympians`, `heroes`, `pantheoniste` — `sort_order` 12–16, names from Epic Brief |
+| Seed tiers | 5 ranks × 5 groups; titles + thresholds exactly as Epic Brief locked table |
+| Replace RPCs | `check_and_grant_achievements` + `get_badge_status`: shared `qualifying_runs` CTE + cast slug lists + 5 `UNION ALL` branches; keep existing 11 metrics |
+| Qualifying run | GO `block_runs.benchmark_circuit_id` → `benchmark_circuits.owner_id IS NULL`; `finished_at NOT NULL`; `full_rounds = MAX(set_number)-1 ≥ 1` via `block_exercises`/`set_logs` |
+| Cast Clearing | LEFT JOIN fixed slug lists → `COALESCE(cnt,0)` → `MIN` (missing seed = 0) |
+| Spidey | `MAX(full_rounds)` where `slug = 'cindy'` |
+| Icons | `icon_asset_url` NULL |
+
+Casts: olympians `zeus,ares,athena,hades` · heroes `heracles,theseus,atlas,achilles` · pantheoniste = eight · runner = all seeds · spidey = cindy.
+
+### i18n
+
+| File | Keys |
+|---|---|
+| `file:src/locales/fr/achievements.json` | `groups.*`, `groupDescriptions.*`, `thresholdHint.*` for all 5 slugs |
+| `file:src/locales/en/achievements.json` | idem |
+
+Use Tech Plan metric placeholders (voice rewrite later OK).
+
+### Metrics (must match in both RPC bodies)
+
+| `metric_type` | Value |
+|---|---|
+| `circuit_runner` | `COUNT(*)` from `qualifying_runs` |
+| `spidey` | `COALESCE(MAX(full_rounds) FILTER cindy, 0)` |
+| `olympians` / `heroes` / `pantheoniste` | `MIN` over LEFT JOIN fixed slugs |
+
+### Demoable behavior
+
+After `supabase db reset` / migrate: open Succès → five new rows (sort 12–16). Finish a session with a qualifying Cindy → runner + Spidey progress move via existing `processSessionFinish` (no syncService code change).
+
+## Out of Scope
+
+- Arch test hardening beyond what’s needed to land the migration (→ T210)
+- Running `retroactive-badge-grant.sql` as ops (→ T211 / T212)
+- Catalog badge chrome, bottleneck UI, badge art, equip/showcase changes
+- Rewriting `groupDescriptions` for “voice” (placeholders ship)
+
+## Acceptance Criteria
+
+- [ ] Migration seeds 5 groups × 5 tiers with locked titles/thresholds/sort_order
+- [ ] Both RPCs contain identical `qualifying_runs` + five new metric branches + existing 11
+- [ ] Cast Clearing uses LEFT JOIN fixed slugs (Hades missing → olympians value 0) — documented in SQL comments if not unit-testable in CI
+- [ ] FR + EN `groupDescriptions` and `thresholdHint` exist for all 5 slugs (no raw keys in accordion/drawer)
+- [ ] No new React components; catalog pages untouched
+- [ ] `npx tsc -p tsconfig.app.json --noEmit` green
+- [ ] Demo: post-migrate, `/achievements` lists the five groups; a qualifying history advances runner (and Spidey if Cindy)
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_Benchmark_Circuit_achievement_tracks_#482.md`
+- Tech Plan: `file:docs/Tech_Plan_—_Benchmark_Circuit_achievement_tracks_#482.md` (CTE sketch, i18n table)
+- Precedent: `file:supabase/migrations/20260419120000_new_achievement_tracks.sql`
+- Current RPCs: `file:supabase/migrations/20260802170000_secure_definer_rpcs.sql`
+- ADR: `file:docs/adr/0019-circuit-achievement-cast-clearing-and-spidey.md`

--- a/docs/T210_—_Arch_guards_+_catalog_isolation.md
+++ b/docs/T210_—_Arch_guards_+_catalog_isolation.md
@@ -1,0 +1,59 @@
+# T210 — Arch guards + catalog isolation
+
+## Goal
+
+Prove in CI that the #482 migration keeps the security-definer / metric contract and that the **Circuit Catalog** does not grow badge chrome. Addresses Epic stories 8 and 11 (forks/seeds filter in SQL; catalog stays encyclopedia). Stories: 8, 11.
+
+## Mode
+
+AFK — mechanical assertions.
+
+## Slice
+
+`securityDefiner.arch.test.ts` (+ catalog isolation test) → vitest
+
+## Dependencies
+
+T209 (migration file must exist on the branch).
+
+## Scope
+
+### Arch assertions (extend existing file)
+
+Target migration: the new `*_circuit_achievement_tracks.sql` (or whatever timestamp lands in T209).
+
+| Assert | Why |
+|---|---|
+| Both RPC names still in `SECURITY_DEFINER_FUNCTIONS` / auth-guard signals | Regression |
+| SQL contains metric_type literals: `circuit_runner`, `spidey`, `olympians`, `heroes`, `pantheoniste` | Wiring |
+| SQL contains `owner_id IS NULL` near benchmark join | Seed-only |
+| SQL contains fixed cast slugs (`zeus`…`hades`, heroes, pantheon) | Cast Clearing |
+| SQL shows LEFT JOIN / unnest slug-list pattern for casts (string markers agreed in implementation) | Missing seed → 0 |
+
+### Catalog isolation
+
+| Assert | Why |
+|---|---|
+| `CircuitCatalogPage` / `CircuitCatalogSeedPage` (and related library circuit components) do not import `@/hooks/useBadgeStatus`, achievement atoms, or `SessionBadges` | ADR 0018 |
+
+Prefer a small grep/arch test over brittle full-file snapshots.
+
+## Out of Scope
+
+- Implementing metrics (→ T209)
+- HITL eyeball (→ T212)
+- Changing catalog UI
+
+## Acceptance Criteria
+
+- [ ] Arch test fails if any of the five `metric_type` strings is removed from the migration
+- [ ] Arch test fails if `owner_id IS NULL` guard is removed from the circuit join path
+- [ ] Arch test fails if catalog circuit pages import badge status/overlay modules
+- [ ] `VITE_SUPABASE_URL= VITE_SUPABASE_ANON_KEY= npx vitest run src/test/securityDefiner.arch.test.ts` (and any new isolation test file) green
+
+## References
+
+- Tech Plan: `file:docs/Tech_Plan_—_Benchmark_Circuit_achievement_tracks_#482.md` (tests decision)
+- ADR 0018: `file:docs/adr/0018-circuit-catalog-encyclopedia-under-library.md`
+- Arch precedent: `file:src/test/securityDefiner.arch.test.ts`
+- Catalog: `file:src/pages/library/CircuitCatalogPage.tsx`, `file:src/pages/library/CircuitCatalogSeedPage.tsx`

--- a/docs/T211_—_Retroactive_runbook_+_grant_path.md
+++ b/docs/T211_—_Retroactive_runbook_+_grant_path.md
@@ -1,0 +1,54 @@
+# T211 — Retroactive runbook + grant path
+
+## Goal
+
+Make post-migrate catch-up explicit and keep the existing session-finish → `check_and_grant_achievements` path covered so circuit tiers grant like other tracks without blocking finish. Addresses Epic stories 9, 10, 14. Stories: 9, 10, 14.
+
+## Mode
+
+AFK — document + regression tests; no new product behavior.
+
+## Slice
+
+`scripts/retroactive-badge-grant.sql` (runbook/AC) → `syncService.test.ts` → docs note in PR/ticket
+
+## Dependencies
+
+T209 (RPCs must expose the new metrics before retroactive grant is meaningful).
+
+## Scope
+
+### Retroactive
+
+| Item | Detail |
+|---|---|
+| Script | Existing `file:scripts/retroactive-badge-grant.sql` — call after migrate (local + prod ops) |
+| Ticket/PR note | One-line runbook: migrate → run script (service role / trusted) → optional next finish for overlay |
+| Behavior | Silent `user_achievements` inserts; overlay not required for catch-up (Realtime gate) |
+
+### Grant path regression
+
+| File | Change |
+|---|---|
+| `file:src/lib/syncService.test.ts` | Keep/strengthen: finish calls RPC with `p_user_id`; RPC failure does not fail finish; unlocked rows push queue + `lastSessionBadgesAtom` |
+| `file:src/lib/syncService.ts` | **No code change** unless a bug is found |
+
+## Out of Scope
+
+- Running the script against prod (human/ops in T212)
+- Changing overlay UX
+- New grant trigger beyond session finish
+
+## Acceptance Criteria
+
+- [ ] PR description or ticket checklist includes: run `scripts/retroactive-badge-grant.sql` after applying the #482 migration
+- [ ] `syncService` tests still assert RPC-on-finish, non-critical failure, and queue/`lastSessionBadgesAtom` push
+- [ ] No change that makes badge RPC failure fail `processSessionFinish`
+- [ ] Vitest for syncService green with `VITE_SUPABASE_URL= VITE_SUPABASE_ANON_KEY=`
+
+## References
+
+- Tech Plan: `file:docs/Tech_Plan_—_Benchmark_Circuit_achievement_tracks_#482.md` (retroactive decision)
+- Script: `file:scripts/retroactive-badge-grant.sql`
+- Grant: `file:src/lib/syncService.ts`
+- Epic stories 9, 10, 14

--- a/docs/T211_—_Retroactive_runbook_+_grant_path.md
+++ b/docs/T211_—_Retroactive_runbook_+_grant_path.md
@@ -26,6 +26,10 @@ T209 (RPCs must expose the new metrics before retroactive grant is meaningful).
 | Ticket/PR note | One-line runbook: migrate → run script (service role / trusted) → optional next finish for overlay |
 | Behavior | Silent `user_achievements` inserts; overlay not required for catch-up (Realtime gate) |
 
+### Ops runbook (post-migrate)
+
+After applying the **#482** migration, run `scripts/retroactive-badge-grant.sql` once (SQL Editor / service role). Idempotent; silent grants. Overlay not required for catch-up — optional next session finish still grants remaining tiers via the normal RPC path.
+
 ### Grant path regression
 
 | File | Change |
@@ -41,10 +45,10 @@ T209 (RPCs must expose the new metrics before retroactive grant is meaningful).
 
 ## Acceptance Criteria
 
-- [ ] PR description or ticket checklist includes: run `scripts/retroactive-badge-grant.sql` after applying the #482 migration
-- [ ] `syncService` tests still assert RPC-on-finish, non-critical failure, and queue/`lastSessionBadgesAtom` push
-- [ ] No change that makes badge RPC failure fail `processSessionFinish`
-- [ ] Vitest for syncService green with `VITE_SUPABASE_URL= VITE_SUPABASE_ANON_KEY=`
+- [x] PR description or ticket checklist includes: run `scripts/retroactive-badge-grant.sql` after applying the #482 migration
+- [x] `syncService` tests still assert RPC-on-finish, non-critical failure, and queue/`lastSessionBadgesAtom` push
+- [x] No change that makes badge RPC failure fail `processSessionFinish`
+- [x] Vitest for syncService green with `VITE_SUPABASE_URL= VITE_SUPABASE_ANON_KEY=`
 
 ## References
 

--- a/docs/T212_—_HITL_Succès_closeout.md
+++ b/docs/T212_—_HITL_Succès_closeout.md
@@ -1,0 +1,69 @@
+# T212 — HITL Succès closeout
+
+## Goal
+
+Human-verify the five circuit tracks on a real (or local seeded) history: accordion copy, Cast Clearing `MIN`, Spidey Holland 27, empty TIME / forks excluded, and retroactive grant after migrate. Closes Epic success criteria qualitatively. Stories: 1–17 (verification).
+
+## Mode
+
+HITL — requires eyeballing Succès / history against real data and judging edge cases the arch tests cannot see.
+
+## Slice
+
+local migrate → retroactive script → PWA Succès + session finish overlay → checklist
+
+## Dependencies
+
+T210, T211 (guards + runbook in place).
+
+## Scope
+
+### Setup
+
+1. Branch with T209–T211 merged (or stacked).
+2. `supabase db reset` / apply migration.
+3. Run `scripts/retroactive-badge-grant.sql` for the test user.
+4. Optional: `npm run seed:circuit-history -- --user-id=…` — **know** that local seed labels can inflate runner; prefer known hand-run Cindy/Pantheon fixtures when asserting exact counts.
+
+### Checklist (eyeball)
+
+| Check | Pass |
+|---|---|
+| Accordion shows 5 new groups, sort after Early Bird, locked titles FR/EN | |
+| `groupDescriptions` / drawer hints are real strings (no raw keys) | |
+| Circuit runner increments on qualifying seed runs only | |
+| Spidey `current_value` = Cindy PB full rounds; diamond at ≥27; `26+N` does not diamond | |
+| Olympians/Heroes/Pantheoniste = MIN; Zeus spam alone does not raise clearing | |
+| Missing cast seed keeps clearing at 0 | |
+| TIME empty / `fullRounds = 0` grants nothing | |
+| Circuit Fork / jetable AMRAP ignored | |
+| Catalog `/library/circuits` has no badge chips | |
+| Post-finish overlay can unlock newly earned tiers; finish works if RPC mocked fail (spot-check) | |
+| Retroactive: tiers already earned appear on Succès without requiring a new run (after script) | |
+
+### Outcome
+
+- Comment on #482 or PR with pass/fail notes.
+- File follow-ups only for real bugs (not copy polish unless broken).
+
+## Out of Scope
+
+- Badge art, bottleneck UI, voice rewrite of descriptions
+- Leaderboards / catalog chrome
+- Changing thresholds or titles
+
+## Acceptance Criteria
+
+- [ ] Checklist above completed on local (or staging) with notes
+- [ ] At least one Spidey diamond-boundary check (27 unlocks / 26 does not)
+- [ ] At least one Cast Clearing missing-seed → 0 check
+- [ ] Catalog confirmed badge-free
+- [ ] Retroactive script run once and Succès reflects history
+- [ ] #482 / PR updated: HITL done or blockers listed
+
+## References
+
+- Epic Brief success criteria: `file:docs/Epic_Brief_—_Benchmark_Circuit_achievement_tracks_#482.md`
+- Tech Plan failure modes: `file:docs/Tech_Plan_—_Benchmark_Circuit_achievement_tracks_#482.md`
+- ADR 0019: `file:docs/adr/0019-circuit-achievement-cast-clearing-and-spidey.md`
+- Seed hygiene: `file:scripts/seed-local-history.ts`

--- a/docs/Tech_Plan_—_Benchmark_Circuit_achievement_tracks_#482.md
+++ b/docs/Tech_Plan_—_Benchmark_Circuit_achievement_tracks_#482.md
@@ -1,0 +1,223 @@
+# Tech Plan — Benchmark Circuit achievement tracks (#482)
+
+## Architectural Approach
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Delivery shape | One migration à la #218: seed 5 groups + 25 tiers + replace both RPCs | Proven path; accordion stays data-driven |
+| Qualifying run definition | Shared CTE in both RPCs: GO `block_runs.benchmark_circuit_id` → `benchmark_circuits.owner_id IS NULL`, `finished_at NOT NULL`, `fullRounds = max(set_number)-1 ≥ 1` | Matches ADR 0019 / **Circuit Achievement Run**; never join live day FK |
+| fullRounds in SQL | Inline CTE helper (no SQL function, no `block_runs` column) | Brief: no new tables; #218 style dual-body replace |
+| Spidey metric | `MAX(fullRounds)` on `slug = 'cindy'` only | Leftover never crosses tiers; diamond = Holland 27 |
+| Cast Clearing | Per-seed run counts then `MIN()` over hardcoded slug arrays via **LEFT JOIN fixed slug list** (missing seed → 0) | Surplus = advance; no Zeus spam; never `MIN` over observed-only rows |
+| UI | i18n only (`groupDescriptions`, `thresholdHint`, optional `groups`) with metric placeholders | Zero new React; titles from DB; missing keys would show raw i18n strings |
+| Retroactive | Next session finish + run `scripts/retroactive-badge-grant.sql` post-migrate | Overlay on finish; silent DB catch-up like #218 docs |
+| Tests | Extend `securityDefiner.arch.test.ts` + pin fullRounds fixtures in `amrapScore.test.ts` | No pgTAP; catch drift without Postgres harness |
+
+### Critical Constraints
+
+- Both RPCs live in `file:supabase/migrations/20260802170000_secure_definer_rpcs.sql` and must stay **byte-identical on the `metrics` CTE** (and the shared `qualifying_runs` helper). Every new branch is duplicated. Drift between grant and status is the #1 footgun.
+- `fullRounds` today exists only in `file:src/lib/amrapScore.ts` (+ MCP twin). SQL must scope cells via `block_runs → block_exercises → set_logs` for that `block_id`/`session_id`, not all session logs.
+- Catalog shelf (`file:src/pages/library/CircuitCatalogPage.tsx`, seed detail) must not import badge hooks — ADR 0018.
+- `AchievementAccordion` / Overlay / Drawer call `t(\`groupDescriptions.${slug}\`)` and Drawer also `thresholdHint.${slug}` — missing keys show raw i18n keys in prod.
+- Local `npm run seed:circuit-history` labels must not be used as production fixtures for achievement assertions (test hygiene from the Epic Brief).
+- Cast Clearing **must** LEFT JOIN a fixed slug list so a user missing Hades gets `olympians = 0`, not `MIN` over only the gods they ran.
+
+---
+
+## Data Model
+
+No new tables. Extend seed data + RPC metrics.
+
+```mermaid
+erDiagram
+  achievement_groups ||--o{ achievement_tiers : has
+  achievement_tiers ||--o{ user_achievements : grants
+  block_runs }o--|| benchmark_circuits : "GO snapshot FK"
+  block_runs }o--|| sessions : in
+  block_runs }o--|| exercise_blocks : of
+  set_logs }o--|| block_exercises : "AMRAP cells"
+  block_exercises }o--|| exercise_blocks : in
+
+  achievement_groups {
+    text slug
+    text metric_type
+    int sort_order
+  }
+  block_runs {
+    uuid benchmark_circuit_id
+    timestamptz finished_at
+    text template_fingerprint
+  }
+  benchmark_circuits {
+    uuid id
+    text slug
+    uuid owner_id "NULL = GymLogic seed"
+  }
+```
+
+### Metrics → values
+
+| `metric_type` (= group slug) | SQL value |
+|---|---|
+| `circuit_runner` | `COUNT(*)` qualifying runs (all GymLogic seeds) |
+| `spidey` | `COALESCE(MAX(full_rounds) FILTER (WHERE slug = 'cindy'), 0)` |
+| `olympians` | `MIN` of per-slug counts over `{zeus,ares,athena,hades}`; missing slug → 0 |
+| `heroes` | same over `{heracles,theseus,atlas,achilles}` |
+| `pantheoniste` | same over the eight Greek slugs |
+
+### Shared CTE sketch (both RPCs)
+
+```sql
+qualifying_runs AS (
+  -- one row per finished seed run with full_rounds >= 1
+  SELECT br.id, br.session_id, bc.slug,
+         (MAX(sl.set_number) - 1) AS full_rounds
+  FROM block_runs br
+  JOIN sessions s ON s.id = br.session_id AND s.user_id = p_user_id
+  JOIN benchmark_circuits bc ON bc.id = br.benchmark_circuit_id
+    AND bc.owner_id IS NULL
+  JOIN block_exercises be ON be.block_id = br.block_id
+  JOIN set_logs sl ON sl.session_id = br.session_id
+    AND sl.block_exercise_id = be.id
+  WHERE br.finished_at IS NOT NULL
+  GROUP BY br.id, br.session_id, bc.slug
+  HAVING (MAX(sl.set_number) - 1) >= 1
+),
+olympian_slugs AS (
+  SELECT unnest(ARRAY['zeus','ares','athena','hades']) AS slug
+),
+hero_slugs AS (
+  SELECT unnest(ARRAY['heracles','theseus','atlas','achilles']) AS slug
+),
+pantheon_slugs AS (
+  SELECT slug FROM olympian_slugs
+  UNION ALL
+  SELECT slug FROM hero_slugs
+),
+metrics AS (
+  -- existing 11 UNION ALL …
+  UNION ALL
+  SELECT 'circuit_runner', COUNT(*)::numeric FROM qualifying_runs
+  UNION ALL
+  SELECT 'spidey', COALESCE(MAX(full_rounds), 0)::numeric
+    FROM qualifying_runs WHERE slug = 'cindy'
+  UNION ALL
+  SELECT 'olympians', COALESCE(MIN(c.cnt), 0)::numeric
+  FROM (
+    SELECT COALESCE(COUNT(q.id), 0) AS cnt
+    FROM olympian_slugs o
+    LEFT JOIN qualifying_runs q ON q.slug = o.slug
+    GROUP BY o.slug
+  ) c
+  -- heroes / pantheoniste: same pattern on hero_slugs / pantheon_slugs
+)
+```
+
+### Seed rows
+
+`sort_order` 12–16; titles and thresholds exactly as the Epic Brief locked table. `icon_asset_url` NULL. Group `name_fr` / `name_en` match accordion titles; `description_fr` / `description_en` may mirror metric placeholders (UI prefers i18n).
+
+| `sort_order` | Slug | FR name | EN name | Thresholds |
+|---|---|---|---|---|
+| 12 | `circuit_runner` | Circuit runner | Circuit Runner | 1 / 5 / 15 / 40 / 100 |
+| 13 | `spidey` | L’Araignée | Spidey | 1 / 10 / 18 / 23 / 27 |
+| 14 | `olympians` | Au sommet de l’Olympe | Olympus Summit | 1 / 5 / 10 / 50 / 100 |
+| 15 | `heroes` | Le tour des Héros | Heroes’ Tour | 1 / 5 / 10 / 50 / 100 |
+| 16 | `pantheoniste` | Le Pantheoniste | Pantheoniste | 1 / 5 / 10 / 50 / 100 |
+
+Tier `title_fr` / `title_en`: see Epic Brief locked title table (25 rows).
+
+### Table Notes
+
+- **MIN with missing seeds:** implement as LEFT JOIN from a fixed slug-list CTE → `COALESCE(cnt,0)` → `MIN`. Observed-only `MIN` fails story 4 (Zeus×100 with Hades missing must stay 0).
+- **Spidey vs runner double-count:** one Cindy row in `qualifying_runs` feeds both branches — intentional (Epic story 17).
+- **Fingerprint:** not used for achievements. Cap/Rx forks mint `owner_id` rows and drop out of seed filters.
+- **Leftover:** unused in SQL tiers. `MAX(set_number) - 1` is enough for Spidey and the `fullRounds ≥ 1` gate.
+
+---
+
+## Component Architecture
+
+### Layer Overview
+
+```mermaid
+graph TD
+  SF[processSessionFinish] -->|rpc check_and_grant| RPC[check_and_grant_achievements]
+  RPC -->|UnlockedAchievement[]| Q[achievementUnlockQueueAtom]
+  RPC --> LSB[lastSessionBadgesAtom]
+  Q --> Overlay[AchievementUnlockOverlay]
+  LSB --> SessionBadges
+  Page[AchievementsPage] -->|rpc get_badge_status| Status[get_badge_status]
+  Status --> Accordion[AchievementAccordion]
+  Accordion --> Drawer[BadgeDetailDrawer]
+  Catalog[Circuit Catalog pages] -.->|no badge imports| X[out of scope]
+  Migrate[circuit_achievement_tracks.sql] --> RPC
+  Migrate --> Status
+  Retro[retroactive-badge-grant.sql] --> RPC
+```
+
+### New Files & Responsibilities
+
+| File | Purpose |
+|---|---|
+| `supabase/migrations/YYYYMMDDHHMMSS_circuit_achievement_tracks.sql` | Seed 5×5 + replace both RPCs with shared `qualifying_runs` + 5 new metric branches |
+| `src/locales/fr/achievements.json` | `groups`, `groupDescriptions`, `thresholdHint` for 5 slugs (metric placeholders OK) |
+| `src/locales/en/achievements.json` | idem |
+| `src/test/securityDefiner.arch.test.ts` | Extend: assert migration SQL contains the 5 `metric_type` literals, `owner_id IS NULL`, and fixed cast slug lists / LEFT JOIN pattern |
+| `src/lib/amrapScore.test.ts` | Pin fixtures that mirror the SQL contract (`fullRounds = max set_number - 1`, unfinished → null, `0` excluded from “qualifying”) |
+
+No new React components. No changes to `file:src/lib/syncService.ts` grant call (already fire-and-forget after session upsert). Post-migrate ops: run `file:scripts/retroactive-badge-grant.sql` (ticket AC).
+
+### Component Responsibilities
+
+**Migration RPC bodies**
+- Own all metric math; `qualifying_runs` + cast slug CTEs + five `UNION ALL` branches must be identical in `check_and_grant_achievements` and `get_badge_status`.
+- Auth guard unchanged (`auth.uid()` / `is_trusted_backend_caller()`).
+
+**i18n placeholders (shippable; copy may be rewritten later)**
+
+| Key | FR | EN |
+|---|---|---|
+| `groupDescriptions.circuit_runner` | Runs de circuits GymLogic (1+ tour) | GymLogic circuit runs (1+ round) |
+| `groupDescriptions.spidey` | Meilleur score Cindy en tours | Best Cindy score in rounds |
+| `groupDescriptions.olympians` | Min. de runs Zeus / Arès / Athéna / Hadès | Min. runs across Zeus / Ares / Athena / Hades |
+| `groupDescriptions.heroes` | Min. de runs Héraclès / Thésée / Atlas / Achille | Min. runs across Heracles / Theseus / Atlas / Achilles |
+| `groupDescriptions.pantheoniste` | Min. de runs sur les huit grecs | Min. runs across the eight Greek seeds |
+| `thresholdHint.circuit_runner` (pattern for all five) | Atteins {{target}} | Reach {{target}} |
+
+Also add `groups.{slug}` for completeness (unused by current accordion; names come from DB).
+
+**AchievementAccordion / Overlay / Drawer**
+- Unchanged code paths; new rows appear via RPC + i18n.
+
+**Circuit Catalog**
+- No badge imports, no chips — ADR 0018.
+
+### Failure Mode Analysis
+
+| Failure | Behavior |
+|---|---|
+| Grant RPC errors | Session finish still succeeds; warn log; Realtime / next finish retries (existing) |
+| User has only Zeus×100 | `olympians` / `pantheoniste` stay 0 until every cast seed has ≥ 1 qualifying run |
+| Cindy `26+15` | Spidey `current_value = 26`; platinum 23 unlocked; diamond locked |
+| TIME `0+0` / no set_logs | Row absent from `qualifying_runs`; no metric moves |
+| Circuit Fork GO snapshot | `owner_id` set → excluded |
+| Jetable AMRAP (`benchmark_circuit_id` NULL) | Excluded |
+| Missing i18n key | Raw key in UI — blocked by ticket AC |
+| Catalog pages | No change; no badge fetch |
+| Retroactive script after migrate | Grants rows silently; overlay does not flood (Realtime gate / no live session) |
+
+---
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_Benchmark_Circuit_achievement_tracks_#482.md`
+- ADR: `file:docs/adr/0019-circuit-achievement-cast-clearing-and-spidey.md`
+- Encyclopedia boundary: `file:docs/adr/0018-circuit-catalog-encyclopedia-under-library.md`
+- Precedent: `file:supabase/migrations/20260419120000_new_achievement_tracks.sql`, `file:docs/done/Tech_Plan_—_New_Achievement_Tracks_#218.md`
+- Current RPCs: `file:supabase/migrations/20260802170000_secure_definer_rpcs.sql`
+- Score contract: `file:src/lib/amrapScore.ts`
+- Grant path: `file:src/lib/syncService.ts`
+- Retroactive: `file:scripts/retroactive-badge-grant.sql`

--- a/docs/adr/0019-circuit-achievement-cast-clearing-and-spidey.md
+++ b/docs/adr/0019-circuit-achievement-cast-clearing-and-spidey.md
@@ -1,0 +1,43 @@
+# ADR 0019 — Circuit achievement Cast Clearing and Spidey rounds
+
+- **Status:** Accepted
+- **Date:** 2026-08-17
+- **Decided in:** grill for [#482](https://github.com/PierreTsia/workout-app/issues/482)
+
+## Context
+
+GymLogic ships nine **Benchmark Circuit** seeds (Cindy + eight Pantheon). Achievement groups already use one numeric `metric_type` per accordion row, granted by `check_and_grant_achievements` / `get_badge_status`. Collection-style tracks (touch every god) do not fit a naive “distinct count 1→4 maps to bronze→platinum” ladder: the third god is not harder than the first, and diamond must stay rare.
+
+Cindy already has a scored identity (`amrapScore` / history PB) and an editorial Holland `reference` of 27 rounds. Leftover reps live in ragged `set_logs`, not on `block_runs`. Badges must not appear on the **Circuit Catalog** encyclopedia (ADR 0018).
+
+## Decision
+
+We will:
+
+1. Define a **Circuit Achievement Run** as a finished **Block Run** on a GymLogic seed (`owner_id` NULL) with AMRAP `fullRounds ≥ 1`. TIME-empty closes, **Circuit Fork**s, and jetable Circuits do not count.
+2. Add five achievement groups (sort_order 12–16):
+   - `circuit_runner` — count of those runs (thresholds 1 / 5 / 15 / 40 / 100)
+   - `spidey` — Cindy PB in **full rounds only** (1 / 10 / 18 / 23 / 27); diamond equals Holland 27, not 28+; leftover does not cross tiers
+   - `olympians` / `heroes` / `pantheoniste` — **Cast Clearing** = `MIN` of per-seed run ledgers over hardcoded casts (4 Olympiens, 4 Héros, 8 Greeks). Thresholds 1 / 5 / 10 / 50 / 100. Surplus on one seed is advance, not waste.
+3. Keep accordion progress as the numeric metric only in v1 (no bottleneck-seed chrome).
+4. Grant retroactively on the next session finish via the existing RPC overlay path. No ship-date cutoff.
+5. Keep badge surfaces on `/achievements` + session unlock UI only — not under **Library** / **Circuit Catalog**.
+
+User-facing group titles (slug unchanged): *Circuit runner*, *L’Araignée* / *Spidey*, *Au sommet de l’Olympe* / *Olympus Summit*, *Le tour des Héros* / *Heroes’ Tour*, *Le Pantheoniste* / *Pantheoniste*. Tier titles and `groupDescriptions` copy land in the Epic Brief, not here.
+
+## Consequences
+
+- **Positive:** Collection grind is honest (no spam-Zeus diamond). Spidey and Cindy history share round identity without encoding leftover in SQL for tiers. Five ranks stay on every new group. Catalog stays encyclopedia.
+- **Negative:** Cast membership is a hardcoded slug list (same class of debt as editorial **Olympien** / **Héros**). Pantheoniste diamond is a very long grind (~800 runs). Accordion will not explain which seed is the bottleneck in v1.
+- **Follow-ups:** Epic Brief + Tech Plan for #482 (RPC CTE branches, seeds, i18n, titles). Optional later: bottleneck hint under collection progress. Product copy such as “3+ diamonds ⇒ transformed” is marketing, not a DB rule.
+
+## Alternatives considered
+
+| Option | Why we didn't pick it |
+|---|---|
+| Distinct 1/2/3/4 as bronze→platinum, no diamond | Makes the 3rd god “worth” gold; diamond nowhere to go |
+| Diamond = finish the cast once | Too easy for the top rank |
+| Collection metric = total runs / cast size | Allows diamond by repeating one seed |
+| Spidey diamond = 28+ or leftover-aware decimal score | Fights Holland `reference` 27; leftover complexity for no tier crossing |
+| Badge chips on `/library/circuits/:slug` | Violates ADR 0018 encyclopedia boundary |
+| Ship-date cutoff or silent backfill migration | Breaks the #218 retroactive grant contract |

--- a/scripts/retroactive-badge-grant.sql
+++ b/scripts/retroactive-badge-grant.sql
@@ -1,6 +1,10 @@
--- Run manually via Supabase SQL Editor AFTER deploying achievement migrations.
+-- #482 post-migrate runbook:
+-- After applying the #482 migration (circuit achievement tracks + RPC metrics),
+-- run this script once against the target DB (Supabase SQL Editor / service role).
 -- Idempotent: ON CONFLICT DO NOTHING inside the RPC means re-running is safe.
--- Badges are granted silently (no overlay) — they appear in the BadgeGrid on next load.
+-- Grants are silent user_achievements inserts — overlay is not required for
+-- catch-up (Realtime gate skips old grants). Optional: next session finish still
+-- runs check_and_grant for overlay of any remaining tiers.
 SELECT up.user_id, a.*
 FROM user_profiles up
 CROSS JOIN LATERAL check_and_grant_achievements(up.user_id) AS a;

--- a/src/lib/amrapScore.test.ts
+++ b/src/lib/amrapScore.test.ts
@@ -55,7 +55,35 @@ function makeCindyPlusLeftover(
 }
 
 describe("amrapScore", () => {
-  it("derives 27+3 and the leftover movement from a finished ragged last round", () => {
+  /**
+   * #482 RPC `qualifying_runs` must match `fullRounds = MAX(set_number) - 1`.
+   * Spidey / Circuit Achievement Run tiers key off fullRounds only; leftover is
+   * display/PB tie-break in history, not a SQL tier input. When two cells share
+   * the max set_number, leftover identity is max(logged_at) — SQL authors still
+   * only need MAX(set_number)-1 for the round count.
+   */
+  it("sets fullRounds to max(set_number) - 1 on a finished run", () => {
+    const cells = [
+      makeCell({ set_number: 1, reps_logged: "5", logged_at: "2026-08-15T10:00:00.000Z" }),
+      makeCell({ set_number: 2, reps_logged: "5", logged_at: "2026-08-15T10:01:00.000Z" }),
+      makeCell({
+        set_number: 5,
+        reps_logged: "12",
+        exercise_name: "sit-ups",
+        logged_at: "2026-08-15T10:04:00.000Z",
+      }),
+    ]
+
+    expect(
+      amrapScore({ finished_at: "2026-08-15T10:20:00.000Z" }, cells),
+    ).toEqual({
+      fullRounds: 4,
+      leftover: 12,
+      leftoverName: "sit-ups",
+    })
+  })
+
+  it("derives 27+3 Cindy shape; leftover does not change fullRounds for Spidey tiers", () => {
     const cells = makeCindyPlusLeftover(27, 3, "pompes")
 
     expect(
@@ -67,10 +95,56 @@ describe("amrapScore", () => {
     })
   })
 
-  it("returns no score when finished_at is missing (session finish without Terminer)", () => {
-    const cells = makeCindyPlusLeftover(14, 0)
+  it("returns null for an unfinished run (finished_at null)", () => {
+    const cells = [
+      makeCell({ set_number: 14, reps_logged: "10", logged_at: "2026-08-15T10:14:00.000Z" }),
+    ]
 
     expect(amrapScore({ finished_at: null }, cells)).toBeNull()
+  })
+
+  it("yields fullRounds 0 when the only leftover is set_number 1", () => {
+    const cells = [
+      makeCell({
+        set_number: 1,
+        reps_logged: "7",
+        exercise_name: "push-ups",
+        logged_at: "2026-08-15T10:00:00.000Z",
+      }),
+    ]
+
+    expect(
+      amrapScore({ finished_at: "2026-08-15T10:20:00.000Z" }, cells),
+    ).toEqual({
+      fullRounds: 0,
+      leftover: 7,
+      leftoverName: "push-ups",
+    })
+  })
+
+  it("picks the later logged_at when two leftover cells share max set_number", () => {
+    const cells = [
+      makeCell({
+        set_number: 3,
+        reps_logged: "5",
+        exercise_name: "push-ups",
+        logged_at: "2026-08-15T10:03:00.000Z",
+      }),
+      makeCell({
+        set_number: 3,
+        reps_logged: "9",
+        exercise_name: "sit-ups",
+        logged_at: "2026-08-15T10:03:30.000Z",
+      }),
+    ]
+
+    expect(
+      amrapScore({ finished_at: "2026-08-15T10:20:00.000Z" }, cells),
+    ).toEqual({
+      fullRounds: 2,
+      leftover: 9,
+      leftoverName: "sit-ups",
+    })
   })
 })
 

--- a/src/lib/syncService.test.ts
+++ b/src/lib/syncService.test.ts
@@ -795,6 +795,7 @@ describe("SyncService", () => {
 
       await drainQueue(USER_ID)
 
+      expect(mockRpc).toHaveBeenCalledTimes(1)
       expect(mockRpc).toHaveBeenCalledWith("check_and_grant_achievements", {
         p_user_id: USER_ID,
       })
@@ -803,12 +804,42 @@ describe("SyncService", () => {
     it("returns true even when achievement RPC fails", async () => {
       mockRpc.mockRejectedValueOnce(new Error("RPC failed"))
       vi.spyOn(console, "error").mockImplementation(() => {})
+      vi.spyOn(console, "warn").mockImplementation(() => {})
 
       enqueueSessionFinish(makeSessionFinishPayload())
 
       await drainQueue(USER_ID)
 
       expect(readQueue()).toHaveLength(0)
+      const statusCalls = mockStore.set.mock.calls
+        .filter(([atom]) => atom === SYNC_STATUS_ATOM)
+        .map(([, val]) => val)
+      expect(statusCalls).toContain("synced")
+      expect(statusCalls).not.toContain("failed")
+      expect(
+        mockStore.set.mock.calls.some(
+          ([atom]) => atom === LAST_SESSION_BADGES_ATOM,
+        ),
+      ).toBe(false)
+    })
+
+    it("treats achievement RPC error response as non-critical", async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: null,
+        error: { message: "RPC failed" },
+      })
+      vi.spyOn(console, "warn").mockImplementation(() => {})
+
+      enqueueSessionFinish(makeSessionFinishPayload())
+
+      await drainQueue(USER_ID)
+
+      expect(readQueue()).toHaveLength(0)
+      const statusCalls = mockStore.set.mock.calls
+        .filter(([atom]) => atom === SYNC_STATUS_ATOM)
+        .map(([, val]) => val)
+      expect(statusCalls).toContain("synced")
+      expect(statusCalls).not.toContain("failed")
     })
 
     it("pushes RPC response into achievement queue and lastSessionBadgesAtom", async () => {
@@ -831,12 +862,12 @@ describe("SyncService", () => {
       const queueSetCall = mockStore.set.mock.calls.find(
         ([atom]) => atom === ACHIEVEMENT_UNLOCK_QUEUE_ATOM,
       )
-      expect(queueSetCall).toBeDefined()
+      expect(queueSetCall?.[1]).toEqual(mockBadges)
 
       const badgesSetCall = mockStore.set.mock.calls.find(
         ([atom]) => atom === LAST_SESSION_BADGES_ATOM,
       )
-      expect(badgesSetCall).toBeDefined()
+      expect(badgesSetCall?.[1]).toEqual(mockBadges)
     })
 
     it("does not call RPC when session upsert fails", async () => {

--- a/src/locales/en/achievements.json
+++ b/src/locales/en/achievements.json
@@ -42,7 +42,12 @@
     "streak_king": "Streak King",
     "marathoner": "The Marathoner",
     "pr_streak": "PR Streak",
-    "early_bird": "Early Bird"
+    "early_bird": "Early Bird",
+    "circuit_runner": "Circuit Runner",
+    "spidey": "Spidey",
+    "olympians": "Olympus Summit",
+    "heroes": "Heroes' Tour",
+    "pantheoniste": "Pantheoniste"
   },
   "groupDescriptions": {
     "consistency_streak": "Total finished workout sessions",
@@ -55,7 +60,12 @@
     "streak_king": "Longest streak of consecutive weeks",
     "marathoner": "Sessions with total volume ≥ 5,000 kg",
     "pr_streak": "Longest streak of sessions with a PR",
-    "early_bird": "Sessions finished before 8 AM"
+    "early_bird": "Sessions finished before 8 AM",
+    "circuit_runner": "GymLogic circuit runs (1+ round)",
+    "spidey": "Best Cindy score in rounds",
+    "olympians": "Min. runs across Zeus / Ares / Athena / Hades",
+    "heroes": "Min. runs across Heracles / Theseus / Atlas / Achilles",
+    "pantheoniste": "Min. runs across the eight Greek seeds"
   },
   "thresholdHint": {
     "consistency_streak": "Complete {{target}} sessions",
@@ -68,6 +78,11 @@
     "streak_king": "Train {{target}} weeks in a row",
     "marathoner": "Complete {{target}} heavy sessions (≥ 5,000 kg)",
     "pr_streak": "Set PRs in {{target}} sessions in a row",
-    "early_bird": "Finish {{target}} sessions before 8 AM"
+    "early_bird": "Finish {{target}} sessions before 8 AM",
+    "circuit_runner": "Reach {{target}}",
+    "spidey": "Reach {{target}}",
+    "olympians": "Reach {{target}}",
+    "heroes": "Reach {{target}}",
+    "pantheoniste": "Reach {{target}}"
   }
 }

--- a/src/locales/fr/achievements.json
+++ b/src/locales/fr/achievements.json
@@ -42,7 +42,12 @@
     "streak_king": "Streak King",
     "marathoner": "Le Marathonien",
     "pr_streak": "Série de Records",
-    "early_bird": "Early Bird"
+    "early_bird": "Early Bird",
+    "circuit_runner": "Circuit runner",
+    "spidey": "L'Araignée",
+    "olympians": "Au sommet de l'Olympe",
+    "heroes": "Le tour des Héros",
+    "pantheoniste": "Le Pantheoniste"
   },
   "groupDescriptions": {
     "consistency_streak": "Nombre total de séances terminées",
@@ -55,7 +60,12 @@
     "streak_king": "Plus longue série de semaines consécutives",
     "marathoner": "Séances avec un volume total ≥ 5 000 kg",
     "pr_streak": "Plus longue série de séances avec au moins 1 PR",
-    "early_bird": "Séances terminées avant 8h"
+    "early_bird": "Séances terminées avant 8h",
+    "circuit_runner": "Runs de circuits GymLogic (1+ tour)",
+    "spidey": "Meilleur score Cindy en tours",
+    "olympians": "Min. de runs Zeus / Arès / Athéna / Hadès",
+    "heroes": "Min. de runs Héraclès / Thésée / Atlas / Achille",
+    "pantheoniste": "Min. de runs sur les huit grecs"
   },
   "thresholdHint": {
     "consistency_streak": "Terminer {{target}} séances",
@@ -68,6 +78,11 @@
     "streak_king": "S'entraîner {{target}} semaines d'affilée",
     "marathoner": "Compléter {{target}} séances lourdes (≥ 5 000 kg)",
     "pr_streak": "Battre des records dans {{target}} séances d'affilée",
-    "early_bird": "Terminer {{target}} séances avant 8h"
+    "early_bird": "Terminer {{target}} séances avant 8h",
+    "circuit_runner": "Atteins {{target}}",
+    "spidey": "Atteins {{target}}",
+    "olympians": "Atteins {{target}}",
+    "heroes": "Atteins {{target}}",
+    "pantheoniste": "Atteins {{target}}"
   }
 }

--- a/src/test/circuitAchievementTracks.arch.test.ts
+++ b/src/test/circuitAchievementTracks.arch.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest"
+import enAchievements from "@/locales/en/achievements.json"
+import frAchievements from "@/locales/fr/achievements.json"
+
+/**
+ * #482 / T209 oracle: the circuit achievement migration must seed five tracks
+ * and wire identical `qualifying_runs` + metric branches into both RPCs.
+ * T210 hardens catalog isolation; this file only pins the SQL/i18n contract.
+ */
+
+const migrationSources = import.meta.glob("../../supabase/migrations/*.sql", {
+  query: "?raw",
+  eager: true,
+  import: "default",
+}) as Record<string, string>
+
+const CIRCUIT_METRICS = [
+  "circuit_runner",
+  "spidey",
+  "olympians",
+  "heroes",
+  "pantheoniste",
+] as const
+
+const OLYMPIAN_SLUGS = ["zeus", "ares", "athena", "hades"] as const
+const HERO_SLUGS = ["heracles", "theseus", "atlas", "achilles"] as const
+
+const circuitMigrationEntry = Object.entries(migrationSources).find(([path]) =>
+  path.includes("circuit_achievement_tracks"),
+)
+
+const circuitSql = circuitMigrationEntry?.[1] ?? ""
+
+const extractFunctionBody = (sql: string, name: string): string => {
+  const head = new RegExp(
+    `CREATE\\s+OR\\s+REPLACE\\s+FUNCTION\\s+${name}\\s*\\(`,
+    "i",
+  )
+  const start = sql.search(head)
+  if (start === -1) return ""
+  const open = sql.indexOf("$$", start)
+  const close = sql.indexOf("$$", open + 2)
+  if (open === -1 || close === -1) return ""
+  return sql.slice(open + 2, close)
+}
+
+const extractNamedCte = (body: string, cteName: string): string => {
+  const marker = `${cteName} AS (`
+  const start = body.indexOf(marker)
+  if (start === -1) return ""
+  let depth = 0
+  let i = start + marker.length - 1
+  for (; i < body.length; i++) {
+    const ch = body[i]
+    if (ch === "(") depth += 1
+    else if (ch === ")") {
+      depth -= 1
+      if (depth === 0) return body.slice(start, i + 1)
+    }
+  }
+  return ""
+}
+
+const normalizeSql = (sql: string) =>
+  sql.replace(/--[^\n]*/g, "").replace(/\s+/g, " ").trim()
+
+describe("circuit achievement tracks migration (#482 / T209)", () => {
+  it("ships a circuit_achievement_tracks migration file", () => {
+    expect(circuitMigrationEntry).toBeDefined()
+  })
+
+  it("seeds all five metric_type literals and Cast Clearing slug lists", () => {
+    expect(circuitSql).toContain("owner_id IS NULL")
+    expect(circuitSql).toContain("qualifying_runs")
+    expect(
+      CIRCUIT_METRICS.every((metric) => circuitSql.includes(`'${metric}'`)),
+    ).toBe(true)
+    expect(
+      [...OLYMPIAN_SLUGS, ...HERO_SLUGS].every((slug) =>
+        circuitSql.includes(`'${slug}'`),
+      ),
+    ).toBe(true)
+    expect(circuitSql).toMatch(/LEFT\s+JOIN\s+qualifying_runs/i)
+  })
+
+  it("keeps qualifying_runs + circuit metrics identical in both RPCs", () => {
+    const grantBody = extractFunctionBody(
+      circuitSql,
+      "check_and_grant_achievements",
+    )
+    const statusBody = extractFunctionBody(circuitSql, "get_badge_status")
+
+    expect(grantBody.length).toBeGreaterThan(0)
+    expect(statusBody.length).toBeGreaterThan(0)
+
+    const grantRuns = extractNamedCte(grantBody, "qualifying_runs")
+    const statusRuns = extractNamedCte(statusBody, "qualifying_runs")
+    expect(normalizeSql(grantRuns)).toBe(normalizeSql(statusRuns))
+    expect(normalizeSql(grantRuns)).toContain("MAX(sl.set_number) - 1")
+    expect(normalizeSql(grantRuns)).toContain("owner_id IS NULL")
+
+    expect(
+      CIRCUIT_METRICS.every(
+        (metric) =>
+          grantBody.includes(`'${metric}'`) &&
+          statusBody.includes(`'${metric}'`),
+      ),
+    ).toBe(true)
+  })
+})
+
+describe("circuit achievement i18n (#482 / T209)", () => {
+  it("exposes groups, groupDescriptions, and thresholdHint for all five slugs", () => {
+    const missing = CIRCUIT_METRICS.flatMap((slug) =>
+      (
+        [
+          ["en.groups", enAchievements.groups],
+          ["fr.groups", frAchievements.groups],
+          ["en.groupDescriptions", enAchievements.groupDescriptions],
+          ["fr.groupDescriptions", frAchievements.groupDescriptions],
+          ["en.thresholdHint", enAchievements.thresholdHint],
+          ["fr.thresholdHint", frAchievements.thresholdHint],
+        ] as const
+      )
+        .filter(([, bag]) => !(slug in bag))
+        .map(([label]) => `${label}.${slug}`),
+    )
+
+    expect(missing).toEqual([])
+  })
+})

--- a/src/test/circuitAchievementTracks.arch.test.ts
+++ b/src/test/circuitAchievementTracks.arch.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest"
 import enAchievements from "@/locales/en/achievements.json"
 import frAchievements from "@/locales/fr/achievements.json"
+import { importsOf } from "./imports"
 
 /**
- * #482 / T209 oracle: the circuit achievement migration must seed five tracks
- * and wire identical `qualifying_runs` + metric branches into both RPCs.
- * T210 hardens catalog isolation; this file only pins the SQL/i18n contract.
+ * #482 / T209–T210: migration SQL + i18n contract (T209) and Circuit Catalog
+ * isolation from badge chrome (T210 / ADR 0018).
  */
 
 const migrationSources = import.meta.glob("../../supabase/migrations/*.sql", {
@@ -70,7 +70,9 @@ describe("circuit achievement tracks migration (#482 / T209)", () => {
   })
 
   it("seeds all five metric_type literals and Cast Clearing slug lists", () => {
-    expect(circuitSql).toContain("owner_id IS NULL")
+    expect(normalizeSql(circuitSql)).toMatch(
+      /JOIN\s+benchmark_circuits\s+\w+\s+ON[\s\S]*?owner_id\s+IS\s+NULL/i,
+    )
     expect(circuitSql).toContain("qualifying_runs")
     expect(
       CIRCUIT_METRICS.every((metric) => circuitSql.includes(`'${metric}'`)),
@@ -80,7 +82,15 @@ describe("circuit achievement tracks migration (#482 / T209)", () => {
         circuitSql.includes(`'${slug}'`),
       ),
     ).toBe(true)
-    expect(circuitSql).toMatch(/LEFT\s+JOIN\s+qualifying_runs/i)
+    expect(circuitSql).toMatch(
+      /unnest\s*\(\s*ARRAY\s*\[\s*'zeus'\s*,\s*'ares'\s*,\s*'athena'\s*,\s*'hades'\s*\]\s*\)/i,
+    )
+    expect(circuitSql).toMatch(
+      /unnest\s*\(\s*ARRAY\s*\[\s*'heracles'\s*,\s*'theseus'\s*,\s*'atlas'\s*,\s*'achilles'\s*\]\s*\)/i,
+    )
+    expect(circuitSql).toMatch(
+      /LEFT\s+JOIN\s+qualifying_runs\s+\w+\s+ON\s+\w+\.slug\s*=/i,
+    )
   })
 
   it("keeps qualifying_runs + circuit metrics identical in both RPCs", () => {
@@ -127,5 +137,49 @@ describe("circuit achievement i18n (#482 / T209)", () => {
     )
 
     expect(missing).toEqual([])
+  })
+})
+
+/**
+ * ADR 0018: Circuit Catalog is encyclopedia under Library — no badge chrome.
+ * Badge status / overlay / session badges stay on /achievements and session UI.
+ */
+const catalogCircuitSources = import.meta.glob(
+  [
+    "../pages/library/CircuitCatalog*.tsx",
+    "../components/library/Circuit*.tsx",
+  ],
+  {
+    query: "?raw",
+    eager: true,
+    import: "default",
+  },
+) as Record<string, string>
+
+const CATALOG_BADGE_FORBIDDEN = [
+  "useBadgeStatus",
+  "SessionBadges",
+  "AchievementUnlockOverlay",
+  "lastSessionBadgesAtom",
+  "achievementUnlockQueueAtom",
+] as const
+
+const badgeChromeImports = (source: string): string[] =>
+  CATALOG_BADGE_FORBIDDEN.flatMap((token) => {
+    const fromSpecifier = importsOf(source, token)
+    if (fromSpecifier.length > 0) return fromSpecifier
+    return new RegExp(`\\b${token}\\b`).test(source) ? [token] : []
+  })
+
+describe("circuit catalog isolation (#482 / T210 / ADR 0018)", () => {
+  it("does not import badge status, overlay, or achievement atoms", () => {
+    const offenders = Object.entries(catalogCircuitSources)
+      .filter(([path]) => !/\.test\.tsx?$/.test(path))
+      .flatMap(([path, source]) =>
+        badgeChromeImports(source).map((hit) => `${path}: ${hit}`),
+      )
+      .sort()
+
+    expect(offenders).toEqual([])
   })
 })

--- a/src/test/securityDefiner.arch.test.ts
+++ b/src/test/securityDefiner.arch.test.ts
@@ -291,3 +291,86 @@ describe("SECURITY DEFINER functions", () => {
     expect(stale).toEqual([])
   })
 })
+
+/**
+ * #482 / T210: the circuit achievement migration must keep the five metric
+ * branches, seed-only join (`owner_id IS NULL`), Cast Clearing slug lists, and
+ * the LEFT JOIN / unnest pattern that yields 0 when a seed is missing.
+ * Auth-guard coverage for both RPCs stays in the suite above (last-wins).
+ */
+const CIRCUIT_ACHIEVEMENT_METRICS = [
+  "circuit_runner",
+  "spidey",
+  "olympians",
+  "heroes",
+  "pantheoniste",
+] as const
+
+const CAST_CLEARING_SLUGS = [
+  "zeus",
+  "ares",
+  "athena",
+  "hades",
+  "heracles",
+  "theseus",
+  "atlas",
+  "achilles",
+] as const
+
+const circuitAchievementMigration = Object.entries(migrationSources).find(
+  ([path]) => path.includes("circuit_achievement_tracks"),
+)
+
+const circuitAchievementSql = circuitAchievementMigration?.[1] ?? ""
+
+describe("circuit achievement tracks migration (#482 / T210)", () => {
+  it("ships the circuit_achievement_tracks migration", () => {
+    expect(circuitAchievementMigration).toBeDefined()
+  })
+
+  it("keeps both achievement RPCs on the SECURITY DEFINER roster", () => {
+    expect(SECURITY_DEFINER_FUNCTIONS).toEqual(
+      expect.arrayContaining([
+        "check_and_grant_achievements",
+        "get_badge_status",
+      ]),
+    )
+  })
+
+  it("pins the five circuit metric_type literals", () => {
+    const missing = CIRCUIT_ACHIEVEMENT_METRICS.filter(
+      (metric) => !circuitAchievementSql.includes(`'${metric}'`),
+    )
+
+    expect(missing).toEqual([])
+  })
+
+  it("keeps the seed-only owner_id IS NULL guard on the circuit join path", () => {
+    const sql = stripComments(circuitAchievementSql)
+    const seedJoins = [
+      ...sql.matchAll(
+        /JOIN\s+benchmark_circuits\s+\w+\s+ON[\s\S]*?owner_id\s+IS\s+NULL/gi,
+      ),
+    ]
+
+    // Both check_and_grant_achievements and get_badge_status must keep the guard.
+    expect(seedJoins).toHaveLength(2)
+  })
+
+  it("pins Cast Clearing fixed slugs and the LEFT JOIN / unnest pattern", () => {
+    const missingSlugs = CAST_CLEARING_SLUGS.filter(
+      (slug) => !circuitAchievementSql.includes(`'${slug}'`),
+    )
+
+    expect(missingSlugs).toEqual([])
+    expect(circuitAchievementSql).toMatch(
+      /unnest\s*\(\s*ARRAY\s*\[\s*'zeus'\s*,\s*'ares'\s*,\s*'athena'\s*,\s*'hades'\s*\]\s*\)/i,
+    )
+    expect(circuitAchievementSql).toMatch(
+      /unnest\s*\(\s*ARRAY\s*\[\s*'heracles'\s*,\s*'theseus'\s*,\s*'atlas'\s*,\s*'achilles'\s*\]\s*\)/i,
+    )
+    expect(circuitAchievementSql).toMatch(
+      /LEFT\s+JOIN\s+qualifying_runs\s+\w+\s+ON\s+\w+\.slug\s*=/i,
+    )
+  })
+})

--- a/supabase/migrations/20260817120000_circuit_achievement_tracks.sql
+++ b/supabase/migrations/20260817120000_circuit_achievement_tracks.sql
@@ -1,0 +1,522 @@
+-- =============================================================
+-- Circuit Achievement Tracks (#482 / T209)
+-- 5 new groups (circuit_runner, spidey, olympians, heroes,
+-- pantheoniste) with 25 tiers (sort_order 12–16).
+-- Replaces both achievement RPCs with shared qualifying_runs CTE
+-- + 5 metric branches (16 total). Auth guards unchanged.
+-- =============================================================
+
+-- 1. Seed new achievement groups
+INSERT INTO achievement_groups (slug, name_fr, name_en, description_fr, description_en, metric_type, sort_order)
+VALUES
+  ('circuit_runner', 'Circuit runner',        'Circuit Runner',  'Runs de circuits GymLogic (1+ tour)',              'GymLogic circuit runs (1+ round)',                         'circuit_runner', 12),
+  ('spidey',         'L''Araignée',            'Spidey',          'Meilleur score Cindy en tours',                   'Best Cindy score in rounds',                               'spidey',         13),
+  ('olympians',      'Au sommet de l''Olympe', 'Olympus Summit',  'Min. de runs Zeus / Arès / Athéna / Hadès',       'Min. runs across Zeus / Ares / Athena / Hades',            'olympians',      14),
+  ('heroes',         'Le tour des Héros',      'Heroes'' Tour',   'Min. de runs Héraclès / Thésée / Atlas / Achille','Min. runs across Heracles / Theseus / Atlas / Achilles',   'heroes',         15),
+  ('pantheoniste',   'Le Pantheoniste',        'Pantheoniste',    'Min. de runs sur les huit grecs',                 'Min. runs across the eight Greek seeds',                   'pantheoniste',   16);
+
+-- 2. Seed new achievement tiers (5 ranks × 5 groups = 25). icon_asset_url NULL.
+
+-- Circuit runner
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'circuit_runner')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Premier tour',       'First Lap',       1),
+  ((SELECT id FROM g), 2, 'silver',   'En rythme',          'In Cadence',      5),
+  ((SELECT id FROM g), 3, 'gold',     'Sans relâche',       'No Break',        15),
+  ((SELECT id FROM g), 4, 'platinum', 'Workout machine',    'Workout Machine', 40),
+  ((SELECT id FROM g), 5, 'diamond',  'Star des circuits',  'Circuit Star',    100);
+
+-- Spidey (L'Araignée) — full rounds only; diamond = Holland 27
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'spidey')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Baby Spidey',              'Baby Spidey',       1),
+  ((SELECT id FROM g), 2, 'silver',   'Side-kick',                'Sidekick',          10),
+  ((SELECT id FROM g), 3, 'gold',     'Araignée du quotidien',    'Everyday Spidey',   18),
+  ((SELECT id FROM g), 4, 'platinum', 'Au bord du 27',            'Edge of 27',        23),
+  ((SELECT id FROM g), 5, 'diamond',  'À la table de Holland',    'Holland''s Table',  27);
+
+-- Olympians (Au sommet de l'Olympe)
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'olympians')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Selfie avec Zeus',   'Zeus Selfie',     1),
+  ((SELECT id FROM g), 2, 'silver',   'Nectar gratis',      'Free Nectar',     5),
+  ((SELECT id FROM g), 3, 'gold',     'Banquet divin',      'Divine Banquet',  10),
+  ((SELECT id FROM g), 4, 'platinum', 'VIP Olympe',         'Olympus VIP',     50),
+  ((SELECT id FROM g), 5, 'diamond',  'PDG de l''Olympe',   'Olympus CEO',     100);
+
+-- Heroes (Le tour des Héros)
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'heroes')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Stage chez Héraclès',       'Intern for Heracles',      1),
+  ((SELECT id FROM g), 2, 'silver',   'GPS de Thésée',             'Theseus GPS',              5),
+  ((SELECT id FROM g), 3, 'gold',     'Atlas porte tes courses',   'Atlas Holds Your Bags',    10),
+  ((SELECT id FROM g), 4, 'platinum', 'Achille sans talon',        'Achilles, No Heel',        50),
+  ((SELECT id FROM g), 5, 'diamond',  'DRH des héros',             'Heroes'' HR',              100);
+
+-- Pantheoniste
+WITH g AS (SELECT id FROM achievement_groups WHERE slug = 'pantheoniste')
+INSERT INTO achievement_tiers (group_id, tier_level, rank, title_fr, title_en, threshold_value)
+VALUES
+  ((SELECT id FROM g), 1, 'bronze',   'Badge d''entrée',              'Pantheon Guest Pass',   1),
+  ((SELECT id FROM g), 2, 'silver',   'Collectionneur de statues',    'Statue Collector',      5),
+  ((SELECT id FROM g), 3, 'gold',     'Guide du musée grec',          'Greek Museum Guide',    10),
+  ((SELECT id FROM g), 4, 'platinum', 'Conservateur du temple',       'Temple Curator',        50),
+  ((SELECT id FROM g), 5, 'diamond',  'Le 9e du Panthéon',            'Ninth of the Pantheon', 100);
+
+
+-- 3. Replace check_and_grant_achievements
+-- Body from 20260802170000_secure_definer_rpcs.sql + qualifying_runs + 5 branches.
+
+CREATE OR REPLACE FUNCTION check_and_grant_achievements(p_user_id uuid)
+RETURNS TABLE (
+  tier_id uuid, group_slug text, rank text,
+  title_en text, title_fr text, icon_asset_url text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+BEGIN
+  IF NOT (
+    COALESCE(auth.uid() = p_user_id, false)
+    OR is_trusted_backend_caller()
+  ) THEN
+    RAISE EXCEPTION 'access denied: cannot grant achievements for another user'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_sessions AS (
+    SELECT s.id, s.workout_day_id, s.finished_at
+    FROM sessions s
+    WHERE s.user_id = p_user_id AND s.finished_at IS NOT NULL
+  ),
+  -- Circuit Achievement Run: GO snapshot FK → seed (owner_id IS NULL),
+  -- finished_at set, full_rounds = MAX(set_number)-1 >= 1 (amrapScore oracle).
+  qualifying_runs AS (
+    SELECT br.id, br.session_id, bc.slug,
+           (MAX(sl.set_number) - 1) AS full_rounds
+    FROM block_runs br
+    JOIN sessions s ON s.id = br.session_id AND s.user_id = p_user_id
+    JOIN benchmark_circuits bc ON bc.id = br.benchmark_circuit_id
+      AND bc.owner_id IS NULL
+    JOIN block_exercises be ON be.block_id = br.block_id
+    JOIN set_logs sl ON sl.session_id = br.session_id
+      AND sl.block_exercise_id = be.id
+    WHERE br.finished_at IS NOT NULL
+    GROUP BY br.id, br.session_id, bc.slug
+    HAVING (MAX(sl.set_number) - 1) >= 1
+  ),
+  olympian_slugs AS (
+    SELECT unnest(ARRAY['zeus','ares','athena','hades']) AS slug
+  ),
+  hero_slugs AS (
+    SELECT unnest(ARRAY['heracles','theseus','atlas','achilles']) AS slug
+  ),
+  pantheon_slugs AS (
+    SELECT slug FROM olympian_slugs
+    UNION ALL
+    SELECT slug FROM hero_slugs
+  ),
+  metrics AS (
+    SELECT 'session_count' AS metric_type, COUNT(*)::numeric AS value
+      FROM user_sessions
+
+    UNION ALL
+    SELECT 'total_volume_kg',
+           COALESCE(SUM(sl.weight_logged * sl.reps_logged::int), 0)
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.reps_logged IS NOT NULL
+        AND sl.reps_logged ~ '^\d+$'
+
+    UNION ALL
+    SELECT 'pr_count', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.was_pr = true
+
+    UNION ALL
+    SELECT 'unique_exercises', COUNT(DISTINCT sl.exercise_id)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+
+    UNION ALL
+    SELECT 'active_weeks', COUNT(*)::numeric
+      FROM (
+        SELECT date_trunc('week', us.finished_at) AS wk
+        FROM user_sessions us
+        GROUP BY date_trunc('week', us.finished_at)
+        HAVING COUNT(*) >= 3
+      ) AS weeks_with_3plus
+
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN workout_days wd ON wd.id = us.workout_day_id
+      LEFT JOIN programs p ON p.id = wd.program_id
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) AS day_count
+        FROM workout_days wd2
+        WHERE wd2.program_id = p.id
+      ) dc ON true
+      WHERE wd.program_id IS NULL
+         OR (p.template_id IS NULL AND dc.day_count = 1)
+
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
+
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
+          FROM (
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at, us.id) AS session_ord,
+                   (prs.session_id IS NOT NULL) AS has_pr
+            FROM user_sessions us
+            LEFT JOIN (
+              SELECT DISTINCT sl.session_id
+              FROM set_logs sl
+              WHERE sl.was_pr = true
+            ) prs ON prs.session_id = us.id
+          ) all_sessions
+          WHERE has_pr
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) BETWEEN 5 AND 7
+
+    -- === CIRCUIT TRACKS (#482) ===
+
+    UNION ALL
+    SELECT 'circuit_runner', COUNT(*)::numeric
+      FROM qualifying_runs
+
+    UNION ALL
+    SELECT 'spidey', COALESCE(MAX(full_rounds), 0)::numeric
+      FROM qualifying_runs
+      WHERE slug = 'cindy'
+
+    -- Cast Clearing: LEFT JOIN fixed slug lists so a missing seed (e.g. Hades)
+    -- yields cnt 0; MIN stays 0. Never MIN over observed-only rows.
+    UNION ALL
+    SELECT 'olympians', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM olympian_slugs o
+        LEFT JOIN qualifying_runs q ON q.slug = o.slug
+        GROUP BY o.slug
+      ) c
+
+    UNION ALL
+    SELECT 'heroes', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM hero_slugs h
+        LEFT JOIN qualifying_runs q ON q.slug = h.slug
+        GROUP BY h.slug
+      ) c
+
+    UNION ALL
+    SELECT 'pantheoniste', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM pantheon_slugs p
+        LEFT JOIN qualifying_runs q ON q.slug = p.slug
+        GROUP BY p.slug
+      ) c
+  ),
+  eligible AS (
+    SELECT at.id, ag.slug, at.rank AS r,
+           at.title_en, at.title_fr, at.icon_asset_url
+    FROM metrics m
+    JOIN achievement_groups ag ON ag.metric_type = m.metric_type
+    JOIN achievement_tiers at ON at.group_id = ag.id
+    WHERE at.threshold_value <= m.value
+      AND NOT EXISTS (
+        SELECT 1 FROM user_achievements ua
+        WHERE ua.user_id = p_user_id AND ua.tier_id = at.id
+      )
+  ),
+  granted AS (
+    INSERT INTO user_achievements (user_id, tier_id)
+    SELECT p_user_id, e.id FROM eligible e
+    ON CONFLICT (user_id, tier_id) DO NOTHING
+    RETURNING user_achievements.tier_id
+  )
+  SELECT e.id, e.slug, e.r, e.title_en, e.title_fr, e.icon_asset_url
+  FROM eligible e
+  JOIN granted g ON g.tier_id = e.id;
+END;
+$$;
+
+
+-- 4. Replace get_badge_status (identical qualifying_runs + metrics CTE)
+
+CREATE OR REPLACE FUNCTION get_badge_status(p_user_id uuid)
+RETURNS TABLE (
+  group_id uuid, group_slug text, group_name_en text, group_name_fr text,
+  tier_id uuid, tier_level int, rank text,
+  title_en text, title_fr text,
+  threshold_value numeric, icon_asset_url text,
+  is_unlocked boolean, granted_at timestamptz,
+  current_value numeric, progress_pct numeric
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+BEGIN
+  IF NOT (
+    COALESCE(auth.uid() = p_user_id, false)
+    OR is_trusted_backend_caller()
+  ) THEN
+    RAISE EXCEPTION 'access denied: cannot read badge status for another user'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_sessions AS (
+    SELECT s.id, s.workout_day_id, s.finished_at
+    FROM sessions s
+    WHERE s.user_id = p_user_id AND s.finished_at IS NOT NULL
+  ),
+  -- Circuit Achievement Run: GO snapshot FK → seed (owner_id IS NULL),
+  -- finished_at set, full_rounds = MAX(set_number)-1 >= 1 (amrapScore oracle).
+  qualifying_runs AS (
+    SELECT br.id, br.session_id, bc.slug,
+           (MAX(sl.set_number) - 1) AS full_rounds
+    FROM block_runs br
+    JOIN sessions s ON s.id = br.session_id AND s.user_id = p_user_id
+    JOIN benchmark_circuits bc ON bc.id = br.benchmark_circuit_id
+      AND bc.owner_id IS NULL
+    JOIN block_exercises be ON be.block_id = br.block_id
+    JOIN set_logs sl ON sl.session_id = br.session_id
+      AND sl.block_exercise_id = be.id
+    WHERE br.finished_at IS NOT NULL
+    GROUP BY br.id, br.session_id, bc.slug
+    HAVING (MAX(sl.set_number) - 1) >= 1
+  ),
+  olympian_slugs AS (
+    SELECT unnest(ARRAY['zeus','ares','athena','hades']) AS slug
+  ),
+  hero_slugs AS (
+    SELECT unnest(ARRAY['heracles','theseus','atlas','achilles']) AS slug
+  ),
+  pantheon_slugs AS (
+    SELECT slug FROM olympian_slugs
+    UNION ALL
+    SELECT slug FROM hero_slugs
+  ),
+  metrics AS (
+    SELECT 'session_count' AS metric_type, COUNT(*)::numeric AS value
+      FROM user_sessions
+
+    UNION ALL
+    SELECT 'total_volume_kg',
+           COALESCE(SUM(sl.weight_logged * sl.reps_logged::int), 0)
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.reps_logged IS NOT NULL
+        AND sl.reps_logged ~ '^\d+$'
+
+    UNION ALL
+    SELECT 'pr_count', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.was_pr = true
+
+    UNION ALL
+    SELECT 'unique_exercises', COUNT(DISTINCT sl.exercise_id)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+
+    UNION ALL
+    SELECT 'active_weeks', COUNT(*)::numeric
+      FROM (
+        SELECT date_trunc('week', us.finished_at) AS wk
+        FROM user_sessions us
+        GROUP BY date_trunc('week', us.finished_at)
+        HAVING COUNT(*) >= 3
+      ) AS weeks_with_3plus
+
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN workout_days wd ON wd.id = us.workout_day_id
+      LEFT JOIN programs p ON p.id = wd.program_id
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) AS day_count
+        FROM workout_days wd2
+        WHERE wd2.program_id = p.id
+      ) dc ON true
+      WHERE wd.program_id IS NULL
+         OR (p.template_id IS NULL AND dc.day_count = 1)
+
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
+
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
+          FROM (
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at, us.id) AS session_ord,
+                   (prs.session_id IS NOT NULL) AS has_pr
+            FROM user_sessions us
+            LEFT JOIN (
+              SELECT DISTINCT sl.session_id
+              FROM set_logs sl
+              WHERE sl.was_pr = true
+            ) prs ON prs.session_id = us.id
+          ) all_sessions
+          WHERE has_pr
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) BETWEEN 5 AND 7
+
+    -- === CIRCUIT TRACKS (#482) ===
+
+    UNION ALL
+    SELECT 'circuit_runner', COUNT(*)::numeric
+      FROM qualifying_runs
+
+    UNION ALL
+    SELECT 'spidey', COALESCE(MAX(full_rounds), 0)::numeric
+      FROM qualifying_runs
+      WHERE slug = 'cindy'
+
+    -- Cast Clearing: LEFT JOIN fixed slug lists so a missing seed (e.g. Hades)
+    -- yields cnt 0; MIN stays 0. Never MIN over observed-only rows.
+    UNION ALL
+    SELECT 'olympians', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM olympian_slugs o
+        LEFT JOIN qualifying_runs q ON q.slug = o.slug
+        GROUP BY o.slug
+      ) c
+
+    UNION ALL
+    SELECT 'heroes', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM hero_slugs h
+        LEFT JOIN qualifying_runs q ON q.slug = h.slug
+        GROUP BY h.slug
+      ) c
+
+    UNION ALL
+    SELECT 'pantheoniste', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM pantheon_slugs p
+        LEFT JOIN qualifying_runs q ON q.slug = p.slug
+        GROUP BY p.slug
+      ) c
+  )
+  SELECT
+    ag.id, ag.slug, ag.name_en, ag.name_fr,
+    at.id, at.tier_level, at.rank,
+    at.title_en, at.title_fr,
+    at.threshold_value, at.icon_asset_url,
+    (ua.id IS NOT NULL), ua.granted_at,
+    COALESCE(m.value, 0),
+    LEAST(COALESCE(m.value, 0) / NULLIF(at.threshold_value, 0) * 100, 100)
+  FROM achievement_groups ag
+  JOIN achievement_tiers at ON at.group_id = ag.id
+  LEFT JOIN user_achievements ua ON ua.tier_id = at.id AND ua.user_id = p_user_id
+  LEFT JOIN metrics m ON m.metric_type = ag.metric_type
+  ORDER BY ag.sort_order, at.tier_level;
+END;
+$$;


### PR DESCRIPTION
## What

- **Five new circuit achievement groups**: circuit_runner, spidey, olympians, heroes, pantheoniste with bronze/silver/gold/diamond tiers
- **Shared qualifying_runs CTE**: Unifies circuit metrics computation across all achievement tracks via RPC extension
- **Migration with i18n seeds**: Database schema changes + French/English achievement translations  
- **Retroactive grant capability**: Badge status syncing for existing workout history via enhanced RPCs

## Why

Issue #482 requests circuit-specific achievements to gamify workout completion and provide milestone recognition. The existing achievement system lacked circuit-focused tracks, and implementing them individually would create metric computation duplication and maintenance overhead.

## How

- **ADR 0019 Architecture**: Cast Clearing MIN pattern + Spidey diamond tier at 27 full rounds
- **SQL Migration 20260817120000**: Seeds achievement groups/tiers, extends check_and_grant_achievements and get_badge_status with qualifying_runs CTE for unified circuit metrics
- **Test Coverage**: Architecture guards prevent badge chrome in Circuit Catalog + syncService grant path tests + amrapScore pinning to prevent SQL oracle drift
- **HITL Validation**: T212 manual verification passed (see issue #482 comments)

**Note**: icon_asset_url intentionally NULL pending asset pipeline completion (handled separately)

Closes #482

Made with [Cursor](https://cursor.com)