### PR TITLE
Gate merge on Copilot findings via labels and required check

### DIFF
--- a/.github/workflows/copilot-gate.yml
+++ b/.github/workflows/copilot-gate.yml
@@ -7,8 +7,8 @@
 # This workflow counts findings on the latest Copilot review of the current
 # HEAD SHA, then:
 #   - sets exactly one of copilot:pending | copilot:blocking | copilot:ok
-#   - posts commit status `copilot / review` (pending / failure / success)
-# Pierre can mark that status required in a ruleset. This file cannot.
+#   - posts check run + commit status `copilot / review`
+# Pierre can mark that check required in a ruleset. This file cannot.
 
 name: Copilot gate
 
@@ -28,6 +28,7 @@ permissions:
   pull-requests: write
   issues: write
   statuses: write
+  checks: write
 
 jobs:
   report:
@@ -47,7 +48,7 @@ jobs:
       EVENT_ACTION: ${{ github.event.action }}
       REQUESTED_REVIEWER: ${{ github.event.requested_reviewer.login || '' }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      STATUS_CONTEXT: "copilot / review"
+      GATE_NAME: "copilot / review"
       BOT: "copilot-pull-request-reviewer[bot]"
     steps:
       - name: Evaluate Copilot review on HEAD
@@ -81,15 +82,36 @@ jobs:
               | gh api -X POST "repos/${GH_REPO}/issues/${PR_NUMBER}/labels" --input - >/dev/null
           }
 
+          # Commit status: pending | success | failure (ruleset-compatible).
           post_status() {
             local state="$1" desc="$2"
             jq -n \
               --arg state "$state" \
               --arg desc "$desc" \
-              --arg ctx "$STATUS_CONTEXT" \
+              --arg ctx "$GATE_NAME" \
               --arg url "$RUN_URL" \
               '{state:$state, description:$desc, context:$ctx, target_url:$url}' \
               | gh api -X POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" --input - >/dev/null
+          }
+
+          # Check run: in_progress (pending) or completed + success/failure.
+          post_check() {
+            local status="$1" conclusion="${2:-}" title="$3"
+            jq -n \
+              --arg name "$GATE_NAME" \
+              --arg sha "$HEAD_SHA" \
+              --arg status "$status" \
+              --arg conclusion "$conclusion" \
+              --arg title "$title" \
+              --arg url "$RUN_URL" \
+              '{
+                name: $name,
+                head_sha: $sha,
+                status: $status,
+                details_url: $url,
+                output: {title: $title, summary: $title}
+              } + (if $status == "completed" then {conclusion: $conclusion} else {} end)' \
+              | gh api -X POST "repos/${GH_REPO}/check-runs" --input - >/dev/null
           }
 
           HEAD_SHA=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq .head.sha)
@@ -150,19 +172,22 @@ jobs:
             pending)
               apply_label "copilot:pending"
               post_status "pending" "$DETAIL"
+              post_check "in_progress" "" "$DETAIL"
               ;;
             blocking)
               apply_label "copilot:blocking"
               post_status "failure" "$DETAIL"
+              post_check "completed" "failure" "$DETAIL"
               ;;
             ok)
               apply_label "copilot:ok"
               post_status "success" "$DETAIL"
+              post_check "completed" "success" "$DETAIL"
               ;;
           esac
 
       - name: Fail when Copilot left findings
         if: steps.eval.outputs.verdict == 'blocking'
         run: |
-          echo "Copilot left findings on this HEAD. Status \`copilot / review\` is failure."
+          echo "Copilot left findings on this HEAD. Check \`copilot / review\` is failure."
           exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Update `.github/workflows/copilot-gate.yml` (already on `main` from #493) so the gate posts a **check run** as well as the commit status, both named **`copilot / review`**.
- Labels were already in #493 (`copilot:pending` / `copilot:blocking` / `copilot:ok`). Unchanged product-wise: Copilot findings on this HEAD still drive the verdict.
- No product code, no #492 instruction files, no paid “call an LLM” Action.

Rebased onto latest `main` after #493 merged, so this is a 30-line update of the existing workflow — not a second add of the same path.

## Why

Copilot **cannot block merge by itself.** GitHub’s docs are explicit: it always leaves a **Comment** review, never Approve or Request changes. `review.state === CHANGES_REQUESTED` will never fire.

#493 posted a commit status. This PR also posts a check run (`in_progress` while waiting, `failure` on findings, `success` on a clean Copilot review) so the required-check picker has a first-class Actions check. Verdict still comes from inline review comments / “generated N comments” on the latest Copilot review of the **current HEAD SHA**. No Copilot review on this SHA is **pending**, not a pass.

## How

Workflow `Copilot gate` runs on PR open/synchronize/reopen and on Copilot’s `pull_request_review` submission (`copilot-pull-request-reviewer[bot]`). It:

1. Creates the labels on first run if missing.
2. Sets exactly one of `copilot:pending` | `copilot:blocking` | `copilot:ok`.
3. Posts check run + commit status **`copilot / review`**.

| Copilot on this HEAD | Label (stop / wait / go) | Check `copilot / review` |
|---|---|---|
| Has not reviewed this SHA | `copilot:pending` (yellow `#fbca04`) | **pending** — not a pass |
| Reviewed and left findings | `copilot:blocking` (red `#b60205`) | **failure** |
| Reviewed with zero findings | `copilot:ok` (green `#0e8a16`) | **success** |

A new push **clears** the gate back to pending until Copilot reviews the new SHA. Re-requesting Copilot flips to pending, then recomputes when the bot submits.

Do **not** require the Actions job named `Copilot gate / report`. Require **`copilot / review`**.

## Pierre — one Settings click to make the check required

This workflow **cannot** enable branch protection or edit a ruleset. Until you require the check, labels are informational and a red `copilot / review` will not stop merge.

1. Repo **Settings → Rules → Rulesets** (or **Settings → Branches** → branch protection on `main`).
2. On the `main` ruleset, add a required status check named **`copilot / review`**.
3. Save. After a workflow run has posted that context once, it should appear in the checks picker; if the picker is empty, type the name exactly.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfdd13f4-bc6b-4b65-8158-af9afc7faf12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfdd13f4-bc6b-4b65-8158-af9afc7faf12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

