### PR TITLE
Teach Copilot to review against CONTEXT and ADRs, not style nits

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,25 @@
+# GymLogic — Copilot instructions
+
+MCP-native workout tracker (React 19 + TypeScript PWA, Supabase Edge/MCP, Vitest). Cursor house rules live in `.cursor/rules/` — do not contradict them. There is no `AGENTS.md` on purpose.
+
+## Canonical docs
+
+Read these; do not treat this file as a substitute:
+
+- `file:docs/CONTEXT.md` — ubiquitous language
+- `file:docs/adr/` — accepted decisions
+- `file:skills/gymlogic-mcp/SKILL.md` — MCP agent contract
+
+Count MCP tools from `file:supabase/functions/mcp/tools/registry.ts`, never from `README.md` or `file:docs/PRD.md`. Those two lag. If a PR changes the MCP surface and leaves them stale, that lag is a **finding**, not a source of truth.
+
+## Pull request review
+
+When reviewing a PR, follow `file:.github/skills/code-review/SKILL.md`. Product paths also load `file:.github/instructions/gymlogic-product.instructions.md`.
+
+Your job is **product lies** and **ADR/invariant breaks**. Silence is correct for generic style.
+
+## Banned nits
+
+Do **not** ask to revert `.map()` / `.flatMap()` / `.filter()` pipelines to `for` loops, `Set.add`, or other mutable accumulators. House style is `file:.cursor/rules/prefer-functional-style.mdc`. Raise a loop only when a hot path is **profiled**, not assumed. Copilot got this wrong on PR #490 (`countBlockSetsDone`).
+
+Skip formatting, import order, and taste-level renames. If you cannot cite a CONTEXT term, an ADR, a PR-claim mismatch, or a concrete defect (crash / data loss / auth), do not comment.

--- a/.github/instructions/gymlogic-product.instructions.md
+++ b/.github/instructions/gymlogic-product.instructions.md
@@ -1,0 +1,26 @@
+---
+applyTo: "src/**,supabase/**,docs/**"
+---
+
+# GymLogic product review (src / supabase / docs)
+
+Apply on top of `file:.github/copilot-instructions.md`. Canonical language is `file:docs/CONTEXT.md`; decisions are `file:docs/adr/`. Do not treat `README.md` or `file:docs/PRD.md` as truth.
+
+When reviewing, also follow `file:.github/skills/code-review/SKILL.md`.
+
+## Invariants
+
+- **Circuit** is the user-facing name. **Exercise Block** is code-only (tables `exercise_blocks` / `block_exercises`, hooks, i18n **keys**). UI strings, MCP-to-agents, and docs that users read say Circuit — never "block". ADR 0007.
+- Circuits are **out of the progression engine**. Frozen prescription; Builder-edited; no suggestion / snapshot / rule on block cells.
+- **Agent proposes / user confirms.** No auto-commit. `dry_run: true` first.
+- **`update_program`**: omitted day = DELETE. Never `create_program` to edit an existing program (orphans history).
+- **Last Performance** is slot-scoped: `(workout_exercise_id, exercise_id)`. ADR 0012.
+- **Weight**: dumbbell / kettlebell per-hand; barbell / machine / cable / `ez_bar` total. Persist kg only.
+- **Catalog labels** resolve at display time from the joined `exercises` row. Snapshots are fallback. ADR 0010.
+- **In-app AI UI** never names Gemini / Groq / Claude. ADR 0009.
+- **MCP is additive.** Growing the tool list must not regress the in-app path.
+- If this change adds/removes an MCP tool, `README.md` and `file:docs/mcp-connect/` must match `file:supabase/functions/mcp/tools/registry.ts` — those docs currently lag.
+
+## Do not nitpick
+
+Do not ask to rewrite `.map()` / `.flatMap()` / `.filter()` into `for` loops or `Set.add`. That is house style (`file:.cursor/rules/prefer-functional-style.mdc`) unless a hot path is profiled. Copilot false-positive: PR #490.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: code-review
+description: >
+  Review GymLogic pull requests for product lies and ADR/invariant breaks.
+  Use whenever reviewing a PR, leaving review comments, or auditing a diff
+  against docs/CONTEXT.md and docs/adr/. Do not use for generic style advice
+  or to rewrite map/flatMap into for-loops.
+---
+
+# GymLogic code review
+
+Review the **diff + PR title/body + tests**, not a generic style guide. Load canonical docs; do not paste them into comments.
+
+## Load before commenting
+
+1. PR title and body — claims to verify.
+2. The diff.
+3. `file:docs/CONTEXT.md` terms the diff touches.
+4. Cited ADRs under `file:docs/adr/` (especially 0007, 0009, 0010, 0011, 0012).
+5. If the PR touches MCP: `file:skills/gymlogic-mcp/SKILL.md` and `file:supabase/functions/mcp/tools/registry.ts`.
+
+`README.md` and `file:docs/PRD.md` lag. Do not review *against* them. Do flag them when this PR makes them wrong.
+
+House style is `.cursor/rules/`. Do not contradict it.
+
+## Hunt lies
+
+Comment when any of these is true:
+
+- **PR claim vs diff** — title/body promises behavior the diff does not implement (or implements the opposite).
+- **Tests/docs encode the old behavior** — assertions, fixtures, or copy still describe the pre-PR world.
+- **User-facing "block"** — i18n **values**, labels, dialog titles, history cards say "block" instead of **Circuit**. Keys like `blockRunner.*` / `createBlock` are fine (ADR 0007). FR and EN both say **Circuit**.
+- **In-app AI UI names a model vendor** — Gemini, Groq, Claude, ChatGPT in PWA copy. Provider is infrastructure (logs/Sentry only). ADR 0009.
+- **Stale MCP tool counts** — this PR changes the MCP surface (registry, tool handlers, skill) but `README.md` or `file:docs/mcp-connect/` still lists the old set. Count from `file:supabase/functions/mcp/tools/registry.ts`.
+
+## Hunt ADR / invariant breaks
+
+- **Circuit vs Exercise Block** — UI/MCP-to-agents = Circuit. Tables/types/hooks/i18n **keys** = block. Never leak "Exercise Block" to users. ADR `file:docs/adr/0007-exercise-blocks-rich-structure-no-progression.md`.
+- **No progression engine on circuits** — no Progression Suggestion / Prescription Snapshot / Progression Rule on block cells.
+- **Agent proposes, user confirms** — writes go `dry_run: true` → explicit confirm → `dry_run: false`. No auto-commit.
+- **`update_program` omit-a-day = delete** — `days[]` is declarative. Do not recreate a program with `create_program` to edit; that orphans history.
+- **Last Performance is slot-scoped** — `(workout_exercise_id, exercise_id)`, not catalog-global. ADR `file:docs/adr/0012-slot-scoped-last-performance.md`.
+- **Weight convention** — dumbbell / kettlebell = per-hand; barbell / machine / cable / `ez_bar` = total. Storage always kg (`weightUnitAtom` is display only).
+- **Catalog names at display time** — resolve `name_en` / `name` from the joined catalog row; snapshots are fallback. ADR `file:docs/adr/0010-localize-catalog-at-display-time.md`.
+- **MCP is additive** — in-app path must not regress when MCP tools grow.
+
+## Do not comment on
+
+- Replacing `.map()` / `.flatMap()` / `.filter()` with `for` + `Set.add` / `.push`. House style prefers the pipeline unless a hot path is **profiled**. False positive: PR #490.
+- Formatting, import order, “add a comment”, rename-for-taste.
+- Anything you cannot pin to a lie, an invariant above, a CONTEXT term, an ADR, or a concrete defect (crash / data loss / auth).
+
+## How to comment
+
+One finding per thread. Cite the CONTEXT term or ADR (`0007`, `0012`, …). Stay silent when the diff is clean.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Add repository-wide `.github/copilot-instructions.md` so Copilot (and GitHub agents) load GymLogic’s real source of truth instead of README/PRD.
- Add `.github/skills/code-review/SKILL.md` — the review-focused skill Copilot’s own #490 footer asked for.
- Add path-specific `.github/instructions/gymlogic-product.instructions.md` (`applyTo`: `src/**`, `supabase/**`, `docs/**`) so product-path reviews get the Circuit / progression / MCP invariants even on a lite pass.

No product code, tests, or ADRs changed. No paid “call an LLM” Action.

## Why

Copilot already comments on PRs. On #490 it spent a thread telling us to revert `.flatMap()` → `for` + `Set.add` — the opposite of `prefer-functional-style`, and not a profiled hot path. Meanwhile the reviews we actually want (PR claims the diff doesn’t implement, UI saying “block” instead of Circuit, Gemini/Groq leaking into in-app copy, `update_program` omit-a-day = delete, slot-scoped Last Performance, stale MCP tool counts in README) never fire, because Copilot has no CONTEXT/ADR checklist.

## How

Instructions **point at** canonical docs rather than copying them:

- `file:docs/CONTEXT.md`
- `file:docs/adr/`
- `file:skills/gymlogic-mcp/SKILL.md` (tool count from `file:supabase/functions/mcp/tools/registry.ts`)

`README.md` and `docs/PRD.md` are called out as lagging. House style stays in `.cursor/rules/`; no `AGENTS.md` (this repo never had one).

The review checklist hunts (1) **lies** and (2) **ADR/invariant breaks**, and explicitly bans the #490 functional-style nit unless a hot path is profiled.

## Pierre — how Copilot picks this up (this PR is the first test)

Copilot code review reads custom instructions, path-specific `*.instructions.md`, and skills from the **PR head branch**, not from `main`. So this PR is already the experiment: request a Copilot review on **this** branch and see whether it:

1. Loads `.github/copilot-instructions.md` / `.github/skills/code-review/SKILL.md` (the skill directory name is what Copilot looks for).
2. Stops recommending `for` + `Set.add` over `.map`/`.flatMap`.
3. Starts citing CONTEXT terms / ADR numbers when it comments.

Repo setting **Settings → Copilot → Code review → “Use custom instructions when reviewing pull requests”** is on by default; leave it on. No extra GitHub Action required — Copilot’s existing PR reviewer is the consumer.

If Copilot’s overview still ends with “Add a `code-review` agent skill”, the skill file landed on the wrong path or wasn’t in HEAD when the review ran; re-request after checking `.github/skills/code-review/SKILL.md` on this branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfdd13f4-bc6b-4b65-8158-af9afc7faf12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfdd13f4-bc6b-4b65-8158-af9afc7faf12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

