### PR TITLE
Allow deleting a trained program day without wiping history

### DIFF
--- a/skills/gymlogic-mcp/SKILL.md
+++ b/skills/gymlogic-mcp/SKILL.md
@@ -465,7 +465,7 @@ Always `dry_run: true` first. The preview returns:
 - `removed_days[]`: every day that would be deleted (with `session_count` and `blocking` flag)
 - `added_days[]`: every new day that would be inserted
 - `warnings[]`: includes the active-cycle warning (`"Cycle actif depuis YYYY-MM-DD — ..."`) when applicable
-- `errors[]`: blocking issues (e.g. trying to delete a day with logged sessions)
+- `errors[]`: validation / apply failures (empty when the patch is well-formed)
 
 **Discovery prerequisite for any non-rename edit**: `list_programs` → `get_program_details(program_id)` to read every current day's `id`, label, and exercise prescription. The `*(exercise_id: <uuid>)*` annotation on every exercise line in `get_program_details` (since v0.4.0) is the catalog id you reuse in your patch — not the row's slot id.
 
@@ -586,7 +586,7 @@ update_program({
 
 When the dry_run preview's `removed_days[]` is non-empty, applying needs **both** `dry_run: false` AND `confirm: true`. Without `confirm`, the server returns: *"Patch removes N day(s): … Pass `confirm: true` along with `dry_run: false` to apply, or revise the payload to keep these days."*
 
-Days with logged sessions are **always** blocked, even with `confirm: true` — the response surfaces an `errors[]` entry: *"Cannot remove day 'X' — it has N logged sessions. Rename or repurpose it instead, or remove the corresponding entries from the patch and resubmit."* The user has to decide between renaming (keep history) or doing it manually in-app.
+Removing a day with logged sessions is allowed. Those sessions are **detached** from the template (`sessions.workout_day_id` SET NULL) — history stays (label snapshot + set logs). `removed_days[].session_count` tells you how many sessions will be detached; `blocking` stays `false`. `confirm: true` is still required.
 
 **Mid-cycle awareness**:
 

--- a/src/lib/syncService.test.ts
+++ b/src/lib/syncService.test.ts
@@ -466,6 +466,32 @@ describe("SyncService", () => {
       expect(readQueue()).toHaveLength(0)
     })
 
+    it("retries set_log upsert without slot FKs when the template row is gone", async () => {
+      enqueueSetLog(makeSetLogPayload({ workoutExerciseId: "we-gone" }))
+      let upserts = 0
+      setLogsChain.then.mockImplementation((resolve: (v: unknown) => void) => {
+        upserts += 1
+        if (upserts === 1) {
+          return resolve({
+            data: null,
+            error: { code: "23503", message: "fk" },
+          })
+        }
+        return resolve({ data: null, error: null })
+      })
+
+      await drainQueue(USER_ID)
+
+      expect(setLogsChain.upsert.mock.calls.length).toBeGreaterThanOrEqual(2)
+      expect(
+        setLogsChain.upsert.mock.calls.some(
+          ([row]) =>
+            row.workout_exercise_id === null && row.block_exercise_id === null,
+        ),
+      ).toBe(true)
+      expect(readQueue()).toHaveLength(0)
+    })
+
     it("keeps failed item in queue and sets syncStatus to failed on partial failure", async () => {
       enqueueSetLog(makeSetLogPayload({ setNumber: 1, loggedAt: 1000 }))
       enqueueSetLog(makeSetLogPayload({ setNumber: 2, loggedAt: 2000 }))

--- a/src/lib/syncService.test.ts
+++ b/src/lib/syncService.test.ts
@@ -441,6 +441,31 @@ describe("SyncService", () => {
       )
     })
 
+    it("retries session upsert without workout_day_id when the day row is gone", async () => {
+      enqueueSessionFinish(makeSessionFinishPayload())
+      let upserts = 0
+      sessionsChain.then.mockImplementation((resolve: (v: unknown) => void) => {
+        upserts += 1
+        if (upserts === 1) {
+          return resolve({
+            data: null,
+            error: { code: "23503", message: "fk" },
+          })
+        }
+        return resolve({ data: null, error: null })
+      })
+
+      await drainQueue(USER_ID)
+
+      expect(sessionsChain.upsert.mock.calls.length).toBeGreaterThanOrEqual(2)
+      expect(
+        sessionsChain.upsert.mock.calls.some(
+          ([row]) => row.workout_day_id === null,
+        ),
+      ).toBe(true)
+      expect(readQueue()).toHaveLength(0)
+    })
+
     it("keeps failed item in queue and sets syncStatus to failed on partial failure", async () => {
       enqueueSetLog(makeSetLogPayload({ setNumber: 1, loggedAt: 1000 }))
       enqueueSetLog(makeSetLogPayload({ setNumber: 2, loggedAt: 2000 }))

--- a/src/lib/syncService.ts
+++ b/src/lib/syncService.ts
@@ -726,6 +726,28 @@ export function drainQueue(userId: string): Promise<void> {
 // Supabase operations
 // ---------------------------------------------------------------------------
 
+async function upsertSession(row: {
+  id: string
+  user_id: string
+  workout_day_id: string | null
+  workout_label_snapshot: string
+  started_at: string
+  finished_at?: string
+  active_duration_ms?: number
+  total_sets_done: number
+  has_skipped_sets: boolean
+  cycle_id?: string | null
+}) {
+  const first = await supabase.from("sessions").upsert(row, { onConflict: "id" })
+  if (first.error?.code !== "23503" || row.workout_day_id == null) {
+    return first
+  }
+  return supabase.from("sessions").upsert(
+    { ...row, workout_day_id: null },
+    { onConflict: "id" },
+  )
+}
+
 async function ensureSession(
   realSessionId: string,
   userId: string,
@@ -740,42 +762,36 @@ async function ensureSession(
 
     if (sessionFinishItem) {
       const p = sessionFinishItem.payload as SessionFinishPayload
-      const { error } = await supabase.from("sessions").upsert(
-        {
-          id: realSessionId,
-          user_id: userId,
-          workout_day_id: p.workoutDayId || null,
-          workout_label_snapshot: p.workoutLabelSnapshot || "Workout",
-          started_at: new Date(p.startedAt).toISOString(),
-          finished_at: new Date(p.finishedAt).toISOString(),
-          active_duration_ms: Math.max(0, Math.round(p.activeDurationMs)),
-          total_sets_done: p.totalSetsDone,
-          has_skipped_sets: p.hasSkippedSets,
-          cycle_id: p.cycleId ?? null,
-        },
-        { onConflict: "id" },
-      )
+      const { error } = await upsertSession({
+        id: realSessionId,
+        user_id: userId,
+        workout_day_id: p.workoutDayId || null,
+        workout_label_snapshot: p.workoutLabelSnapshot || "Workout",
+        started_at: new Date(p.startedAt).toISOString(),
+        finished_at: new Date(p.finishedAt).toISOString(),
+        active_duration_ms: Math.max(0, Math.round(p.activeDurationMs)),
+        total_sets_done: p.totalSetsDone,
+        has_skipped_sets: p.hasSkippedSets,
+        cycle_id: p.cycleId ?? null,
+      })
       if (error) {
         console.error("[SyncService] session upsert failed", error)
         return false
       }
     } else {
       // Partial session (mid-session drain — no finish yet)
-      const { error } = await supabase.from("sessions").upsert(
-        {
-          id: realSessionId,
-          user_id: userId,
-          workout_day_id: meta?.workoutDayId ?? null,
-          workout_label_snapshot:
-            meta?.workoutLabelSnapshot || "Workout",
-          started_at: new Date(
-            meta?.startedAt ?? Date.now(),
-          ).toISOString(),
-          total_sets_done: 0,
-          has_skipped_sets: false,
-        },
-        { onConflict: "id" },
-      )
+      const { error } = await upsertSession({
+        id: realSessionId,
+        user_id: userId,
+        workout_day_id: meta?.workoutDayId ?? null,
+        workout_label_snapshot:
+          meta?.workoutLabelSnapshot || "Workout",
+        started_at: new Date(
+          meta?.startedAt ?? Date.now(),
+        ).toISOString(),
+        total_sets_done: 0,
+        has_skipped_sets: false,
+      })
       if (error) {
         console.error("[SyncService] partial session upsert failed", error)
         return false
@@ -874,21 +890,18 @@ async function processSessionFinish(
 ): Promise<boolean> {
   const p = item.payload as SessionFinishPayload
   try {
-    const { error } = await supabase.from("sessions").upsert(
-      {
-        id: item.realSessionId,
-        user_id: userId,
-        workout_day_id: p.workoutDayId || null,
-        workout_label_snapshot: p.workoutLabelSnapshot || "Workout",
-        started_at: new Date(p.startedAt).toISOString(),
-        finished_at: new Date(p.finishedAt).toISOString(),
-        active_duration_ms: Math.max(0, Math.round(p.activeDurationMs)),
-        total_sets_done: p.totalSetsDone,
-        has_skipped_sets: p.hasSkippedSets,
-        cycle_id: p.cycleId ?? null,
-      },
-      { onConflict: "id" },
-    )
+    const { error } = await upsertSession({
+      id: item.realSessionId,
+      user_id: userId,
+      workout_day_id: p.workoutDayId || null,
+      workout_label_snapshot: p.workoutLabelSnapshot || "Workout",
+      started_at: new Date(p.startedAt).toISOString(),
+      finished_at: new Date(p.finishedAt).toISOString(),
+      active_duration_ms: Math.max(0, Math.round(p.activeDurationMs)),
+      total_sets_done: p.totalSetsDone,
+      has_skipped_sets: p.hasSkippedSets,
+      cycle_id: p.cycleId ?? null,
+    })
 
     if (error) {
       console.error("[SyncService] session finish upsert failed", error)

--- a/src/lib/syncService.ts
+++ b/src/lib/syncService.ts
@@ -748,6 +748,40 @@ async function upsertSession(row: {
   )
 }
 
+async function upsertSetLog(row: {
+  session_id: string
+  exercise_id: string
+  block_exercise_id: string | null
+  workout_exercise_id: string | null
+  exercise_name_snapshot: string
+  set_number: number
+  weight_logged: number
+  logged_at: string
+  reps_logged: string | null
+  duration_seconds: number | null
+  estimated_1rm: number | null
+  was_pr: boolean
+  rir: number | null
+  rest_seconds: number | null
+  prescribed_reps: number | null
+  prescribed_weight: number | null
+  prescribed_sets: number | null
+  prescribed_duration_seconds: number | null
+}) {
+  const first = await supabase.from("set_logs").upsert(row, {
+    onConflict: "session_id,log_slot,set_number",
+  })
+  const hasSlotFk =
+    row.block_exercise_id != null || row.workout_exercise_id != null
+  if (first.error?.code !== "23503" || !hasSlotFk) {
+    return first
+  }
+  return supabase.from("set_logs").upsert(
+    { ...row, block_exercise_id: null, workout_exercise_id: null },
+    { onConflict: "session_id,log_slot,set_number" },
+  )
+}
+
 async function ensureSession(
   realSessionId: string,
   userId: string,
@@ -867,11 +901,7 @@ async function processSetLog(item: QueueItem): Promise<boolean> {
       prescribed_duration_seconds: isDuration ? (p.prescribedDurationSeconds ?? null) : null,
     }
 
-    const { error } = await supabase
-      .from("set_logs")
-      .upsert(row, {
-        onConflict: "session_id,log_slot,set_number",
-      })
+    const { error } = await upsertSetLog(row)
 
     if (error) {
       console.error("[SyncService] set_log upsert failed", error)

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -202,7 +202,7 @@ export interface BenchmarkCircuit {
 export interface BlockRun {
   id: string
   session_id: string
-  block_id: string
+  block_id: string | null
   started_at: string
   finished_at: string | null
   mode: ExerciseBlockMode

--- a/supabase/functions/mcp/lib/updateProgramTypes.ts
+++ b/supabase/functions/mcp/lib/updateProgramTypes.ts
@@ -72,9 +72,13 @@ export interface DiffDayUpdate {
 export interface DiffDayDelete {
   id: string
   label: string
-  /** Populated post-FK-precheck (initially 0 from `computeProgramDiff`). */
+  /** Populated after counting sessions on days_to_delete (initially 0). */
   session_count: number
-  /** Populated post-FK-precheck (initially false). True iff session_count > 0. */
+  /**
+   * Always false: `sessions.workout_day_id` is ON DELETE SET NULL, so logged
+   * sessions never block a day delete. Kept on the wire so agents that still
+   * read `removed_days[].blocking` don't treat a history-safe delete as an error.
+   */
   blocking: boolean
 }
 

--- a/supabase/functions/mcp/tools/updateProgram.ts
+++ b/supabase/functions/mcp/tools/updateProgram.ts
@@ -15,11 +15,11 @@
  *   ↓
  *   computeProgramDiff (T78)      → structural diff + apply_order
  *   ↓
- *   FK pre-check (sessions)       → annotates days_to_delete with session_count
+ *   session-count on days_to_delete → informational (ON DELETE SET NULL)
  *   ↓
  *   active-cycle check            → optional warning string
  *   ↓
- *   ┌─ dry_run=true  → render + structured preview (errors[] when blocking)
+ *   ┌─ dry_run=true  → render + structured preview
  *   └─ dry_run=false → requireConfirmForDestructive + applyProgramDiff (T80)
  */
 
@@ -137,7 +137,7 @@ Atomicity: per-day, no cross-day rollback. If a mid-flight INSERT fails, prior d
 
 Always call with \`dry_run: true\` first (the default) — review the top-level \`rendered\` markdown plus the \`removed_days\`/\`added_days\`/\`warnings\` arrays. Re-call with \`dry_run: false\` to apply.
 
-Destructive guard: removing ≥1 day requires \`confirm: true\` along with \`dry_run: false\`. The handler also blocks deletion of any day with logged sessions (returns a structured error).
+Destructive guard: removing ≥1 day requires \`confirm: true\` along with \`dry_run: false\`. Logged sessions do not block deletion — \`sessions.workout_day_id\` is \`ON DELETE SET NULL\`, so history stays (label snapshot + set_logs).
 
 Mid-cycle awareness: when an active cycle exists for the program, the response surfaces a French warning ("Cycle actif depuis ..."). Edits still proceed when confirmed.
 
@@ -165,7 +165,7 @@ export const updateProgram: ToolDefinition = {
       days: {
         type: "array",
         description:
-          "Optional. Full desired list of days (declarative PUT inside this field). Days with `id` matching an existing day = UPDATE; days without `id` = INSERT; existing days NOT in this array = DELETE (requires `confirm: true` and FK pre-check). Omit the field entirely to leave days unchanged.",
+          "Optional. Full desired list of days (declarative PUT inside this field). Days with `id` matching an existing day = UPDATE; days without `id` = INSERT; existing days NOT in this array = DELETE (requires `confirm: true`). Logged sessions are detached (SET NULL), not deleted. Omit the field entirely to leave days unchanged.",
         minItems: 1,
         maxItems: 14,
         items: {
@@ -318,9 +318,8 @@ export const updateProgram: ToolDefinition = {
 
     const diff = computeProgramDiff(currentProgram, parsedPatch)
 
-    // FK pre-check: count sessions per to-be-deleted day in a single batched
-    // query, then annotate the diff entries (mutating in place is fine — the
-    // diff is a fresh object owned by this handler).
+    // Count sessions per to-be-deleted day for `removed_days[].session_count`.
+    // Deletion is not blocked: sessions.workout_day_id is ON DELETE SET NULL.
     if (diff.days_to_delete.length > 0) {
       const deleteIds = diff.days_to_delete.map((d) => d.id)
       const { data: sessionRows, error: sessErr } = await supabase
@@ -337,7 +336,6 @@ export const updateProgram: ToolDefinition = {
       }, new Map())
       diff.days_to_delete.forEach((d) => {
         d.session_count = counts.get(d.id) ?? 0
-        d.blocking = d.session_count > 0
       })
     }
 
@@ -352,12 +350,7 @@ export const updateProgram: ToolDefinition = {
         ? formatActiveCycleWarning({ started_at: (cycleData as { started_at: string }).started_at })
         : null
 
-    const blockingErrors = diff.days_to_delete
-      .filter((d) => d.blocking)
-      .map((d) => ({
-        day_label: d.label,
-        error: `Cannot remove day '${d.label}' — it has ${d.session_count} logged sessions. Rename or repurpose it instead, or remove the corresponding entries from the patch and resubmit.`,
-      }))
+    const warnings = activeCycleWarning ? [activeCycleWarning] : []
 
     if (parsedPatch.dry_run) {
       const rendered = formatProgramAfterUpdate(diff, currentProgram, catalogById)
@@ -368,7 +361,6 @@ export const updateProgram: ToolDefinition = {
         blocking: d.blocking,
       }))
       const added_days = diff.days_to_insert.map((d) => ({ label: d.label }))
-      const warnings = activeCycleWarning ? [activeCycleWarning] : []
 
       const payload = {
         dry_run: true,
@@ -377,24 +369,17 @@ export const updateProgram: ToolDefinition = {
         removed_days,
         added_days,
         warnings,
-        errors: blockingErrors,
+        errors: [],
         message:
-          blockingErrors.length > 0
-            ? "Patch blocked — see `errors[]`. Revise the payload and re-run."
-            : "Dry run preview only — no writes performed. Re-call with `dry_run: false` to apply.",
+          "Dry run preview only — no writes performed. Re-call with `dry_run: false` to apply.",
       }
 
-      return jsonReply(payload, blockingErrors.length > 0)
+      return jsonReply(payload, false)
     }
 
     const confirmResult = requireConfirmForDestructive(diff, parsedPatch.confirm)
     if (!confirmResult.ok) {
       return err(confirmResult.error)
-    }
-
-    if (blockingErrors.length > 0) {
-      const message = blockingErrors.map((e) => e.error).join("\n")
-      return err(message)
     }
 
     const applyResult = await applyProgramDiff(supabase, diff, catalogById, userId)
@@ -404,7 +389,7 @@ export const updateProgram: ToolDefinition = {
       applied_days: applyResult.applied_days,
       failed_at: applyResult.failed_at,
       remaining_days: applyResult.remaining_days,
-      warnings: activeCycleWarning ? [activeCycleWarning] : [],
+      warnings,
       message: applyResult.message,
     }
     return jsonReply(responsePayload, applyResult.failed_at !== null)

--- a/supabase/functions/mcp/tools/updateProgram_test.ts
+++ b/supabase/functions/mcp/tools/updateProgram_test.ts
@@ -615,9 +615,8 @@ Deno.test("update_program adds a new day, captures its id, and reports it in app
   assertEquals(newDays.length, 3)
 })
 
-Deno.test("update_program blocks deletion of a day with logged sessions (FK pre-check) and writes nothing", async () => {
+Deno.test("update_program removes a trained day without deleting its logged sessions", async () => {
   const state = makeBaseState()
-  // Pull day has 2 logged sessions → FK pre-check should block deletion.
   state.sessions.push(
     { id: "s1", workout_day_id: ID_DAY_PULL, user_id: ID_USER },
     { id: "s2", workout_day_id: ID_DAY_PULL, user_id: ID_USER },
@@ -627,7 +626,6 @@ Deno.test("update_program blocks deletion of a day with logged sessions (FK pre-
   const reply = await updateProgram.handler(
     {
       program_id: ID_PROGRAM,
-      // Omit Pull → DELETE intended. Pass confirm so we reach the FK check.
       days: [
         {
           id: ID_DAY_PUSH,
@@ -642,12 +640,15 @@ Deno.test("update_program blocks deletion of a day with logged sessions (FK pre-
     mock as never,
   )
 
-  assertEquals(reply.isError, true)
-  const text = reply.content[0].text
-  assertStringIncludes(text, "Pull")
-  assertStringIncludes(text, "2 logged sessions")
-  // No mutating writes happened on programs/workout_days/workout_exercises.
-  assertEquals(writeOps(mock.callLog).length, 0)
+  assertEquals(reply.isError ?? false, false)
+  assertEquals(
+    mock.state.days.some((d) => d.id === ID_DAY_PULL),
+    false,
+  )
+  assertEquals(
+    mock.state.sessions.map((s) => s.id),
+    ["s1", "s2"],
+  )
 })
 
 Deno.test("update_program rejects destructive apply without confirm and writes nothing", async () => {

--- a/supabase/migrations/20260819113249_sessions_workout_day_on_delete_set_null.sql
+++ b/supabase/migrations/20260819113249_sessions_workout_day_on_delete_set_null.sql
@@ -1,0 +1,16 @@
+-- Editing a program (drop a day) must not be blocked by historical sessions.
+-- sessions already carry workout_label_snapshot; set_logs keep the actual work.
+-- Same history-safe pattern as set_logs.block_exercise_id / workout_exercise_id.
+--
+-- Previous behavior: REFERENCES with no ON DELETE (NO ACTION). Postgres refused
+-- to delete a workout_days row while any session pointed at it — including
+-- finished sessions from past cycles. That made trained days undeletable.
+
+ALTER TABLE sessions
+  DROP CONSTRAINT sessions_workout_day_id_fkey;
+
+ALTER TABLE sessions
+  ADD CONSTRAINT sessions_workout_day_id_fkey
+    FOREIGN KEY (workout_day_id)
+    REFERENCES workout_days(id)
+    ON DELETE SET NULL;

--- a/supabase/migrations/20260819114837_quick_sessions_exclude_detached_days.sql
+++ b/supabase/migrations/20260819114837_quick_sessions_exclude_detached_days.sql
@@ -1,0 +1,459 @@
+-- Detached program sessions (workout_day_id SET NULL when a trained day is
+-- deleted) must not count as quick_sessions. LEFT JOIN + `wd.program_id IS NULL`
+-- treated a missing day as a programless quick workout.
+
+CREATE OR REPLACE FUNCTION check_and_grant_achievements(p_user_id uuid)
+RETURNS TABLE (
+  tier_id uuid, group_slug text, rank text,
+  title_en text, title_fr text, icon_asset_url text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+BEGIN
+  IF NOT (
+    COALESCE(auth.uid() = p_user_id, false)
+    OR is_trusted_backend_caller()
+  ) THEN
+    RAISE EXCEPTION 'access denied: cannot grant achievements for another user'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_sessions AS (
+    SELECT s.id, s.workout_day_id, s.finished_at
+    FROM sessions s
+    WHERE s.user_id = p_user_id AND s.finished_at IS NOT NULL
+  ),
+  -- Circuit Achievement Run: GO snapshot FK → seed (owner_id IS NULL),
+  -- finished_at set, full_rounds = MAX(set_number)-1 >= 1 (amrapScore oracle).
+  qualifying_runs AS (
+    SELECT br.id, br.session_id, bc.slug,
+           (MAX(sl.set_number) - 1) AS full_rounds
+    FROM block_runs br
+    JOIN sessions s ON s.id = br.session_id AND s.user_id = p_user_id
+    JOIN benchmark_circuits bc ON bc.id = br.benchmark_circuit_id
+      AND bc.owner_id IS NULL
+    JOIN block_exercises be ON be.block_id = br.block_id
+    JOIN set_logs sl ON sl.session_id = br.session_id
+      AND sl.block_exercise_id = be.id
+    WHERE br.finished_at IS NOT NULL
+    GROUP BY br.id, br.session_id, bc.slug
+    HAVING (MAX(sl.set_number) - 1) >= 1
+  ),
+  olympian_slugs AS (
+    SELECT unnest(ARRAY['zeus','ares','athena','hades']) AS slug
+  ),
+  hero_slugs AS (
+    SELECT unnest(ARRAY['heracles','theseus','atlas','achilles']) AS slug
+  ),
+  pantheon_slugs AS (
+    SELECT slug FROM olympian_slugs
+    UNION ALL
+    SELECT slug FROM hero_slugs
+  ),
+  metrics AS (
+    SELECT 'session_count' AS metric_type, COUNT(*)::numeric AS value
+      FROM user_sessions
+
+    UNION ALL
+    SELECT 'total_volume_kg',
+           COALESCE(SUM(sl.weight_logged * sl.reps_logged::int), 0)
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.reps_logged IS NOT NULL
+        AND sl.reps_logged ~ '^\d+$'
+
+    UNION ALL
+    SELECT 'pr_count', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.was_pr = true
+
+    UNION ALL
+    SELECT 'unique_exercises', COUNT(DISTINCT sl.exercise_id)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+
+    UNION ALL
+    SELECT 'active_weeks', COUNT(*)::numeric
+      FROM (
+        SELECT date_trunc('week', us.finished_at) AS wk
+        FROM user_sessions us
+        GROUP BY date_trunc('week', us.finished_at)
+        HAVING COUNT(*) >= 3
+      ) AS weeks_with_3plus
+
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN workout_days wd ON wd.id = us.workout_day_id
+      LEFT JOIN programs p ON p.id = wd.program_id
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) AS day_count
+        FROM workout_days wd2
+        WHERE wd2.program_id = p.id
+      ) dc ON true
+      WHERE us.workout_day_id IS NOT NULL
+        AND (
+          wd.program_id IS NULL
+          OR (p.template_id IS NULL AND dc.day_count = 1)
+        )
+
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
+
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
+          FROM (
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at, us.id) AS session_ord,
+                   (prs.session_id IS NOT NULL) AS has_pr
+            FROM user_sessions us
+            LEFT JOIN (
+              SELECT DISTINCT sl.session_id
+              FROM set_logs sl
+              WHERE sl.was_pr = true
+            ) prs ON prs.session_id = us.id
+          ) all_sessions
+          WHERE has_pr
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) BETWEEN 5 AND 7
+
+    -- === CIRCUIT TRACKS (#482) ===
+
+    UNION ALL
+    SELECT 'circuit_runner', COUNT(*)::numeric
+      FROM qualifying_runs
+
+    UNION ALL
+    SELECT 'spidey', COALESCE(MAX(full_rounds), 0)::numeric
+      FROM qualifying_runs
+      WHERE slug = 'cindy'
+
+    -- Cast Clearing: LEFT JOIN fixed slug lists so a missing seed (e.g. Hades)
+    -- yields cnt 0; MIN stays 0. Never MIN over observed-only rows.
+    UNION ALL
+    SELECT 'olympians', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM olympian_slugs o
+        LEFT JOIN qualifying_runs q ON q.slug = o.slug
+        GROUP BY o.slug
+      ) c
+
+    UNION ALL
+    SELECT 'heroes', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM hero_slugs h
+        LEFT JOIN qualifying_runs q ON q.slug = h.slug
+        GROUP BY h.slug
+      ) c
+
+    UNION ALL
+    SELECT 'pantheoniste', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM pantheon_slugs p
+        LEFT JOIN qualifying_runs q ON q.slug = p.slug
+        GROUP BY p.slug
+      ) c
+  ),
+  eligible AS (
+    SELECT at.id, ag.slug, at.rank AS r,
+           at.title_en, at.title_fr, at.icon_asset_url
+    FROM metrics m
+    JOIN achievement_groups ag ON ag.metric_type = m.metric_type
+    JOIN achievement_tiers at ON at.group_id = ag.id
+    WHERE at.threshold_value <= m.value
+      AND NOT EXISTS (
+        SELECT 1 FROM user_achievements ua
+        WHERE ua.user_id = p_user_id AND ua.tier_id = at.id
+      )
+  ),
+  granted AS (
+    INSERT INTO user_achievements (user_id, tier_id)
+    SELECT p_user_id, e.id FROM eligible e
+    ON CONFLICT (user_id, tier_id) DO NOTHING
+    RETURNING user_achievements.tier_id
+  )
+  SELECT e.id, e.slug, e.r, e.title_en, e.title_fr, e.icon_asset_url
+  FROM eligible e
+  JOIN granted g ON g.tier_id = e.id;
+END;
+$$;
+
+
+-- 4. Replace get_badge_status (identical qualifying_runs + metrics CTE)
+
+CREATE OR REPLACE FUNCTION get_badge_status(p_user_id uuid)
+RETURNS TABLE (
+  group_id uuid, group_slug text, group_name_en text, group_name_fr text,
+  tier_id uuid, tier_level int, rank text,
+  title_en text, title_fr text,
+  threshold_value numeric, icon_asset_url text,
+  is_unlocked boolean, granted_at timestamptz,
+  current_value numeric, progress_pct numeric
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+BEGIN
+  IF NOT (
+    COALESCE(auth.uid() = p_user_id, false)
+    OR is_trusted_backend_caller()
+  ) THEN
+    RAISE EXCEPTION 'access denied: cannot read badge status for another user'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_sessions AS (
+    SELECT s.id, s.workout_day_id, s.finished_at
+    FROM sessions s
+    WHERE s.user_id = p_user_id AND s.finished_at IS NOT NULL
+  ),
+  -- Circuit Achievement Run: GO snapshot FK → seed (owner_id IS NULL),
+  -- finished_at set, full_rounds = MAX(set_number)-1 >= 1 (amrapScore oracle).
+  qualifying_runs AS (
+    SELECT br.id, br.session_id, bc.slug,
+           (MAX(sl.set_number) - 1) AS full_rounds
+    FROM block_runs br
+    JOIN sessions s ON s.id = br.session_id AND s.user_id = p_user_id
+    JOIN benchmark_circuits bc ON bc.id = br.benchmark_circuit_id
+      AND bc.owner_id IS NULL
+    JOIN block_exercises be ON be.block_id = br.block_id
+    JOIN set_logs sl ON sl.session_id = br.session_id
+      AND sl.block_exercise_id = be.id
+    WHERE br.finished_at IS NOT NULL
+    GROUP BY br.id, br.session_id, bc.slug
+    HAVING (MAX(sl.set_number) - 1) >= 1
+  ),
+  olympian_slugs AS (
+    SELECT unnest(ARRAY['zeus','ares','athena','hades']) AS slug
+  ),
+  hero_slugs AS (
+    SELECT unnest(ARRAY['heracles','theseus','atlas','achilles']) AS slug
+  ),
+  pantheon_slugs AS (
+    SELECT slug FROM olympian_slugs
+    UNION ALL
+    SELECT slug FROM hero_slugs
+  ),
+  metrics AS (
+    SELECT 'session_count' AS metric_type, COUNT(*)::numeric AS value
+      FROM user_sessions
+
+    UNION ALL
+    SELECT 'total_volume_kg',
+           COALESCE(SUM(sl.weight_logged * sl.reps_logged::int), 0)
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.reps_logged IS NOT NULL
+        AND sl.reps_logged ~ '^\d+$'
+
+    UNION ALL
+    SELECT 'pr_count', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.was_pr = true
+
+    UNION ALL
+    SELECT 'unique_exercises', COUNT(DISTINCT sl.exercise_id)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+
+    UNION ALL
+    SELECT 'active_weeks', COUNT(*)::numeric
+      FROM (
+        SELECT date_trunc('week', us.finished_at) AS wk
+        FROM user_sessions us
+        GROUP BY date_trunc('week', us.finished_at)
+        HAVING COUNT(*) >= 3
+      ) AS weeks_with_3plus
+
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN workout_days wd ON wd.id = us.workout_day_id
+      LEFT JOIN programs p ON p.id = wd.program_id
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) AS day_count
+        FROM workout_days wd2
+        WHERE wd2.program_id = p.id
+      ) dc ON true
+      WHERE us.workout_day_id IS NOT NULL
+        AND (
+          wd.program_id IS NULL
+          OR (p.template_id IS NULL AND dc.day_count = 1)
+        )
+
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
+
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
+          FROM (
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at, us.id) AS session_ord,
+                   (prs.session_id IS NOT NULL) AS has_pr
+            FROM user_sessions us
+            LEFT JOIN (
+              SELECT DISTINCT sl.session_id
+              FROM set_logs sl
+              WHERE sl.was_pr = true
+            ) prs ON prs.session_id = us.id
+          ) all_sessions
+          WHERE has_pr
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) BETWEEN 5 AND 7
+
+    -- === CIRCUIT TRACKS (#482) ===
+
+    UNION ALL
+    SELECT 'circuit_runner', COUNT(*)::numeric
+      FROM qualifying_runs
+
+    UNION ALL
+    SELECT 'spidey', COALESCE(MAX(full_rounds), 0)::numeric
+      FROM qualifying_runs
+      WHERE slug = 'cindy'
+
+    -- Cast Clearing: LEFT JOIN fixed slug lists so a missing seed (e.g. Hades)
+    -- yields cnt 0; MIN stays 0. Never MIN over observed-only rows.
+    UNION ALL
+    SELECT 'olympians', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM olympian_slugs o
+        LEFT JOIN qualifying_runs q ON q.slug = o.slug
+        GROUP BY o.slug
+      ) c
+
+    UNION ALL
+    SELECT 'heroes', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM hero_slugs h
+        LEFT JOIN qualifying_runs q ON q.slug = h.slug
+        GROUP BY h.slug
+      ) c
+
+    UNION ALL
+    SELECT 'pantheoniste', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM pantheon_slugs p
+        LEFT JOIN qualifying_runs q ON q.slug = p.slug
+        GROUP BY p.slug
+      ) c
+  )
+  SELECT
+    ag.id, ag.slug, ag.name_en, ag.name_fr,
+    at.id, at.tier_level, at.rank,
+    at.title_en, at.title_fr,
+    at.threshold_value, at.icon_asset_url,
+    (ua.id IS NOT NULL), ua.granted_at,
+    COALESCE(m.value, 0),
+    LEAST(COALESCE(m.value, 0) / NULLIF(at.threshold_value, 0) * 100, 100)
+  FROM achievement_groups ag
+  JOIN achievement_tiers at ON at.group_id = ag.id
+  LEFT JOIN user_achievements ua ON ua.tier_id = at.id AND ua.user_id = p_user_id
+  LEFT JOIN metrics m ON m.metric_type = ag.metric_type
+  ORDER BY ag.sort_order, at.tier_level;
+END;
+$$;

--- a/supabase/migrations/20260819131215_block_runs_block_id_on_delete_set_null.sql
+++ b/supabase/migrations/20260819131215_block_runs_block_id_on_delete_set_null.sql
@@ -1,0 +1,16 @@
+-- Deleting a trained workout day CASCADE-deletes exercise_blocks. block_runs
+-- used ON DELETE CASCADE on block_id, which wiped AMRAP history even though
+-- the session row survives (workout_day_id SET NULL).
+-- Same history-safe pattern as set_logs.block_exercise_id.
+
+ALTER TABLE block_runs
+  ALTER COLUMN block_id DROP NOT NULL;
+
+ALTER TABLE block_runs
+  DROP CONSTRAINT block_runs_block_id_fkey;
+
+ALTER TABLE block_runs
+  ADD CONSTRAINT block_runs_block_id_fkey
+    FOREIGN KEY (block_id)
+    REFERENCES exercise_blocks(id)
+    ON DELETE SET NULL;


### PR DESCRIPTION
## What

- Deleting a program day that already has logged sessions succeeds instead of failing on `sessions_workout_day_id_fkey`.
- Those sessions stay in history (`workout_label_snapshot` + `set_logs`); only the template row goes away.
- `update_program` no longer treats a trained day as undeletable. `confirm: true` is still required.
- AMRAP `block_runs` survive the same delete (`block_id` SET NULL). Queued `set_logs` retry without slot FKs if the template is already gone.

## Why

Editing a program mid-cycle is a legitimate use case. The FK had no `ON DELETE` clause, so **any** past session — including one from a finished cycle in June — blocked the delete forever. That is a template-edit constraint pretending to be history protection.

## How

- `sessions.workout_day_id` is now `ON DELETE SET NULL` (same history-safe pattern as `set_logs.block_exercise_id`).
- `block_runs.block_id` follows the same SET NULL path, so deleting a day does not cascade-wipe circuit runs.
- Sync retries a session upsert with a null day id, and a set_log upsert with null slot FKs, if Postgres returns `23503` after the template is gone.
- Achievement `quick_sessions` ignores detached rows (`workout_day_id IS NOT NULL`), so a deleted program day does not inflate the Quick & Dirty track.

Already applied on production. You can retry the Pull-day delete in the builder now.