### PR TITLE
refactor(session): one sessionProgress snapshot for live and finish

### DIFF
--- a/src/lib/sessionFinishStats.test.ts
+++ b/src/lib/sessionFinishStats.test.ts
@@ -1,11 +1,96 @@
 import { describe, it, expect } from "vitest"
-import {
-  countBlockSetsDone,
-  countSessionSlots,
-  countSoloSetsDone,
-  sessionHasSkippedSets,
-} from "@/lib/sessionFinishStats"
-import type { SetLog, WorkoutExercise } from "@/types/database"
+import { sessionProgress } from "@/lib/sessionFinishStats"
+import type { SessionSetRow } from "@/lib/sessionSetRow"
+import type { SetLogPayloadReps } from "@/lib/syncService"
+import type {
+  ExerciseBlockWithExercises,
+  SetLog,
+  WorkoutExercise,
+} from "@/types/database"
+
+function makeQueued(
+  overrides: Partial<SetLogPayloadReps> = {},
+): SetLogPayloadReps {
+  return {
+    sessionId: "local-1",
+    exerciseId: "ex-1",
+    exerciseNameSnapshot: "Push",
+    setNumber: 1,
+    repsLogged: "10",
+    weightLogged: 0,
+    estimatedOneRM: 0,
+    wasPr: false,
+    loggedAt: 1,
+    ...overrides,
+  }
+}
+
+function makeSetLog(overrides: Partial<SetLog> = {}): SetLog {
+  return {
+    id: "log-1",
+    session_id: "s1",
+    exercise_id: "e1",
+    block_exercise_id: null,
+    workout_exercise_id: null,
+    exercise_name_snapshot: "Push",
+    set_number: 1,
+    reps_logged: "10",
+    duration_seconds: null,
+    weight_logged: 0,
+    estimated_1rm: null,
+    was_pr: false,
+    logged_at: "2026-01-01T00:00:00Z",
+    rir: null,
+    rest_seconds: null,
+    prescribed_reps: null,
+    prescribed_weight: null,
+    prescribed_sets: null,
+    prescribed_duration_seconds: null,
+    ...overrides,
+  }
+}
+
+function makeBlock(
+  overrides: Partial<ExerciseBlockWithExercises> = {},
+): ExerciseBlockWithExercises {
+  return {
+    id: "blk-cindy",
+    workout_day_id: "day-1",
+    label: "Cindy",
+    rounds: 1,
+    rest_seconds: 0,
+    transition_seconds: 0,
+    mode: "amrap",
+    cap_seconds: 1200,
+    sort_order: 0,
+    created_at: "2026-01-01",
+    exercises: [
+      {
+        id: "be-1",
+        block_id: "blk-cindy",
+        exercise_id: "e1",
+        name_snapshot: "Pull-up",
+        muscle_snapshot: "back",
+        emoji_snapshot: "🏋️",
+        position: 0,
+        per_round: [],
+        exercise: null,
+      },
+      {
+        id: "be-2",
+        block_id: "blk-cindy",
+        exercise_id: "e2",
+        name_snapshot: "Push-up",
+        muscle_snapshot: "chest",
+        emoji_snapshot: "💪",
+        position: 1,
+        per_round: [],
+        exercise: null,
+      },
+    ],
+    ...overrides,
+  }
+}
 
 const solo = (overrides: Partial<WorkoutExercise> = {}): WorkoutExercise => ({
   id: "x",
@@ -29,157 +114,152 @@ const solo = (overrides: Partial<WorkoutExercise> = {}): WorkoutExercise => ({
   ...overrides,
 })
 
-describe("sessionFinishStats", () => {
-  it("counts solo sets from setsData", () => {
-    expect(
-      countSoloSetsDone([solo({ id: "a" })], {
+function hold(done: boolean): SessionSetRow {
+  return {
+    kind: "duration",
+    targetSeconds: 45,
+    weight: "0",
+    done,
+    timerStartedAt: null,
+  }
+}
+
+describe("sessionProgress", () => {
+  it("counts AMRAP setsDone as unique logged cells, not rounds × exercises", () => {
+    const cindy = makeBlock()
+    const progress = sessionProgress({
+      exercises: [],
+      setsData: {},
+      blocks: [cindy],
+      completedBlockIds: new Set([cindy.id]),
+      persistedLogs: [],
+      queuedPayloads: [
+        makeQueued({ blockExerciseId: "be-1", setNumber: 1, loggedAt: 1 }),
+        makeQueued({
+          blockExerciseId: "be-2",
+          setNumber: 1,
+          exerciseId: "ex-2",
+          loggedAt: 2,
+        }),
+        makeQueued({ blockExerciseId: "be-1", setNumber: 2, loggedAt: 3 }),
+        makeQueued({
+          blockExerciseId: "be-2",
+          setNumber: 2,
+          exerciseId: "ex-2",
+          loggedAt: 4,
+        }),
+        makeQueued({ blockExerciseId: "be-1", setNumber: 3, loggedAt: 5 }),
+      ],
+    })
+    expect(progress.setsDone).toBe(5)
+    expect(cindy.rounds * cindy.exercises.length).toBe(2)
+  })
+
+  it("counts done solo rows toward setsDone", () => {
+    const progress = sessionProgress({
+      exercises: [solo({ id: "a" })],
+      setsData: {
         a: [
           { kind: "reps", done: true, reps: "10", weight: "0" },
           { kind: "reps", done: false, reps: "10", weight: "0" },
         ],
-      }),
-    ).toBe(1)
+      },
+      blocks: [],
+      completedBlockIds: new Set(),
+      persistedLogs: [],
+      queuedPayloads: [],
+    })
+    expect(progress.setsDone).toBe(1)
   })
 
   it("dedupes block cells across persisted logs and the offline queue", () => {
-    const logs = [
-      {
-        block_exercise_id: "be-1",
-        set_number: 1,
-      },
-    ] as SetLog[]
-    const queued = [
-      {
-        sessionId: "local-1",
-        exerciseId: "ex-1",
-        blockExerciseId: "be-1",
-        setNumber: 1,
-        exerciseNameSnapshot: "Push",
-        repsLogged: "10",
-        weightLogged: 0,
-        estimatedOneRM: 0,
-        wasPr: false,
-        loggedAt: 1,
-      },
-      {
-        sessionId: "local-1",
-        exerciseId: "ex-2",
-        blockExerciseId: "be-2",
-        setNumber: 1,
-        exerciseNameSnapshot: "Pull",
-        repsLogged: "10",
-        weightLogged: 0,
-        estimatedOneRM: 0,
-        wasPr: false,
-        loggedAt: 2,
-      },
-    ]
-    expect(countBlockSetsDone(logs, queued)).toBe(2)
+    const progress = sessionProgress({
+      exercises: [],
+      setsData: {},
+      blocks: [makeBlock()],
+      completedBlockIds: new Set(),
+      persistedLogs: [
+        makeSetLog({
+          id: "log-be-1",
+          block_exercise_id: "be-1",
+          set_number: 1,
+        }),
+      ],
+      queuedPayloads: [
+        makeQueued({ blockExerciseId: "be-1", setNumber: 1, loggedAt: 1 }),
+        makeQueued({
+          blockExerciseId: "be-2",
+          setNumber: 1,
+          exerciseId: "ex-2",
+          loggedAt: 2,
+        }),
+      ],
+    })
+    expect(progress.setsDone).toBe(2)
   })
 
-  it("counts session slots as solos plus blocks", () => {
-    expect(
-      countSessionSlots([solo({ id: "a" })], [
-        {
-          id: "blk-1",
-          workout_day_id: "day-1",
-          label: null,
-          rounds: 2,
-          rest_seconds: 0,
-          transition_seconds: 0,
-          mode: "rounds",
-          cap_seconds: null,
-          sort_order: 1,
-          created_at: "2026-01-01",
-          exercises: [],
-        },
-      ]),
-    ).toBe(2)
-  })
-
-  // Repro: circuit → plank → circuit. All solo plank sets done, trailing
-  // Finisher never started → sessions.has_skipped_sets must be true.
-  it("is true when all solo sets are done but a circuit remains incomplete", () => {
+  it("marks unfinished circuit as skipped even when every solo set is done", () => {
     const plank = solo({ id: "plank" })
-    expect(
-      sessionHasSkippedSets(
-        [plank],
-        {
-          plank: [
-            {
-              kind: "duration",
-              targetSeconds: 45,
-              weight: "0",
-              done: true,
-              timerStartedAt: null,
-            },
-            {
-              kind: "duration",
-              targetSeconds: 45,
-              weight: "0",
-              done: true,
-              timerStartedAt: null,
-            },
-            {
-              kind: "duration",
-              targetSeconds: 45,
-              weight: "0",
-              done: true,
-              timerStartedAt: null,
-            },
-          ],
-        },
-        1,
-      ),
-    ).toBe(true)
+    const progress = sessionProgress({
+      exercises: [plank],
+      setsData: { plank: [hold(true)] },
+      blocks: [makeBlock()],
+      completedBlockIds: new Set(),
+      persistedLogs: [],
+      queuedPayloads: [],
+    })
+    expect(progress.hasSkipped).toBe(true)
   })
 
-  it("is false when every solo set is done and no circuit is incomplete", () => {
+  it("is not skipped when every solo set is done and no circuit is incomplete", () => {
     const plank = solo({ id: "plank" })
-    expect(
-      sessionHasSkippedSets(
-        [plank],
-        {
-          plank: [
-            {
-              kind: "duration",
-              targetSeconds: 45,
-              weight: "0",
-              done: true,
-              timerStartedAt: null,
-            },
-          ],
-        },
-        0,
-      ),
-    ).toBe(false)
+    const progress = sessionProgress({
+      exercises: [plank],
+      setsData: { plank: [hold(true)] },
+      blocks: [],
+      completedBlockIds: new Set(),
+      persistedLogs: [],
+      queuedPayloads: [],
+    })
+    expect(progress.hasSkipped).toBe(false)
   })
 
-  it("is true when a solo set is left undone", () => {
+  it("is skipped when a solo set is left undone", () => {
     const plank = solo({ id: "plank" })
-    expect(
-      sessionHasSkippedSets(
-        [plank],
-        {
-          plank: [
-            {
-              kind: "duration",
-              targetSeconds: 45,
-              weight: "0",
-              done: true,
-              timerStartedAt: null,
-            },
-            {
-              kind: "duration",
-              targetSeconds: 45,
-              weight: "0",
-              done: false,
-              timerStartedAt: null,
-            },
-          ],
-        },
-        0,
-      ),
-    ).toBe(true)
+    const progress = sessionProgress({
+      exercises: [plank],
+      setsData: { plank: [hold(true), hold(false)] },
+      blocks: [],
+      completedBlockIds: new Set(),
+      persistedLogs: [],
+      queuedPayloads: [],
+    })
+    expect(progress.hasSkipped).toBe(true)
+  })
+
+  it("counts totalSlots as solos plus blocks", () => {
+    const progress = sessionProgress({
+      exercises: [solo({ id: "a" })],
+      setsData: {},
+      blocks: [makeBlock()],
+      completedBlockIds: new Set(),
+      persistedLogs: [],
+      queuedPayloads: [],
+    })
+    expect(progress.totalSlots).toBe(2)
+  })
+
+  it("counts slotsCompleted as finished solos plus completed circuits", () => {
+    const plank = solo({ id: "plank" })
+    const cindy = makeBlock()
+    const progress = sessionProgress({
+      exercises: [plank],
+      setsData: { plank: [hold(true)] },
+      blocks: [cindy],
+      completedBlockIds: new Set([cindy.id]),
+      persistedLogs: [],
+      queuedPayloads: [],
+    })
+    expect(progress.slotsCompleted).toBe(2)
   })
 })

--- a/src/lib/sessionFinishStats.ts
+++ b/src/lib/sessionFinishStats.ts
@@ -7,7 +7,43 @@ import type {
   WorkoutExercise,
 } from "@/types/database"
 
-export function countSoloSetsDone(
+export type SessionProgressInput = {
+  exercises: WorkoutExercise[]
+  setsData: Record<string, SessionSetRow[]>
+  blocks: ExerciseBlockWithExercises[]
+  completedBlockIds: ReadonlySet<string>
+  persistedLogs: SetLog[]
+  queuedPayloads: SetLogPayload[]
+}
+
+export type SessionProgress = {
+  setsDone: number
+  slotsCompleted: number
+  hasSkipped: boolean
+  totalSlots: number
+}
+
+export function sessionProgress(input: SessionProgressInput): SessionProgress {
+  const incompleteBlockCount = input.blocks.filter(
+    (b) => !input.completedBlockIds.has(b.id),
+  ).length
+  return {
+    setsDone:
+      countSoloSetsDone(input.exercises, input.setsData) +
+      countBlockSetsDone(input.persistedLogs, input.queuedPayloads),
+    slotsCompleted:
+      countSoloExercisesCompleted(input.exercises, input.setsData) +
+      input.completedBlockIds.size,
+    hasSkipped: sessionHasSkippedSets(
+      input.exercises,
+      input.setsData,
+      incompleteBlockCount,
+    ),
+    totalSlots: input.exercises.length + input.blocks.length,
+  }
+}
+
+function countSoloSetsDone(
   exercises: WorkoutExercise[],
   setsData: Record<string, SessionSetRow[]>,
 ): number {
@@ -17,25 +53,24 @@ export function countSoloSetsDone(
 }
 
 /** Unique block cells logged (persisted + still queued), including partial circuits. */
-export function countBlockSetsDone(
+function countBlockSetsDone(
   persistedLogs: SetLog[],
   queuedPayloads: SetLogPayload[],
 ): number {
-  const keys = new Set<string>()
-  for (const log of persistedLogs) {
-    if (log.block_exercise_id != null) {
-      keys.add(blockCellKey(log.block_exercise_id, log.set_number))
-    }
-  }
-  for (const payload of queuedPayloads) {
-    if (payload.blockExerciseId != null) {
-      keys.add(blockCellKey(payload.blockExerciseId, payload.setNumber))
-    }
-  }
-  return keys.size
+  const fromLogs = persistedLogs.flatMap((log) =>
+    log.block_exercise_id != null
+      ? [blockCellKey(log.block_exercise_id, log.set_number)]
+      : [],
+  )
+  const fromQueue = queuedPayloads.flatMap((payload) =>
+    payload.blockExerciseId != null
+      ? [blockCellKey(payload.blockExerciseId, payload.setNumber)]
+      : [],
+  )
+  return new Set([...fromLogs, ...fromQueue]).size
 }
 
-export function countSoloExercisesCompleted(
+function countSoloExercisesCompleted(
   exercises: WorkoutExercise[],
   setsData: Record<string, SessionSetRow[]>,
 ): number {
@@ -45,23 +80,7 @@ export function countSoloExercisesCompleted(
   }).length
 }
 
-export function countBlocksCompleted(completedBlockIds: ReadonlySet<string>): number {
-  return completedBlockIds.size
-}
-
-export function countSessionSlots(
-  exercises: WorkoutExercise[],
-  blocks: ExerciseBlockWithExercises[],
-): number {
-  return exercises.length + blocks.length
-}
-
-/**
- * True when the finish payload should set `sessions.has_skipped_sets`.
- * Solo set rows alone are not enough: an unfinished circuit never appears
- * in `setsData`, so incomplete blocks must count as skipped work too.
- */
-export function sessionHasSkippedSets(
+function sessionHasSkippedSets(
   exercises: WorkoutExercise[],
   setsData: Record<string, SessionSetRow[]>,
   incompleteBlockCount: number,

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -74,14 +74,7 @@ import {
 import { resetSessionAtoms } from "@/lib/cancelSession"
 import { canStartPreSession } from "@/lib/canStartPreSession"
 import { buildSessionItems } from "@/lib/sessionItems"
-import {
-  countBlockSetsDone,
-  countBlocksCompleted,
-  countSessionSlots,
-  countSoloExercisesCompleted,
-  countSoloSetsDone,
-  sessionHasSkippedSets,
-} from "@/lib/sessionFinishStats"
+import { sessionProgress } from "@/lib/sessionFinishStats"
 import { WorkoutDayCarousel } from "@/components/workout/WorkoutDayCarousel"
 import { CycleProgressHeader } from "@/components/workout/CycleProgressHeader"
 import { WorkoutHomeSkeleton } from "@/components/workout/WorkoutHomeSkeleton"
@@ -775,20 +768,31 @@ export function WorkoutPage() {
 
 
 
-  const daySetsDone = useMemo(() => {
-    const solo = countSoloSetsDone(exercises, session.setsData)
-    const block = dayBlocks
-      .filter((b) => completedBlockIds.has(b.id))
-      .reduce((sum, b) => sum + b.rounds * b.exercises.length, 0)
-    return solo + block
-  }, [exercises, session.setsData, dayBlocks, completedBlockIds])
+  const persistedLogsForActiveSession = (): SetLog[] => {
+    const realId =
+      user != null ? peekSessionRealId(user.id, sessionId) : null
+    if (realId == null) return []
+    return queryClient.getQueryData<SetLog[]>(["session-set-logs", realId]) ?? []
+  }
 
-  const exercisesCompleted = useMemo(() => {
-    return (
-      countSoloExercisesCompleted(exercises, session.setsData) +
-      countBlocksCompleted(completedBlockIds)
-    )
-  }, [exercises, session.setsData, completedBlockIds])
+  const dayProgress = useMemo(() => {
+    return sessionProgress({
+      exercises,
+      setsData: session.setsData,
+      blocks: dayBlocks,
+      completedBlockIds,
+      persistedLogs: persistedLogsForActiveSession(),
+      queuedPayloads: queuedSetLogPayloadsForSession(sessionId),
+    })
+  }, [
+    user,
+    sessionId,
+    queryClient,
+    exercises,
+    session.setsData,
+    dayBlocks,
+    completedBlockIds,
+  ])
 
   const prExercises = useMemo(() => {
     return exercises
@@ -800,32 +804,24 @@ export function WorkoutPage() {
       }))
   }, [exercises, prFlags])
 
-  // Circuits not yet in completedBlockIds — shared by SessionNav confirm +
-  // sessions.has_skipped_sets on finish (block work never lands in setsData).
+  // Circuits not yet in completedBlockIds — SessionNav confirm still needs
+  // this; block work never lands in setsData. Finish skipped-state lives on
+  // sessionProgress.hasSkipped.
   const incompleteBlockCount = dayBlocks.filter(
     (b) => !completedBlockIds.has(b.id),
   ).length
 
   function handleFinish() {
-    const hasSkipped = sessionHasSkippedSets(
-      exercises,
-      session.setsData,
-      incompleteBlockCount,
+    const { setsDone, slotsCompleted, hasSkipped, totalSlots } = sessionProgress(
+      {
+        exercises,
+        setsData: session.setsData,
+        blocks: dayBlocks,
+        completedBlockIds,
+        persistedLogs: persistedLogsForActiveSession(),
+        queuedPayloads: queuedSetLogPayloadsForSession(sessionId),
+      },
     )
-
-    const realId =
-      user != null ? peekSessionRealId(user.id, sessionId) : null
-    const persistedLogs =
-      realId != null
-        ? (queryClient.getQueryData<SetLog[]>(["session-set-logs", realId]) ??
-          [])
-        : []
-    const totalSetsDone =
-      countSoloSetsDone(exercises, session.setsData) +
-      countBlockSetsDone(persistedLogs, queuedSetLogPayloadsForSession(sessionId))
-    const slotsCompleted =
-      countSoloExercisesCompleted(exercises, session.setsData) +
-      countBlocksCompleted(completedBlockIds)
 
     const finishedAt = Date.now()
     const activeDurationMs = Math.max(
@@ -884,7 +880,7 @@ export function WorkoutPage() {
       startedAt: session.startedAt ?? Date.now(),
       finishedAt,
       activeDurationMs,
-      totalSetsDone,
+      totalSetsDone: setsDone,
       hasSkippedSets: hasSkipped,
       cycleId: session.cycleId,
       closeCycleOnComplete,
@@ -913,8 +909,8 @@ export function WorkoutPage() {
     clearSessionExercisePatchStorage()
     setFinishedStats({
       exercisesCompleted: slotsCompleted,
-      setsDone: totalSetsDone,
-      totalExercises: countSessionSlots(exercises, dayBlocks),
+      setsDone,
+      totalExercises: totalSlots,
       prExercises,
       durationMs: activeDurationMs,
     })
@@ -1051,9 +1047,11 @@ export function WorkoutPage() {
   if (finished) {
     return (
       <SessionSummary
-        setsDone={finishedStats?.setsDone ?? daySetsDone}
-        exercisesCompleted={finishedStats?.exercisesCompleted ?? exercisesCompleted}
-        totalExercises={finishedStats?.totalExercises ?? exercises.length}
+        setsDone={finishedStats?.setsDone ?? dayProgress.setsDone}
+        exercisesCompleted={
+          finishedStats?.exercisesCompleted ?? dayProgress.slotsCompleted
+        }
+        totalExercises={finishedStats?.totalExercises ?? dayProgress.totalSlots}
         prExercises={finishedStats?.prExercises ?? prExercises}
         durationMs={finishedStats?.durationMs}
         onNewSession={handleNewSession}

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -29,6 +29,7 @@ import {
   quickSheetOpenAtom,
   restAtom,
   completedBlockIdsAtom,
+  queueSyncMetaAtom,
 } from "@/store/atoms"
 import { useWorkoutDays } from "@/hooks/useWorkoutDays"
 import { useWorkoutExercises } from "@/hooks/useWorkoutExercises"
@@ -117,7 +118,6 @@ import {
 } from "@/types/preSessionOverrides"
 import type {
   ExerciseListItem,
-  SetLog,
   WorkoutDay,
   WorkoutExerciseWithLabel,
 } from "@/types/database"
@@ -691,6 +691,15 @@ export function WorkoutPage() {
     return "no-session"
   }, [session.isActive, session.startedAt])
 
+  const activeRealId =
+    user != null ? peekSessionRealId(user.id, sessionId) : null
+  const { data: activeSessionLogs = [] } = useSessionSetLogs(activeRealId)
+  const queuePendingCount = useAtomValue(queueSyncMetaAtom).pendingCount
+  const queuedPayloads = useMemo(() => {
+    void queuePendingCount
+    return queuedSetLogPayloadsForSession(sessionId)
+  }, [sessionId, queuePendingCount])
+
   useEffect(() => {
     if (!session.isActive || !user?.id || !currentExercise) return
     const lib = exerciseById.get(currentExercise.exercise_id)
@@ -768,31 +777,14 @@ export function WorkoutPage() {
 
 
 
-  const persistedLogsForActiveSession = (): SetLog[] => {
-    const realId =
-      user != null ? peekSessionRealId(user.id, sessionId) : null
-    if (realId == null) return []
-    return queryClient.getQueryData<SetLog[]>(["session-set-logs", realId]) ?? []
-  }
-
-  const dayProgress = useMemo(() => {
-    return sessionProgress({
-      exercises,
-      setsData: session.setsData,
-      blocks: dayBlocks,
-      completedBlockIds,
-      persistedLogs: persistedLogsForActiveSession(),
-      queuedPayloads: queuedSetLogPayloadsForSession(sessionId),
-    })
-  }, [
-    user,
-    sessionId,
-    queryClient,
+  const dayProgress = sessionProgress({
     exercises,
-    session.setsData,
-    dayBlocks,
+    setsData: session.setsData,
+    blocks: dayBlocks,
     completedBlockIds,
-  ])
+    persistedLogs: activeSessionLogs,
+    queuedPayloads,
+  })
 
   const prExercises = useMemo(() => {
     return exercises
@@ -818,7 +810,7 @@ export function WorkoutPage() {
         setsData: session.setsData,
         blocks: dayBlocks,
         completedBlockIds,
-        persistedLogs: persistedLogsForActiveSession(),
+        persistedLogs: activeSessionLogs,
         queuedPayloads: queuedSetLogPayloadsForSession(sessionId),
       },
     )


### PR DESCRIPTION
## What

- Collapse live vs finish session counters into one `sessionProgress()` snapshot (`setsDone`, `slotsCompleted`, `hasSkipped`, `totalSlots`).
- Hide the old named counters so `WorkoutPage` cannot pass `rounds × n` as “sets done.”
- Rewrite tests onto snapshot cases, including AMRAP cells ≠ `1 × n`.

## Why

Live chrome treated a finished AMRAP as `rounds × exercises` (Cindy → 1 × n). Finish, `sessions.total_sets_done`, history, and MCP already persist unique logged cells. Two answers to the same question, and the live one was a lie.

## How

`sessionProgress` is the only export. Live `useMemo` and `handleFinish` both pass `setsData` + persisted logs ∪ queue. `sessionAtom.totalSetsDone` stays vestigial (solos-only increment in `SetsTable`); deleting it is a follow-up.

Closes #489

Made with [Cursor](https://cursor.com)