### PR TITLE
One unlock ceremony per grant batch

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -272,6 +272,18 @@ Group `heroes` (accordion *Le tour des Héros* / *Heroes’ Tour*). **Cast Clear
 **Pantheoniste**:
 Achievement group `pantheoniste` (accordion *Le Pantheoniste* / *Pantheoniste*). **Cast Clearing** over all eight Greek Pantheon seeds (Cindy excluded). Same thresholds as **Olympians** / **Heroes**. A single seed run can feed **Circuit runner** plus the matching quatuor plus this capstone.
 
+**Grant Batch**:
+Every newly unlocked achievement tier from one finish (RPC return + any Realtime inserts that landed before the overlay opened), frozen as the ceremony opens. Late grants wait for the next ceremony. The unit of the unlock overlay.
+_Avoid_: slot machine, serial queue, one-medal-at-a-time ceremony
+
+**Hero** (unlock ceremony):
+The highest-rank tier in a **Grant Batch** (`diamond > platinum > gold > silver > bronze`; ties keep queue order). Title, rank chip, track name, threshold line, and Equip all describe this tier only.
+_Avoid_: featured badge, primary tile among equals
+
+**Supporting medal**:
+A non-hero grant in the same **Grant Batch**. Count 2: overlaps the hero bottom-right. Count 3+: one under-row. Count 5+: under-row with a `+N` overflow tile. Never an equal grid.
+_Avoid_: second hero, 2×2 grid, carousel, app-icon row
+
 ---
 
 ## Marketing site

--- a/docs/Epic_Brief_—_Grant_Overlay_—_One_Ceremony_per_Batch_#491.md
+++ b/docs/Epic_Brief_—_Grant_Overlay_—_One_Ceremony_per_Batch_#491.md
@@ -1,0 +1,90 @@
+# Epic Brief — Grant Overlay — One Ceremony per Batch #491
+
+## Summary
+
+Finishing a session that unlocks several achievement tiers currently plays a 4-second slot machine — one medal, then the next, same chrome every time. This epic replaces that with one **Grant Batch** ceremony: the highest rank is the **Hero**, everything else is a **Supporting medal**, Equip title sits on the hero, and tap/Escape dismisses the whole batch. Pixel-perfect against the v2 Stitch screens. A hidden `/_unlock-overlay` playground is how we sign it off.
+
+---
+
+## Context & Problem
+
+**Who is affected:** Anyone who finishes a session that grants more than one tier (common on first Circuit runs, volume jumps, and retroactive-adjacent bursts). Also anyone reviewing the overlay against design.
+
+**Current state:**
+- `AchievementUnlockOverlay` renders `queue[0]`, auto-dismisses after 4s, shifts on tap
+- Copy is the group blurb (`groupDescriptions`), not the threshold the hero just cleared
+- Equip title only lives in `BadgeDetailDrawer`
+- No overlay component tests
+- No playground — HITL means finishing real sessions and hoping for the right burst
+
+**Pain points:**
+| Pain | Impact |
+|---|---|
+| Serial 4s medals | A 3–4 tier finish is 12–16s of identical ceremony |
+| Equal treatment of every unlock | Diamond and Bronze get the same stage; the batch has no hierarchy |
+| Group blurb instead of threshold | User doesn't see *what they just cleared* |
+| Auto-dismiss | Can't read, can't equip, can't compare to the Stitch |
+| No fixture route | Pixel-perfect review requires farming grants |
+
+---
+
+## User Stories
+
+1. As a lifter who just unlocked several tiers, I want one overlay for the whole **Grant Batch**, so that I am not queued through a slot machine.
+2. As a lifter, I want the **Hero** to be the highest rank in the batch, so that the ceremony celebrates the biggest jump.
+3. As a lifter with a single unlock, I want the Gold (or any single) layout: hero medal ~112px, eyebrow `Unlocked`, title, metal rank chip + track name, threshold line, so that it matches the v2 single screen.
+4. As a lifter with exactly two unlocks, I want a ~120px hero and a ~72px supporting medal overlapping bottom-right (not a second hero), eyebrow `2 unlocked`, copy still about the hero, so that two grants read as one moment with a satellite.
+5. As a lifter with 3 or 4 unlocks, I want one horizontal under-row of supporting medals (~56px) with rank + title captions, so that extras are a set, not a 2×2 grid or a carousel.
+6. As a lifter with 5+ unlocks, I want that same row with a `+N` overflow tile as the last slot, so that a burst never paginates or serializes.
+7. As a lifter, I want a primary **Equip title** button that equips the hero via the same `user_profiles.active_title_tier_id` path as the badge drawer, so that I can wear the new title without opening Succès.
+8. As a lifter, I want Equip to stay on the overlay (toast, then tap to leave), so that equipping is not also dismiss.
+9. As a lifter whose hero is already the active title, I want no Equip button, so that I never see a dead CTA.
+10. As a lifter, I want tap-outside / overlay tap / Escape to dismiss the entire batch without equipping, so that skip is one gesture.
+11. As a lifter, I want no auto-dismiss, so that I can actually look at the medals.
+12. As a lifter, I want the threshold line to use existing `thresholdHint.{group_slug}` + the hero's `threshold_value` (on its own line, not crammed on the chip row), so that FR strings don't collide and copy stays honest.
+13. As a lifter, I want late Realtime grants that arrive after the overlay opened to wait for the next ceremony, so that medals don't pop into a live takeover.
+14. As a lifter with `prefers-reduced-motion`, I want static medals (no scale burst, no particles, no rain), so that the ceremony is still readable.
+15. As a lifter on a Gold single, I want sparse gold dust + a short particle burst around the medal and rank glow behind the hero only, so that the emotional reference stays quiet.
+16. As a lifter whose hero is Diamond, I want one purple/cyan square-particle burst behind type (not infinite rain, not a purple backdrop), so that Diamond is special without becoming a different game.
+17. As a reviewer, I want a hidden `/_unlock-overlay` route with buttons for Bronze → Diamond singles plus 2 / 4 / 5+ batches, so that HITL does not require farming sessions.
+18. As a lifter whose Equip request fails, I want an error toast and the overlay still open, so that a network blip doesn't eat the ceremony.
+
+### Success measures
+
+| Story # | Measure |
+|---|---|
+| 1 | One overlay open per Grant Batch; `AUTO_DISMISS_MS` gone |
+| 6 | 5+ grants never open a second overlay or a carousel |
+| 14 | `prefers-reduced-motion: reduce` → zero particle/scale animation |
+
+---
+
+## Scope
+
+**In scope:**
+- Grant Batch freeze + consume-whole-queue-on-open
+- Hero pick + supporting layouts (1 / 2 overlap / 3+ row / 5+ `+N`)
+- v2 chrome: dimmed session-summary backdrop, eyebrow, metal chip + track, threshold line, Equip
+- `threshold_value` on `check_and_grant_achievements` return + Realtime mapper
+- Shared Equip mutation (drawer + overlay)
+- Overlay component tests
+- Motion/FX as specified (quiet; Diamond-only extra particles)
+- Hidden `/_unlock-overlay` playground + HITL visual closeout against Stitch v2 PNGs
+
+**Out of scope:**
+- Badge detail sheet restyle (progress bar, unlocked-on date stay there)
+- New tracks / threshold numbers / icon assets
+- Achievements page / accordion IA
+- Recoloring the whole screen gold or purple
+- Confetti cannons, emoji, “CONGRATS!!!”, toasts-as-the-ceremony
+- Design-system / Storybook route (none exists; playground is the fixture)
+
+---
+
+## Success Criteria
+
+- **Qualitative:** A 4-grant finish is one takeover whose hero is the highest rank; supporting medals sit in one under-row; Equip is optional; tap dismisses the batch.
+- **Qualitative:** Single Gold and burst Diamond match the v2 Stitch PNGs at HITL (pixel-perfect, not “inspired by”).
+- **Qualitative:** Reduced-motion users get static medals.
+- **Numeric:** Overlay tests cover 1 / 2 / 4 / overflow, Equip vs dismiss, batch dismiss, reduced-motion skips FX.
+- **Qualitative:** `/_unlock-overlay` can fire Bronze → Diamond and the batch cases without finishing a session.

--- a/docs/T213_—_Grant_RPC_threshold_value_+_mapper.md
+++ b/docs/T213_—_Grant_RPC_threshold_value_+_mapper.md
@@ -1,0 +1,73 @@
+# T213 — Grant RPC `threshold_value` + mapper
+
+## Goal
+
+The overlay’s threshold line needs the hero’s requirement. Today `check_and_grant_achievements` returns `tier_id, group_slug, rank, title_en, title_fr, icon_asset_url` — no `threshold_value`. This ticket adds the column end-to-end (RPC → `UnlockedAchievement` → Realtime mapper) so later overlay work can interpolate `thresholdHint.{group_slug}`. Stories: 12.
+
+## Mode
+
+AFK
+
+## Slice
+
+migration (`RETURNS TABLE`) → `UnlockedAchievement` → Realtime mapper → `syncService` RPC typing → tests
+
+## Dependencies
+
+None
+
+## Scope
+
+### Migration
+
+New file under `file:supabase/migrations/` replacing **only** `check_and_grant_achievements`.
+
+Copy the effective body from `file:supabase/migrations/20260819114837_quick_sessions_exclude_detached_days.sql`.
+
+Changes, and only these:
+
+1. `RETURNS TABLE` adds `threshold_value numeric` after `icon_asset_url`.
+2. `eligible` SELECT adds `at.threshold_value`.
+3. Final `SELECT e.id, e.slug, e.r, e.title_en, e.title_fr, e.icon_asset_url` adds `e.threshold_value`.
+
+Keep `SECURITY DEFINER`, `SET search_path = public`, `#variable_conflict use_column`, and the `auth.uid() = p_user_id OR is_trusted_backend_caller()` guard. Do **not** redefine `get_badge_status`. Do **not** touch `qualifying_runs` / metrics CTEs (arch test identity).
+
+### Types
+
+`file:src/types/achievements.ts` — `UnlockedAchievement` gains `threshold_value: number`.
+
+### Realtime mapper
+
+`file:src/components/achievements/AchievementRealtimeProvider.tsx` — include `threshold_value: match.threshold_value` (already on `BadgeStatusRow`).
+
+### RPC client
+
+`file:src/lib/syncService.ts` — `processSessionFinish` already casts RPC `data` to `UnlockedAchievement[]`. Prefer `.returns<UnlockedAchievement[]>()` (or equivalent typed rpc) over `as`. No overlay UI in this ticket.
+
+### Tests
+
+- Extend `file:src/lib/syncService.test.ts` grant-RPC case if it asserts return shape; otherwise add a focused test that a row with `threshold_value` is pushed onto the queue unchanged.
+- `file:src/test/circuitAchievementTracks.arch.test.ts` must still pass (`qualifying_runs` identical across the two RPCs).
+- `file:src/test/securityDefiner.arch.test.ts` must still pass (guard + `search_path` present on the new definition).
+
+## Out of Scope
+
+- Overlay chrome / threshold line rendering (T214)
+- Equip (T215)
+- Playground (T217)
+
+## Acceptance Criteria
+
+- [ ] Latest `check_and_grant_achievements` `RETURNS TABLE` includes `threshold_value numeric`
+- [ ] `eligible` and the output `SELECT` project `at.threshold_value` / `e.threshold_value`
+- [ ] `UnlockedAchievement` requires `threshold_value: number`
+- [ ] Realtime mapper copies `match.threshold_value`
+- [ ] `npx tsc -p tsconfig.app.json --noEmit` green
+- [ ] `VITE_SUPABASE_URL= VITE_SUPABASE_ANON_KEY= npx vitest run src/lib/syncService.test.ts src/test/circuitAchievementTracks.arch.test.ts src/test/securityDefiner.arch.test.ts` green
+- [ ] Demoable: a grant RPC row (fixture or typed mapper) carries `threshold_value` into `pushAchievementsToQueue`
+
+## References
+
+- Epic Brief: `file:docs/Epic_Brief_—_Grant_Overlay_—_One_Ceremony_per_Batch_#491.md`
+- Tech Plan: Data Model + Critical Constraints (RPC copy rule)
+- Current grant function: `file:supabase/migrations/20260819114837_quick_sessions_exclude_detached_days.sql`

--- a/docs/T214_—_Grant_Batch_overlay_freeze_hero_layouts_chrome.md
+++ b/docs/T214_—_Grant_Batch_overlay_freeze_hero_layouts_chrome.md
@@ -1,0 +1,112 @@
+# T214 — Grant Batch overlay: freeze, hero, layouts, chrome
+
+## Goal
+
+Replace the serial 4s `queue[0]` player with one **Grant Batch** ceremony whose **Hero** is the highest rank and whose chrome matches Stitch v2 (eyebrow, metal chip + track, threshold line, 1 / 2-overlap / 3+ row / 5+ `+N`). Kill auto-dismiss. Stories: 1–6, 10–12, 13.
+
+## Mode
+
+AFK — pixel-perfect is specified by the v2 PNGs + this ticket; visual sign-off is T218.
+
+## Slice
+
+`pickHero` utils → overlay snapshot/dismiss → layouts + i18n chrome → overlay component tests
+
+## Dependencies
+
+T213 (`threshold_value` on `UnlockedAchievement`)
+
+## Scope
+
+### Pure helpers — `file:src/lib/achievementUtils.ts`
+
+| Export | Contract |
+|---|---|
+| `pickHero(batch)` | `diamond > platinum > gold > silver > bronze`; tie → first in array |
+| `supportingMedals(batch, hero)` | All items whose `tier_id !== hero.tier_id`, original order |
+| `supportingOverflow(supporting)` | `{ visible, overflowCount }` with `visible = supporting.slice(0, 3)`, `overflowCount = max(0, length - 3)` |
+
+Unit tests in `file:src/lib/achievementUtils.test.ts` (or extend an existing test file if one exists).
+
+### Overlay freeze — `file:src/components/achievements/AchievementUnlockOverlay.tsx`
+
+- Overlay stays mounted in `AppShell`.
+- When `batch === null && queue.length > 0`, `setBatch(queue)` **during render** (no `useEffect` snapshot).
+- Render `batch`, never live `queue[0]`.
+- Dismiss (Escape, overlay/backdrop click): add every batch `tier_id` to `achievementShownIdsAtom`; `setQueue(prev => prev.filter(a => !batchIds.has(a.tier_id)))`; `setBatch(null)`.
+- Delete `AUTO_DISMISS_MS` and the `setTimeout(dismiss, …)` effect. Chime + vibrate once per ceremony (on batch capture), not per medal.
+- Late inbox items remain for the next ceremony.
+
+### Layouts (pixel-perfect vs gist `*-v2.png`)
+
+Source: https://gist.github.com/PierreTsia/1cf2af5c3010f43a5625cac5f3ab78e9 (`unlock-moment-single-gold-v2.png`, `unlock-moment-burst-4-v2.png`). Two-at-once has no PNG — follow the table, **not** a 2×2 grid.
+
+| Count | Layout |
+|---|---|
+| 1 | Hero `BadgeIcon` size `lg` (~112px). Eyebrow `ceremonyEyebrow`. |
+| 2 | Hero ~120px. Supporting ~72px overlapping bottom-right. Eyebrow `ceremonyEyebrowCount` with `count: 2`. |
+| 3–4 | Hero ~112px. One under-row of supporting ~56px, each with rank word + title, muted. |
+| 5+ | Same row; last slot is `ceremonyOverflow` (`+N`), `N = supporting.length - 3`. No carousel. |
+
+Backdrop: `bg-[#0f0f13]/70 backdrop-blur-sm` over the dimmed session summary. Rank glow **behind the hero only**. Do not purple/gold the page.
+
+Copy describes the **hero only**:
+- Title = localized hero title (`text-2xl` / tracking-tight stand-in for Stitch `headline-lg`)
+- Rank = shadcn `Badge` metal chip (`ranks.{rank}`) using overlay-local hexes: Bronze `#C26A16` · Silver `#c8c8dc` · Gold `#F0C014` · Platinum `#93c5fd` · Diamond `#a855f7` (chip text/border; not the backdrop)
+- Track = sibling `Badge` / muted tag: `groups.{hero.group_slug}` (e.g. Volume, Spidey)
+- Threshold **next line**: `t(\`thresholdHint.${hero.group_slug}\`, { target: formatCompactNumber(hero.threshold_value, locale) })`. Hide the line if `threshold_value` is missing. Do **not** use `groupDescriptions`.
+
+Muted “tap to continue” (`ceremonyTapToContinue`).
+
+### i18n
+
+Add to `file:src/locales/en/achievements.json` and `file:src/locales/fr/achievements.json`:
+
+| Key | EN | FR |
+|---|---|---|
+| `ceremonyEyebrow` | `Unlocked` | `Débloqué` |
+| `ceremonyEyebrowCount` | `{{count}} unlocked` | `{{count}} débloqués` |
+| `ceremonyOverflow` | `+{{count}}` | `+{{count}}` |
+| `ceremonyTapToContinue` | `Tap to continue` | `Toucher pour continuer` |
+
+Do not reuse `unlocked` (`Unlocked!` / `Débloqué !`).
+
+### Tests — `file:src/components/achievements/AchievementUnlockOverlay.test.tsx`
+
+`renderWithProviders` + Jotai store preloaded with `achievementUnlockQueueAtom`. `vi.mock("@/lib/supabase")`.
+
+Cases:
+- 1 grant: eyebrow Unlocked, hero title, rank chip, track, threshold line; no supporting row
+- 2 grants: Silver+Bronze → Silver is hero, Bronze overlaps (not a second equal hero); eyebrow `2 unlocked`
+- 4 grants including Diamond: Diamond is hero; 3 supporting in one row; not a 2×2
+- 6 grants: `+N` overflow (`N = 2` if 5 supporting / 3 visible)
+- Tap / Escape dismisses the **whole** batch (queue empty unless a leftover was pushed after snapshot)
+- No auto-dismiss: fake timers + 4s does **not** close
+- Reduced-motion: assert medals present without relying on animation classes if possible; if FX aren’t in this ticket, skip motion assertions (T216)
+
+Equip button may be absent this ticket (T215). Don’t fail tests for a missing CTA unless you stub the hook.
+
+## Out of Scope
+
+- Equip title CTA (T215)
+- Particle FX / scale polish beyond whatever glow already exists (T216) — existing glow tokens may stay
+- Playground route (T217)
+- Badge drawer restyle
+
+## Acceptance Criteria
+
+- [ ] `AUTO_DISMISS_MS` and `queue.slice(1)` player are gone
+- [ ] Opening snapshots the current queue; late pushes do not appear in the open overlay
+- [ ] Dismiss clears the whole snapshot and leaves post-snapshot inbox items for the next ceremony
+- [ ] Hero is always highest rank; copy (title, chip, track, threshold) is hero-only
+- [ ] Layouts 1 / 2-overlap / 3+ row / 5+ `+N` match the table; no 2×2 grid
+- [ ] Threshold line uses `thresholdHint` + `threshold_value` on its own line
+- [ ] Overlay tests cover 1 / 2 / 4 / overflow, hero pick, batch dismiss, no auto-dismiss
+- [ ] `VITE_SUPABASE_URL= VITE_SUPABASE_ANON_KEY= npx vitest run src/lib/achievementUtils.test.ts src/components/achievements/AchievementUnlockOverlay.test.tsx` green
+
+## References
+
+- Epic Brief stories 1–6, 10–13
+- Tech Plan: snapshot-during-render, layouts, i18n
+- Stitch v2: https://gist.github.com/PierreTsia/1cf2af5c3010f43a5625cac5f3ab78e9
+- Original overlay: T52 / #129

--- a/docs/T215_—_Equip_title_on_the_ceremony.md
+++ b/docs/T215_—_Equip_title_on_the_ceremony.md
@@ -1,0 +1,64 @@
+# T215 — Equip title on the ceremony
+
+## Goal
+
+v2 puts a full-width primary **Equip title** on the overlay. Wire it through the same `user_profiles.active_title_tier_id` mutation as the badge drawer — extracted, not forked. Equip does not dismiss. Stories: 7–9, 18.
+
+## Mode
+
+AFK
+
+## Slice
+
+`useEquipTitle` hook + tests → drawer switchover → overlay CTA + overlay tests
+
+## Dependencies
+
+T214 (ceremony chrome exists)
+
+## Scope
+
+### Hook — `file:src/hooks/useEquipTitle.ts`
+
+Lift the mutation from `file:src/components/achievements/BadgeDetailDrawer.tsx`:
+
+- `mutationFn`: `user_profiles.update({ active_title_tier_id: tierId }).eq("user_id", user.id)` (`tierId: string \| null` so the drawer can still unequip)
+- `onSuccess`: invalidate `["user-profile", user.id]`; toast `titleEquipped` or `titleRemoved`
+- `onError`: toast `titleError`
+
+`file:src/hooks/useEquipTitle.test.ts` via `renderHookWithProviders`. Mock supabase. Cases: equip success invalidates + equipped toast; null unequips + removed toast; error toast.
+
+### Drawer
+
+`BadgeDetailDrawer` calls the hook. Unequip button stays here only.
+
+### Overlay CTA
+
+- shadcn `Button` `size="lg"` full-width, default variant (primary ≈ `#00c9a7` — Equip accent, not celebration color)
+- Label `t("equipTitle")`
+- `onClick` **must** `stopPropagation` (overlay click dismisses)
+- Equips **hero** `tier_id` only. Any rank. No Diamond special case.
+- Does **not** dismiss. Toast, stay, tap/Escape to leave.
+- Hide the button when `useUserProfile().data?.active_title_tier_id === hero.tier_id`
+- Overlay tests: Equip click does not clear the batch; calls update with hero id; already-active hero → no button; click on overlay (not button) still dismisses without equipping
+
+## Out of Scope
+
+- Unequip on the overlay
+- FX (T216)
+- Playground (T217)
+
+## Acceptance Criteria
+
+- [ ] Drawer and overlay share `useEquipTitle` (no copied `useMutation` in the overlay)
+- [ ] Equip hero succeeds → toast, overlay still open, profile query invalidated
+- [ ] Equip click does not dismiss; overlay tap / Escape still dismisses without equipping
+- [ ] Button hidden when hero is already the active title
+- [ ] Equip failure → error toast, overlay stays
+- [ ] `VITE_SUPABASE_URL= VITE_SUPABASE_ANON_KEY= npx vitest run src/hooks/useEquipTitle.test.ts src/components/achievements/AchievementUnlockOverlay.test.tsx` green
+
+## References
+
+- Epic Brief stories 7–9, 18
+- Tech Plan: `useEquipTitle`
+- Existing mutation: `file:src/components/achievements/BadgeDetailDrawer.tsx`

--- a/docs/T216_—_Ceremony_motion_and_reduced-motion.md
+++ b/docs/T216_—_Ceremony_motion_and_reduced-motion.md
@@ -1,0 +1,63 @@
+# T216 — Ceremony motion and reduced-motion
+
+## Goal
+
+Quiet FX: the single-gold screen is the emotional reference; the burst is the same product with more medals. Hero scale + rank glow; sparse burst; Diamond-only purple/cyan squares behind type; `prefers-reduced-motion` is static. Stories: 14–16.
+
+## Mode
+
+AFK
+
+## Slice
+
+CSS/tokens → overlay FX gated on `useMediaQuery("(prefers-reduced-motion: reduce)")` → overlay tests
+
+## Dependencies
+
+T214 (hero exists to hang glow/scale on)
+
+## Scope
+
+### Motion (when motion is allowed)
+
+- Hero medal scale `0 → 1.15 → 1` (reuse/adjust `.achievement-badge-reveal`; do not invent a second animation system unless the existing keyframes can’t express the overshoot)
+- Rank-colored radial glow **behind the hero only** (existing `.achievement-glow-*` / `.achievement-rank-glow`)
+- Single / non-Diamond: sparse dust + short particle burst around the medal (existing `.achievement-particle-burst` is the starting point — keep it short, not a glitter storm)
+- Diamond hero **only**: purple `#a855f7` / cyan `#67e8f9` square particles, **one burst**, then settle. Stitch “Diamond Drama” 300-particle infinite rain is the ceiling, **not** the default. Particles `z-index` behind title/chip/threshold/Equip
+- Supporting medals: slide in ~120ms after the hero
+- Do **not** recolor the backdrop gold or purple. Accent `#00c9a7` stays on Equip (T215)
+
+### Reduced motion
+
+`useMediaQuery("(prefers-reduced-motion: reduce)")` from `file:src/hooks/useMediaQuery.ts`:
+- No scale overshoot (opacity/static medals)
+- No particle burst, no Diamond rain
+- No supporting slide delay — they’re just there
+- Hierarchy/layout unchanged
+
+### Tests
+
+In `AchievementUnlockOverlay.test.tsx`:
+- Default: hero has the reveal/glow class (or equivalent observable)
+- Mock `matchMedia` to `prefers-reduced-motion: reduce` → burst/rain nodes absent or unanimated; medals and copy still present
+- Diamond batch: particle layer is behind the title in DOM order / `z-index` (assert title is in the document and particle container is `aria-hidden`)
+
+## Out of Scope
+
+- New rank metal tokens for the chip (T214)
+- Playground (T217)
+- Confetti / emoji / infinite rain as the default
+
+## Acceptance Criteria
+
+- [ ] Hero glow + short burst on non-reduced motion
+- [ ] Diamond-only extra particles, one burst, behind type
+- [ ] `prefers-reduced-motion: reduce` → static medals, no burst, no rain
+- [ ] Supporting medals appear ~120ms after hero when motion is allowed
+- [ ] Overlay reduced-motion test green with Supabase env stripped
+
+## References
+
+- Epic Brief stories 14–16
+- Tech Plan FX decision
+- Tokens: `file:src/styles/globals.css` (keep `.achievement-glow-*`)

--- a/docs/T217_—_Hidden_unlock-overlay_playground.md
+++ b/docs/T217_—_Hidden_unlock-overlay_playground.md
@@ -1,0 +1,76 @@
+# T217 — Hidden `/_unlock-overlay` playground
+
+## Goal
+
+HITL must not require farming sessions. Add a hidden route (underscore-prefixed, not in the drawer) with buttons that push fixture **Grant Batch**es onto `achievementUnlockQueueAtom` so the real overlay (already in `AppShell`) fires. Stories: 17.
+
+## Mode
+
+AFK — building the route is mechanical. Pixel-perfect eyeballing is T218.
+
+## Slice
+
+router path → playground page → buttons seed the atom → page test
+
+## Dependencies
+
+T214 (overlay consumes a batch). T215/T216 optional but preferred so the playground shows Equip + FX; do not block this ticket on them if the DAG has them in flight — seed the atom regardless.
+
+## Scope
+
+### Route
+
+`file:src/router/index.tsx` — under `AppShell` (auth + overlay mounted):
+
+```ts
+{ path: "/_unlock-overlay", element: <UnlockOverlayPlaygroundPage /> }
+```
+
+No `SideDrawer` link. No sitemap. Not a design-system route (none exists).
+
+### Page — `file:src/pages/UnlockOverlayPlaygroundPage.tsx`
+
+Heading: “Unlock overlay playground”. Short note: not in nav, fixtures only.
+
+Each button calls `pushAchievementsToQueue` with **fresh `tier_id`s** (`crypto.randomUUID()`) so a second click after dismiss retriggers (dedup would swallow static ids).
+
+Buttons (labels exact enough to test by role/name):
+
+| Button | Batch |
+|---|---|
+| Bronze | 1× bronze, slug `volume_king`, threshold 15000 |
+| Silver | 1× silver |
+| Gold | 1× gold — “Plateau Titan” stand-in title + Volume |
+| Platinum | 1× platinum |
+| Diamond | 1× diamond |
+| 2 overlap | silver hero + bronze supporting (different slugs) |
+| Burst 4 | diamond hero + gold + silver + bronze (matches v2 burst count) |
+| Overflow 5+ | diamond + 4 supporting (row shows `+1`) |
+
+Use real `group_slug` values from `achievements.json` `groups` so chips/hints resolve. Titles can be the Stitch names or existing seed titles — don’t invent new i18n groups.
+
+### Tests — `file:src/pages/UnlockOverlayPlaygroundPage.test.tsx`
+
+- Renders the eight buttons
+- Clicking Gold puts one gold grant on the queue atom (via store, or by asserting the overlay heading appears if overlay is in the tree)
+
+`vi.mock("@/lib/supabase")`.
+
+## Out of Scope
+
+- Linking from production IA
+- DEV-only compile-out (preview deploys must work)
+- Visual sign-off (T218)
+
+## Acceptance Criteria
+
+- [ ] `/_unlock-overlay` is reachable behind auth, absent from the drawer
+- [ ] Eight buttons fire the batches in the table
+- [ ] Re-click after dismiss opens a new ceremony (fresh ids)
+- [ ] Page test green with Supabase env stripped
+
+## References
+
+- Epic Brief story 17
+- Tech Plan playground decision
+- Overlay: `file:src/components/achievements/AchievementUnlockOverlay.tsx`

--- a/docs/T218_—_HITL_pixel-perfect_ceremony_closeout.md
+++ b/docs/T218_—_HITL_pixel-perfect_ceremony_closeout.md
@@ -1,0 +1,64 @@
+# T218 — HITL pixel-perfect ceremony closeout
+
+## Goal
+
+Human-compare the real overlay (via `/_unlock-overlay`) to the v2 Stitch PNGs. This is the epic’s visual gate. Stories: 3–6, 15–17.
+
+## Mode
+
+HITL — subjective pixel-perfect judgment against the gist screens. Agents cannot sign this off.
+
+## Slice
+
+playground → eyeball vs PNGs → notes on #491 / PR
+
+## Dependencies
+
+T214, T215, T216, T217
+
+## Scope
+
+### Setup
+
+1. Branch with T213–T217 merged (or stacked locally).
+2. Log in, open `/_unlock-overlay`.
+3. Keep the gist PNGs side-by-side: https://gist.github.com/PierreTsia/1cf2af5c3010f43a5625cac5f3ab78e9
+
+### Checklist (eyeball)
+
+| Check | Pass |
+|---|---|
+| Gold single vs `unlock-moment-single-gold-v2.png` — medal size, eyebrow, title, metal chip + Volume sibling, threshold on the **next** line, Equip teal, dark `#0f0f13` veil | |
+| Burst 4 vs `unlock-moment-burst-4-v2.png` — Diamond hero, three supporting with captions, not a 2×2, Equip present | |
+| 2 overlap — Silver hero, Bronze satellite bottom-right, copy is Silver’s | |
+| Overflow 5+ — `+N` last slot, no carousel | |
+| Bronze → Platinum singles — metal color on chip/glow only; backdrop never recolored | |
+| Equip on Gold → toast, overlay stays; tap dismisses | |
+| Escape / tap-continue dismisses without equip | |
+| Reduced-motion OS setting → static, no rain | |
+| Diamond particles behind type, one burst, not infinite rain | |
+| FR locale: threshold line doesn’t collide with chip row | |
+
+### Outcome
+
+- Comment on #491 or the PR: pass / nits / blockers.
+- File follow-ups only for real visual bugs, not “maybe more glitter.”
+
+## Out of Scope
+
+- Redesigning the badge drawer
+- Changing rank thresholds or icon assets
+- Shipping a public design-system site
+
+## Acceptance Criteria
+
+- [ ] Checklist completed on local or preview
+- [ ] Gold single and burst 4 compared to the v2 PNGs (pixel-perfect bar, not vibe)
+- [ ] 2-overlap and 5+ overflow explicitly checked
+- [ ] #491 / PR updated: HITL done or blockers listed
+
+## References
+
+- Epic Brief success criteria
+- Stitch v2 gist
+- Playground: T217 `/_unlock-overlay`

--- a/docs/Tech_Plan_—_Grant_Overlay_—_One_Ceremony_per_Batch_#491.md
+++ b/docs/Tech_Plan_—_Grant_Overlay_—_One_Ceremony_per_Batch_#491.md
@@ -1,0 +1,174 @@
+# Tech Plan — Grant Overlay — One Ceremony per Batch #491
+
+## Architectural Approach
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Ceremony unit | Snapshot the Jotai queue into a **Grant Batch** on first paint of a non-empty queue; render the snapshot, not the live atom | Late Realtime extras must not pop into an open overlay. Clearing-on-open is worse: it races with in-flight pushes. Snapshot + dismiss-filter is the freeze. |
+| Snapshot without `useEffect` | `setBatch(queue)` during render when `batch === null && queue.length > 0` (React “adjusting state when props change”) | Overlay is always mounted in `AppShell`. An effect that copies the queue is the exact `setState`-in-effect antipattern. |
+| Hero pick | Pure `pickHero(batch)` in `file:src/lib/achievementUtils.ts`: `diamond > platinum > gold > silver > bronze`; ties keep first-in-queue | Overlay stays dumb. Tests cover rank order without RTL. |
+| Supporting overflow | Max 3 visible supporting medals; if more, last slot is `+N` with `N = supporting.length - 3` | 4-grant burst PNG is hero + 3. 5+ never paginates. |
+| Queue atom | Keep `achievementUnlockQueueAtom` as a flat `UnlockedAchievement[]` inbox | Issue forbids a serial player. Do not introduce a batch atom. |
+| `threshold_value` | Add to `check_and_grant_achievements` `RETURNS TABLE` + `eligible`/`SELECT`; Realtime mapper copies it from `BadgeStatusRow` (already has it) | Overlay must not invent marketing copy. `get_badge_status` already returns the column — grant was the gap. |
+| Equip | Extract `useEquipTitle` from `BadgeDetailDrawer`; overlay + drawer both call it | Issue: don’t fork the mutation. Drawer unequip stays drawer-only (ceremony never unequips). |
+| Chrome | shadcn `Dialog` (already Radix), `Button` default (primary ≈ `#00c9a7`), `Badge` for metal chip + track | Prefer shadcn. Rank metal owns glow/particles/chip; primary is Equip only. |
+| Backdrop | `#0f0f13` / 70% + `backdrop-blur-sm` over the dimmed session summary | Matches v2. Do not recolor the page gold/purple. |
+| FX | Keep existing `.achievement-glow-*` tokens; hero-only radial glow; CSS scale `0 → 1.15 → 1`; Diamond-only canvas/DOM squares, one burst, `z-index` behind type | Stitch “Diamond Drama” 300-particle rain is the ceiling, not the default. |
+| Reduced motion | `useMediaQuery("(prefers-reduced-motion: reduce)")` — skip scale, burst, rain | Existing hook. Static medals still hierarchy-correct. |
+| Playground | New route `/_unlock-overlay` under `AppShell` (overlay already mounted). Not in the drawer. No design-system route exists. | HITL must fire Bronze→Diamond and batch cases without farming sessions. |
+| Pixel-perfect | Implement against gist `*-v2.png`. HITL T218 compares playground vs PNGs. | User-locked: not “inspired by.” |
+
+### Critical Constraints
+
+- **Do not rewrite `check_and_grant_achievements` metrics.** Copy the effective body from `file:supabase/migrations/20260819114837_quick_sessions_exclude_detached_days.sql`. Only add `threshold_value` to `RETURNS TABLE`, the `eligible` SELECT (`at.threshold_value`), and the final SELECT. Keep `SECURITY DEFINER`, `search_path = public`, and the `auth.uid()` / `is_trusted_backend_caller()` guard. Arch tests in `file:src/test/circuitAchievementTracks.arch.test.ts` require `qualifying_runs` to stay identical to `get_badge_status`.
+- **Freeze is a snapshot, not a second queue.** `pushAchievementsToQueue` stays an append+dedup. Overlay ignores atom growth while `batch !== null`. On dismiss: mark batch `tier_id`s in `achievementShownIdsAtom`, `setQueue(prev => prev.filter(not in batch))`, `setBatch(null)`. Remaining inbox items open the next ceremony on the following render.
+- **Dismiss clears the batch, not `queue[0]`.** Today `dismiss` does `prev.slice(1)` — that is the slot machine. Kill `AUTO_DISMISS_MS`.
+- **Do not special-case Diamond for Equip.** Any rank is a title (`validate_title_ownership` already allows it).
+- **Overlay click vs Equip click.** Equip `stopPropagation`. Overlay tap / overlay backdrop / Escape dismisses without equipping.
+- **i18n.** Do not reuse `unlocked: "Unlocked!"` / `"Débloqué !"` for the eyebrow (bang). New keys: `ceremonyEyebrow`, `ceremonyEyebrowCount`, `ceremonyOverflow`, `ceremonyTapToContinue`. Threshold copy is `thresholdHint.{group_slug}` + `formatCompactNumber(threshold_value)`. Track name is `groups.{group_slug}`. Rank chip is `ranks.{rank}` with metal color, not `"GOLD RANK"`.
+- **No overlay tests today.** Add `file:src/components/achievements/AchievementUnlockOverlay.test.tsx` using `renderWithProviders`. Mock `@/lib/supabase`. Drive the queue via the Jotai store passed into the provider. Do not `getByTestId`.
+- **BadgeIcon sizes.** `lg` is already `h-28` (112px) — use it for the single/3+ hero. Overlap supporting ~72px and row ~56px via `className` (twMerge). Do not add a 2×2 grid “because four icons fit.”
+- **Type casts.** Realtime mapper currently builds `UnlockedAchievement` field-by-field — keep that. Do not `as UnlockedAchievement` on the RPC row; type `supabase.rpc(...).returns<UnlockedAchievement[]>()`.
+
+---
+
+## Data Model
+
+```mermaid
+classDiagram
+    class UnlockedAchievement {
+      +string tier_id
+      +string group_slug
+      +AchievementRank rank
+      +string title_en
+      +string title_fr
+      +string|null icon_asset_url
+      +number threshold_value
+    }
+    class GrantBatch {
+      +UnlockedAchievement[] items
+      +UnlockedAchievement hero
+      +UnlockedAchievement[] supporting
+      +number overflowCount
+    }
+    UnlockedAchievement "*" -- "1" GrantBatch : frozen as
+    GrantBatch --> UnlockedAchievement : pickHero
+```
+
+No new tables. `user_achievements` and `user_profiles.active_title_tier_id` unchanged.
+
+### `check_and_grant_achievements` return (additive)
+
+```sql
+RETURNS TABLE (
+  tier_id uuid, group_slug text, rank text,
+  title_en text, title_fr text, icon_asset_url text,
+  threshold_value numeric
+)
+```
+
+`eligible` gains `at.threshold_value`. Final `SELECT` projects it.
+
+### Table Notes
+
+- **Grant Batch is not persisted.** It is a UI snapshot of the in-memory inbox.
+- **`threshold_value` on `UnlockedAchievement`** is the tier’s requirement (e.g. 27 Cindy rounds), not current progress. The overlay never shows a progress bar.
+- **Overflow `+N`** is computed, not a fake `UnlockedAchievement`.
+
+### Inbox freeze (runtime)
+
+```
+queue atom: [A, B, C]     batch: null     → render sets batch = [A,B,C]
+queue atom: [A, B, C, D]  batch: [A,B,C]  → D waits (Realtime extra)
+dismiss                    batch: null, queue: [D] → next ceremony is [D]
+```
+
+---
+
+## Component Architecture
+
+### Layer Overview
+
+```mermaid
+graph TD
+    RPC["check_and_grant_achievements + threshold_value"]
+    RT["AchievementRealtimeProvider"]
+    Push["pushAchievementsToQueue"]
+    Atom["achievementUnlockQueueAtom"]
+    Overlay["AchievementUnlockOverlay"]
+    Pick["pickHero / supportingRow"]
+    EquipHook["useEquipTitle"]
+    Drawer["BadgeDetailDrawer"]
+    Play["UnlockOverlayPlaygroundPage /_unlock-overlay"]
+
+    RPC --> Push
+    RT --> Push
+    Push --> Atom
+    Atom --> Overlay
+    Overlay --> Pick
+    Overlay --> EquipHook
+    Drawer --> EquipHook
+    Play --> Atom
+    Overlay -.->|mounted in| AppShell
+    Play -.->|child of| AppShell
+```
+
+### New Files & Responsibilities
+
+| File | Purpose |
+|---|---|
+| `file:supabase/migrations/YYYYMMDDHHMMSS_grant_achievements_threshold_value.sql` | Replace grant RPC; add `threshold_value` only |
+| `file:src/lib/achievementUtils.ts` | Add `pickHero`, `supportingMedals`, `supportingOverflow` (keep `rankColorText` / `resolveActiveTitle`) |
+| `file:src/hooks/useEquipTitle.ts` | Shared mutation + toasts |
+| `file:src/hooks/useEquipTitle.test.ts` | Equip success/error/invalidate |
+| `file:src/components/achievements/AchievementUnlockOverlay.test.tsx` | 1 / 2 / 4 / overflow, hero, Equip vs dismiss, reduced-motion |
+| `file:src/pages/UnlockOverlayPlaygroundPage.tsx` | Hidden playground (buttons push fixtures onto the atom) |
+| `file:src/pages/UnlockOverlayPlaygroundPage.test.tsx` | Buttons exist; clicking seeds a batch |
+
+### Component Responsibilities
+
+**`pickHero` / `supportingMedals` / `supportingOverflow`** (`achievementUtils`)
+- Rank order table; first-wins on tie
+- Supporting = batch minus hero (identity `tier_id`)
+- Visible supporting = first 3; `overflowCount = max(0, supporting.length - 3)`
+
+**`AchievementUnlockOverlay`**
+- Snapshot batch during render; never read live queue for medals/copy while open
+- Layouts: 1 hero; 2 overlap; 3+ under-row; 5+ row with `+N`
+- Chrome: eyebrow, `headline` title, metal `Badge` chip + track `Badge`, threshold line, Equip, tap-to-continue
+- Dismiss: Escape / overlay click / “tap to continue” → clear batch from inbox, no equip
+- Equip: `stopPropagation`, toast, stay open
+- Hide Equip when `profile.active_title_tier_id === hero.tier_id`
+- FX: hero glow only; scale unless reduced-motion; Diamond-only particle burst behind type
+- Kill `AUTO_DISMISS_MS` and `queue[0]` player
+
+**`useEquipTitle`**
+- `supabase.from("user_profiles").update({ active_title_tier_id }).eq("user_id", user.id)`
+- Invalidate `["user-profile", user.id]`
+- Toasts: `titleEquipped` / `titleError` (overlay never calls unequip)
+
+**`BadgeDetailDrawer`**
+- Replace inlined mutation with the hook; keep unequip UI
+
+**`AchievementRealtimeProvider`**
+- Pass `threshold_value: match.threshold_value` into `UnlockedAchievement`
+
+**`UnlockOverlayPlaygroundPage`**
+- Auth-gated via `AppShell`. No nav link.
+- Buttons: Bronze, Silver, Gold, Platinum, Diamond (singles); 2-overlap (Silver+Bronze); 4-burst (Diamond hero + 3); 5+ (Diamond + 4 supporting → `+1`)
+- Each click `pushAchievementsToQueue` with distinct fake `tier_id`s and real-looking titles/slugs/`threshold_value`
+
+### Failure Mode Analysis (if applicable)
+
+| Failure | Behavior |
+|---|---|
+| RPC returns new column, old client | Old overlay ignores extra JSON field (harmless). New overlay on old RPC: `threshold_value` missing — show rank+track without the hint line (don’t crash, don’t invent copy). Mapper: treat missing as `undefined`, hide the line. |
+| Realtime extra mid-ceremony | Stays in inbox; next ceremony after dismiss |
+| Equip network error | `titleError` toast; overlay stays; batch still dismissible |
+| Hero already equipped | No Equip button |
+| Empty queue | Overlay unmounts content (`batch === null`) |
+| Reduced motion | No scale / burst / rain; layout and copy unchanged |
+| Duplicate tier in RPC + Realtime | `pushAchievementsToQueue` dedup via shown+queued ids; snapshot won’t contain dupes |
+| Playground clicked twice | Dedup may swallow second click — buttons should use fresh `tier_id`s (e.g. `crypto.randomUUID()`) so re-trigger works after dismiss |

--- a/src/components/achievements/AchievementRealtimeProvider.tsx
+++ b/src/components/achievements/AchievementRealtimeProvider.tsx
@@ -33,10 +33,12 @@ export function AchievementRealtimeProvider({ children }: { children: React.Reac
           filter: `user_id=eq.${user.id}`,
         },
         (payload) => {
-          const grantedAt = payload.new.granted_at as string
+          const grantedAt = payload.new.granted_at
+          if (typeof grantedAt !== "string") return
           if (new Date(grantedAt).getTime() < subscriptionStartedAt) return
 
-          const tierId = payload.new.tier_id as string
+          const tierId = payload.new.tier_id
+          if (typeof tierId !== "string") return
           const match = badgeRows.find((r) => r.tier_id === tierId)
           if (!match) return
 
@@ -48,6 +50,7 @@ export function AchievementRealtimeProvider({ children }: { children: React.Reac
             title_fr: match.title_fr,
             icon_asset_url: match.icon_asset_url,
             threshold_value: match.threshold_value,
+            granted_at: grantedAt,
           }
           pushAchievementsToQueue([unlocked])
         },

--- a/src/components/achievements/AchievementRealtimeProvider.tsx
+++ b/src/components/achievements/AchievementRealtimeProvider.tsx
@@ -4,7 +4,7 @@ import { supabase } from "@/lib/supabase"
 import { authAtom } from "@/store/atoms"
 import { useBadgeStatus } from "@/hooks/useBadgeStatus"
 import { pushAchievementsToQueue } from "@/lib/syncService"
-import type { UnlockedAchievement, AchievementRank } from "@/types/achievements"
+import type { UnlockedAchievement } from "@/types/achievements"
 
 /**
  * Global Realtime subscription for `user_achievements` INSERT events.
@@ -43,10 +43,11 @@ export function AchievementRealtimeProvider({ children }: { children: React.Reac
           const unlocked: UnlockedAchievement = {
             tier_id: match.tier_id,
             group_slug: match.group_slug,
-            rank: match.rank as AchievementRank,
+            rank: match.rank,
             title_en: match.title_en,
             title_fr: match.title_fr,
             icon_asset_url: match.icon_asset_url,
+            threshold_value: match.threshold_value,
           }
           pushAchievementsToQueue([unlocked])
         },

--- a/src/components/achievements/AchievementRealtimeProvider.tsx
+++ b/src/components/achievements/AchievementRealtimeProvider.tsx
@@ -3,6 +3,7 @@ import { useAtomValue } from "jotai"
 import { supabase } from "@/lib/supabase"
 import { authAtom } from "@/store/atoms"
 import { useBadgeStatus } from "@/hooks/useBadgeStatus"
+import { coerceNumeric } from "@/lib/achievementUtils"
 import { pushAchievementsToQueue } from "@/lib/syncService"
 import type { UnlockedAchievement } from "@/types/achievements"
 
@@ -49,7 +50,7 @@ export function AchievementRealtimeProvider({ children }: { children: React.Reac
             title_en: match.title_en,
             title_fr: match.title_fr,
             icon_asset_url: match.icon_asset_url,
-            threshold_value: match.threshold_value,
+            threshold_value: coerceNumeric(match.threshold_value),
             granted_at: grantedAt,
           }
           pushAchievementsToQueue([unlocked])

--- a/src/components/achievements/AchievementUnlockOverlay.test.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.test.tsx
@@ -1,15 +1,34 @@
-import { describe, expect, it, vi, afterEach } from "vitest"
-import { act, screen } from "@testing-library/react"
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest"
+import { act, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { createStore } from "jotai"
 import { renderWithProviders } from "@/test/utils"
 import {
   achievementUnlockQueueAtom,
   achievementShownIdsAtom,
+  authAtom,
 } from "@/store/atoms"
 import { AchievementUnlockOverlay } from "./AchievementUnlockOverlay"
 import type { UnlockedAchievement } from "@/types/achievements"
 
-vi.mock("@/lib/supabase", () => ({ supabase: { from: vi.fn() } }))
+const mockUpdateEq = vi.fn()
+const mockUpdate = vi.fn(() => ({ eq: mockUpdateEq }))
+const mockMaybeSingle = vi.fn()
+const mockSelectEq = vi.fn(() => ({ maybeSingle: mockMaybeSingle }))
+const mockSelect = vi.fn(() => ({ eq: mockSelectEq }))
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      update: mockUpdate,
+      select: mockSelect,
+    })),
+  },
+}))
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
 
 function makeUnlock(
   overrides: Partial<UnlockedAchievement> = {},
@@ -34,9 +53,24 @@ function renderCeremony(queue: UnlockedAchievement[]) {
   return result
 }
 
+function setAuthed(store: ReturnType<typeof createStore>) {
+  act(() => {
+    store.set(authAtom, { id: "user-1" } as never)
+  })
+}
+
 describe("AchievementUnlockOverlay", () => {
+  beforeEach(() => {
+    mockUpdateEq.mockResolvedValue({ error: null })
+    mockMaybeSingle.mockResolvedValue({
+      data: { active_title_tier_id: null },
+      error: null,
+    })
+  })
+
   afterEach(() => {
     vi.useRealTimers()
+    vi.clearAllMocks()
   })
 
   it("shows a single-grant ceremony with hero title, rank chip, track, and threshold", () => {
@@ -257,5 +291,60 @@ describe("AchievementUnlockOverlay", () => {
     expect(
       screen.getByRole("heading", { name: "Volume King" }),
     ).toBeInTheDocument()
+  })
+
+  it("keeps the ceremony open when Equip title is clicked", async () => {
+    const user = userEvent.setup()
+    const batch = [makeUnlock()]
+    const { store } = renderCeremony(batch)
+    setAuthed(store)
+
+    await user.click(screen.getByRole("button", { name: /equip title/i }))
+
+    expect(
+      screen.getByRole("heading", { name: "Volume King" }),
+    ).toBeInTheDocument()
+    expect(store.get(achievementUnlockQueueAtom)).toEqual(batch)
+  })
+
+  it("equips the hero tier id when Equip title is clicked", async () => {
+    const user = userEvent.setup()
+    const { store } = renderCeremony([makeUnlock({ tier_id: "tier-gold" })])
+    setAuthed(store)
+
+    await user.click(screen.getByRole("button", { name: /equip title/i }))
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith({
+        active_title_tier_id: "tier-gold",
+      })
+    })
+    expect(mockUpdateEq).toHaveBeenCalledWith("user_id", "user-1")
+  })
+
+  it("hides Equip title when the hero is already the active title", async () => {
+    mockMaybeSingle.mockResolvedValue({
+      data: { active_title_tier_id: "tier-gold" },
+      error: null,
+    })
+    const { store } = renderCeremony([makeUnlock({ tier_id: "tier-gold" })])
+    setAuthed(store)
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /equip title/i }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it("dismisses without equipping when the overlay is tapped outside Equip", async () => {
+    const user = userEvent.setup()
+    const { store } = renderCeremony([makeUnlock()])
+    setAuthed(store)
+
+    await user.click(screen.getByText("Tap to continue"))
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(mockUpdate).not.toHaveBeenCalled()
   })
 })

--- a/src/components/achievements/AchievementUnlockOverlay.test.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.test.tsx
@@ -41,6 +41,7 @@ function makeUnlock(
     title_fr: "Roi du Volume",
     icon_asset_url: null,
     threshold_value: 5000,
+    granted_at: "2026-08-19T12:00:00.000Z",
     ...overrides,
   }
 }
@@ -97,11 +98,14 @@ describe("AchievementUnlockOverlay", () => {
     expect(screen.getByText("Gold")).toBeInTheDocument()
     expect(screen.getByText("Volume")).toBeInTheDocument()
     expect(screen.getByText("Lift 5,000 kg total")).toBeInTheDocument()
+    expect(screen.getByText(/Unlocked on/)).toBeInTheDocument()
     expect(screen.getByText("Tap to continue")).toBeInTheDocument()
     expect(
       screen.queryByText("Total volume lifted (kg)"),
     ).not.toBeInTheDocument()
     expect(screen.queryByRole("list")).not.toBeInTheDocument()
+    expect(screen.getByRole("dialog").textContent).toContain("GYMLOGIC")
+    expect(screen.getByRole("dialog").textContent).not.toContain("🏆")
   })
 
   it("treats Silver as the only hero when a Bronze grant overlaps it", () => {
@@ -130,6 +134,13 @@ describe("AchievementUnlockOverlay", () => {
       screen.queryByRole("heading", { name: "First Steps" }),
     ).not.toBeInTheDocument()
     expect(screen.getByText("Silver")).toBeInTheDocument()
+    expect(screen.getByText("Bronze")).toBeInTheDocument()
+    expect(screen.getByText("Volume")).toBeInTheDocument()
+    expect(screen.getByText("Consistency")).toBeInTheDocument()
+    expect(screen.getByText(/Lift .* kg total/)).toBeInTheDocument()
+    expect(screen.getByText("Complete 3 sessions")).toBeInTheDocument()
+    expect(screen.getByText("First Steps")).toBeInTheDocument()
+    expect(screen.getAllByText(/Unlocked on/).length).toBeGreaterThanOrEqual(2)
     expect(screen.getByLabelText("First Steps")).toBeInTheDocument()
     expect(screen.getAllByRole("heading")).toHaveLength(1)
   })
@@ -184,6 +195,7 @@ describe("AchievementUnlockOverlay", () => {
     expect(
       screen.getByRole("listitem", { name: /Volume King/ }),
     ).toBeInTheDocument()
+    expect(screen.getAllByText(/Unlocked on/)).toHaveLength(4)
   })
 
   it("shows a +N overflow tile when more than three supporting medals", () => {
@@ -213,6 +225,7 @@ describe("AchievementUnlockOverlay", () => {
     ).toBeInTheDocument()
     expect(screen.getByText("+2")).toBeInTheDocument()
     expect(screen.getAllByRole("listitem")).toHaveLength(4)
+    expect(screen.getAllByText(/Unlocked on/)).toHaveLength(4)
   })
 
   it("dismisses the whole batch when the overlay is tapped", async () => {
@@ -369,6 +382,25 @@ describe("AchievementUnlockOverlay", () => {
     expect(dialog.querySelector(".achievement-badge-reveal")).not.toBeNull()
     expect(dialog.querySelector(".achievement-glow-gold")).not.toBeNull()
     expect(dialog.querySelector(".achievement-particle-burst")).not.toBeNull()
+    expect(dialog.querySelector(".achievement-rank-sparkles")).not.toBeNull()
+  })
+
+  it("shows medal-colored sparkles from Bronze", () => {
+    renderCeremony([
+      makeUnlock({
+        tier_id: "bronze",
+        rank: "bronze",
+        title_en: "First Steps",
+        group_slug: "consistency_streak",
+        threshold_value: 3,
+      }),
+    ])
+
+    const sparkles = screen
+      .getByRole("dialog")
+      .querySelector(".achievement-rank-sparkles")
+    expect(sparkles).toHaveAttribute("aria-hidden", "true")
+    expect(sparkles?.querySelectorAll(".achievement-sparkle").length).toBe(16)
   })
 
   it("keeps medals, copy, and Equip without burst or rain when motion is reduced", () => {
@@ -401,10 +433,10 @@ describe("AchievementUnlockOverlay", () => {
     const dialog = screen.getByRole("dialog")
     expect(dialog.querySelector(".achievement-badge-reveal")).toBeNull()
     expect(dialog.querySelector(".achievement-particle-burst")).toBeNull()
-    expect(dialog.querySelector(".achievement-diamond-particles")).toBeNull()
+    expect(dialog.querySelector(".achievement-rank-sparkles")).toBeNull()
   })
 
-  it("keeps the Diamond particle burst aria-hidden so the title stays the accessible name", () => {
+  it("keeps rank sparkles aria-hidden so the title stays the accessible name", () => {
     renderCeremony([
       makeUnlock({
         tier_id: "diamond",
@@ -415,8 +447,8 @@ describe("AchievementUnlockOverlay", () => {
       }),
     ])
 
-    const particles = document.querySelector(".achievement-diamond-particles")
-    expect(particles).toHaveAttribute("aria-hidden", "true")
+    const sparkles = document.querySelector(".achievement-rank-sparkles")
+    expect(sparkles).toHaveAttribute("aria-hidden", "true")
     expect(
       screen.getByRole("heading", { name: "The Spider" }),
     ).toBeInTheDocument()

--- a/src/components/achievements/AchievementUnlockOverlay.test.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.test.tsx
@@ -111,6 +111,18 @@ describe("AchievementUnlockOverlay", () => {
     expect(screen.getByRole("dialog").textContent).not.toContain("🏆")
   })
 
+  it("still shows the threshold hint when PostgREST sends NUMERIC as a string", () => {
+    renderCeremony([
+      makeUnlock({
+        // PostgREST NUMERIC arrives as a string even though UnlockedAchievement says number.
+        // @ts-expect-error — simulating the wire payload, not a type-level grant.
+        threshold_value: "5000",
+      }),
+    ])
+
+    expect(screen.getByText("Lift 5,000 kg total")).toBeInTheDocument()
+  })
+
   it("paints the threshold hint in the grant's rank metal color", () => {
     renderCeremony([
       makeUnlock({

--- a/src/components/achievements/AchievementUnlockOverlay.test.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.test.tsx
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi, afterEach } from "vitest"
+import { act, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { renderWithProviders } from "@/test/utils"
+import {
+  achievementUnlockQueueAtom,
+  achievementShownIdsAtom,
+} from "@/store/atoms"
+import { AchievementUnlockOverlay } from "./AchievementUnlockOverlay"
+import type { UnlockedAchievement } from "@/types/achievements"
+
+vi.mock("@/lib/supabase", () => ({ supabase: { from: vi.fn() } }))
+
+function makeUnlock(
+  overrides: Partial<UnlockedAchievement> = {},
+): UnlockedAchievement {
+  return {
+    tier_id: "tier-gold",
+    group_slug: "volume_king",
+    rank: "gold",
+    title_en: "Volume King",
+    title_fr: "Roi du Volume",
+    icon_asset_url: null,
+    threshold_value: 5000,
+    ...overrides,
+  }
+}
+
+function renderCeremony(queue: UnlockedAchievement[]) {
+  const result = renderWithProviders(<AchievementUnlockOverlay />)
+  act(() => {
+    result.store.set(achievementUnlockQueueAtom, queue)
+  })
+  return result
+}
+
+describe("AchievementUnlockOverlay", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("shows a single-grant ceremony with hero title, rank chip, track, and threshold", () => {
+    renderCeremony([makeUnlock()])
+
+    expect(screen.getByText("Unlocked")).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: "Volume King" }),
+    ).toBeInTheDocument()
+    expect(screen.getByText("Gold")).toBeInTheDocument()
+    expect(screen.getByText("Volume")).toBeInTheDocument()
+    expect(screen.getByText("Lift 5,000 kg total")).toBeInTheDocument()
+    expect(screen.getByText("Tap to continue")).toBeInTheDocument()
+    expect(
+      screen.queryByText("Total volume lifted (kg)"),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole("list")).not.toBeInTheDocument()
+  })
+
+  it("treats Silver as the only hero when a Bronze grant overlaps it", () => {
+    renderCeremony([
+      makeUnlock({
+        tier_id: "bronze",
+        rank: "bronze",
+        title_en: "First Steps",
+        group_slug: "consistency_streak",
+        threshold_value: 3,
+      }),
+      makeUnlock({
+        tier_id: "silver",
+        rank: "silver",
+        title_en: "Quiet Strength",
+        group_slug: "volume_king",
+        threshold_value: 10_000,
+      }),
+    ])
+
+    expect(screen.getByText("2 unlocked")).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: "Quiet Strength" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("heading", { name: "First Steps" }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByText("Silver")).toBeInTheDocument()
+    expect(screen.getByLabelText("First Steps")).toBeInTheDocument()
+    expect(screen.getAllByRole("heading")).toHaveLength(1)
+  })
+
+  it("shows a Diamond hero with three supporting medals in one row, not a 2×2", () => {
+    renderCeremony([
+      makeUnlock({
+        tier_id: "bronze",
+        rank: "bronze",
+        title_en: "First Steps",
+        group_slug: "consistency_streak",
+        threshold_value: 3,
+      }),
+      makeUnlock({
+        tier_id: "silver",
+        rank: "silver",
+        title_en: "Quiet Strength",
+        group_slug: "rhythm_master",
+        threshold_value: 12,
+      }),
+      makeUnlock({
+        tier_id: "gold",
+        rank: "gold",
+        title_en: "Volume King",
+        group_slug: "volume_king",
+        threshold_value: 5000,
+      }),
+      makeUnlock({
+        tier_id: "diamond",
+        rank: "diamond",
+        title_en: "The Spider",
+        group_slug: "spidey",
+        threshold_value: 27,
+      }),
+    ])
+
+    expect(screen.getByText("4 unlocked")).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: "The Spider" }),
+    ).toBeInTheDocument()
+    expect(screen.getByText("Diamond")).toBeInTheDocument()
+    expect(screen.getByText("Spidey")).toBeInTheDocument()
+    expect(screen.getByText("Reach 27")).toBeInTheDocument()
+    expect(screen.getAllByRole("heading")).toHaveLength(1)
+    expect(screen.getAllByRole("listitem")).toHaveLength(3)
+    expect(
+      screen.getByRole("listitem", { name: /First Steps/ }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("listitem", { name: /Quiet Strength/ }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("listitem", { name: /Volume King/ }),
+    ).toBeInTheDocument()
+  })
+
+  it("shows a +N overflow tile when more than three supporting medals", () => {
+    const extras = ["s1", "s2", "s3", "s4", "s5"].map((id) =>
+      makeUnlock({
+        tier_id: id,
+        rank: "gold",
+        title_en: `Support ${id}`,
+        group_slug: "volume_king",
+        threshold_value: 5000,
+      }),
+    )
+    renderCeremony([
+      makeUnlock({
+        tier_id: "diamond",
+        rank: "diamond",
+        title_en: "The Spider",
+        group_slug: "spidey",
+        threshold_value: 27,
+      }),
+      ...extras,
+    ])
+
+    expect(screen.getByText("6 unlocked")).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: "The Spider" }),
+    ).toBeInTheDocument()
+    expect(screen.getByText("+2")).toBeInTheDocument()
+    expect(screen.getAllByRole("listitem")).toHaveLength(4)
+  })
+
+  it("dismisses the whole batch when the overlay is tapped", async () => {
+    const user = userEvent.setup()
+    const batch = [
+      makeUnlock({
+        tier_id: "bronze",
+        rank: "bronze",
+        title_en: "First Steps",
+      }),
+      makeUnlock({ tier_id: "gold", rank: "gold", title_en: "Volume King" }),
+    ]
+    const { store } = renderCeremony(batch)
+
+    await user.click(screen.getByRole("dialog"))
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(store.get(achievementUnlockQueueAtom)).toEqual([])
+    expect(store.get(achievementShownIdsAtom)).toEqual(
+      new Set(["bronze", "gold"]),
+    )
+  })
+
+  it("dismisses the whole batch on Escape", async () => {
+    const user = userEvent.setup()
+    const batch = [
+      makeUnlock({
+        tier_id: "bronze",
+        rank: "bronze",
+        title_en: "First Steps",
+      }),
+      makeUnlock({ tier_id: "gold", rank: "gold", title_en: "Volume King" }),
+    ]
+    const { store } = renderCeremony(batch)
+
+    await user.keyboard("{Escape}")
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(store.get(achievementUnlockQueueAtom)).toEqual([])
+  })
+
+  it("leaves grants that arrive after the snapshot for the next ceremony", async () => {
+    const user = userEvent.setup()
+    const first = makeUnlock({
+      tier_id: "gold",
+      rank: "gold",
+      title_en: "Volume King",
+    })
+    const late = makeUnlock({
+      tier_id: "diamond",
+      rank: "diamond",
+      title_en: "The Spider",
+      group_slug: "spidey",
+      threshold_value: 27,
+    })
+    const { store } = renderCeremony([first])
+
+    expect(
+      screen.getByRole("heading", { name: "Volume King" }),
+    ).toBeInTheDocument()
+
+    act(() => {
+      store.set(achievementUnlockQueueAtom, [first, late])
+    })
+
+    expect(
+      screen.getByRole("heading", { name: "Volume King" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("heading", { name: "The Spider" }),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("2 unlocked")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("dialog"))
+
+    expect(
+      screen.getByRole("heading", { name: "The Spider" }),
+    ).toBeInTheDocument()
+    expect(store.get(achievementUnlockQueueAtom)).toEqual([late])
+  })
+
+  it("does not auto-dismiss after 4 seconds", () => {
+    vi.useFakeTimers()
+    renderCeremony([makeUnlock()])
+
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+
+    expect(
+      screen.getByRole("heading", { name: "Volume King" }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/achievements/AchievementUnlockOverlay.test.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.test.tsx
@@ -98,6 +98,9 @@ describe("AchievementUnlockOverlay", () => {
     expect(screen.getByText("Gold")).toBeInTheDocument()
     expect(screen.getByText("Volume")).toBeInTheDocument()
     expect(screen.getByText("Lift 5,000 kg total")).toBeInTheDocument()
+    expect(screen.getByText("Lift 5,000 kg total")).toHaveStyle({
+      color: "#F0C014",
+    })
     expect(screen.getByText(/Unlocked on/)).toBeInTheDocument()
     expect(screen.getByText("Tap to continue")).toBeInTheDocument()
     expect(
@@ -106,6 +109,27 @@ describe("AchievementUnlockOverlay", () => {
     expect(screen.queryByRole("list")).not.toBeInTheDocument()
     expect(screen.getByRole("dialog").textContent).toContain("GYMLOGIC")
     expect(screen.getByRole("dialog").textContent).not.toContain("🏆")
+  })
+
+  it("paints the threshold hint in the grant's rank metal color", () => {
+    renderCeremony([
+      makeUnlock({
+        rank: "platinum",
+        title_en: "Steel Forger",
+      }),
+    ])
+
+    expect(screen.getByText("Lift 5,000 kg total")).toHaveStyle({
+      color: "#93c5fd",
+    })
+  })
+
+  it("links the solo hero card to the achievements page", () => {
+    renderCeremony([makeUnlock()])
+
+    const links = screen.getAllByRole("link", { name: /see all/i })
+    expect(links).toHaveLength(1)
+    expect(links[0]).toHaveAttribute("href", "/achievements")
   })
 
   it("treats Silver as the only hero when a Bronze grant overlaps it", () => {
@@ -137,12 +161,41 @@ describe("AchievementUnlockOverlay", () => {
     expect(screen.getByText("Bronze")).toBeInTheDocument()
     expect(screen.getByText("Volume")).toBeInTheDocument()
     expect(screen.getByText("Consistency")).toBeInTheDocument()
-    expect(screen.getByText(/Lift .* kg total/)).toBeInTheDocument()
-    expect(screen.getByText("Complete 3 sessions")).toBeInTheDocument()
+    expect(screen.getByText(/Lift .* kg total/)).toHaveStyle({
+      color: "#c8c8dc",
+    })
+    expect(screen.getByText("Complete 3 sessions")).toHaveStyle({
+      color: "#C26A16",
+    })
     expect(screen.getByText("First Steps")).toBeInTheDocument()
     expect(screen.getAllByText(/Unlocked on/).length).toBeGreaterThanOrEqual(2)
     expect(screen.getByLabelText("First Steps")).toBeInTheDocument()
     expect(screen.getAllByRole("heading")).toHaveLength(1)
+  })
+
+  it("links both 2-up cards to the achievements page", () => {
+    renderCeremony([
+      makeUnlock({
+        tier_id: "bronze",
+        rank: "bronze",
+        title_en: "First Steps",
+        group_slug: "consistency_streak",
+        threshold_value: 3,
+      }),
+      makeUnlock({
+        tier_id: "silver",
+        rank: "silver",
+        title_en: "Quiet Strength",
+        group_slug: "volume_king",
+        threshold_value: 10_000,
+      }),
+    ])
+
+    const links = screen.getAllByRole("link", { name: /see all/i })
+    expect(links).toHaveLength(2)
+    expect(links.every((link) => link.getAttribute("href") === "/achievements")).toBe(
+      true,
+    )
   })
 
   it("shows a Diamond hero with three supporting medals in one row, not a 2×2", () => {
@@ -183,7 +236,7 @@ describe("AchievementUnlockOverlay", () => {
     ).toBeInTheDocument()
     expect(screen.getByText("Diamond")).toBeInTheDocument()
     expect(screen.getByText("Spidey")).toBeInTheDocument()
-    expect(screen.getByText("Reach 27")).toBeInTheDocument()
+    expect(screen.getByText("Reach 27")).toHaveStyle({ color: "#a855f7" })
     expect(screen.getAllByRole("heading")).toHaveLength(1)
     expect(screen.getAllByRole("listitem")).toHaveLength(3)
     expect(
@@ -196,6 +249,45 @@ describe("AchievementUnlockOverlay", () => {
       screen.getByRole("listitem", { name: /Volume King/ }),
     ).toBeInTheDocument()
     expect(screen.getAllByText(/Unlocked on/)).toHaveLength(4)
+  })
+
+  it("links the hero and each supporting-row card to the achievements page", () => {
+    renderCeremony([
+      makeUnlock({
+        tier_id: "bronze",
+        rank: "bronze",
+        title_en: "First Steps",
+        group_slug: "consistency_streak",
+        threshold_value: 3,
+      }),
+      makeUnlock({
+        tier_id: "silver",
+        rank: "silver",
+        title_en: "Quiet Strength",
+        group_slug: "rhythm_master",
+        threshold_value: 12,
+      }),
+      makeUnlock({
+        tier_id: "gold",
+        rank: "gold",
+        title_en: "Volume King",
+        group_slug: "volume_king",
+        threshold_value: 5000,
+      }),
+      makeUnlock({
+        tier_id: "diamond",
+        rank: "diamond",
+        title_en: "The Spider",
+        group_slug: "spidey",
+        threshold_value: 27,
+      }),
+    ])
+
+    const links = screen.getAllByRole("link", { name: /see all/i })
+    expect(links).toHaveLength(4)
+    links.forEach((link) => {
+      expect(link).toHaveAttribute("href", "/achievements")
+    })
   })
 
   it("shows a +N overflow tile when more than three supporting medals", () => {
@@ -226,6 +318,32 @@ describe("AchievementUnlockOverlay", () => {
     expect(screen.getByText("+2")).toBeInTheDocument()
     expect(screen.getAllByRole("listitem")).toHaveLength(4)
     expect(screen.getAllByText(/Unlocked on/)).toHaveLength(4)
+  })
+
+  it("does not put a See all link on the overflow tile", () => {
+    const extras = ["s1", "s2", "s3", "s4", "s5"].map((id) =>
+      makeUnlock({
+        tier_id: id,
+        rank: "gold",
+        title_en: `Support ${id}`,
+        group_slug: "volume_king",
+        threshold_value: 5000,
+      }),
+    )
+    renderCeremony([
+      makeUnlock({
+        tier_id: "diamond",
+        rank: "diamond",
+        title_en: "The Spider",
+        group_slug: "spidey",
+        threshold_value: 27,
+      }),
+      ...extras,
+    ])
+
+    expect(screen.getAllByRole("link", { name: /see all/i })).toHaveLength(4)
+    const overflow = screen.getByRole("listitem", { name: "+2" })
+    expect(overflow.querySelector("a")).toBeNull()
   })
 
   it("dismisses the whole batch when the overlay is tapped", async () => {
@@ -332,6 +450,20 @@ describe("AchievementUnlockOverlay", () => {
       screen.getByRole("heading", { name: "Volume King" }),
     ).toBeInTheDocument()
     expect(store.get(achievementUnlockQueueAtom)).toEqual(batch)
+  })
+
+  it("dismisses the batch when See all is clicked instead of leaving the overlay stuck", async () => {
+    const user = userEvent.setup()
+    const batch = [makeUnlock({ tier_id: "tier-gold" })]
+    const { store } = renderCeremony(batch)
+    setAuthed(store)
+
+    await user.click(screen.getByRole("link", { name: /see all/i }))
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(store.get(achievementUnlockQueueAtom)).toEqual([])
+    expect(store.get(achievementShownIdsAtom)).toEqual(new Set(["tier-gold"]))
+    expect(mockUpdate).not.toHaveBeenCalled()
   })
 
   it("equips the hero tier id when Equip title is clicked", async () => {

--- a/src/components/achievements/AchievementUnlockOverlay.test.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.test.tsx
@@ -59,8 +59,22 @@ function setAuthed(store: ReturnType<typeof createStore>) {
   })
 }
 
+function stubPrefersReducedMotion(reduce: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes("prefers-reduced-motion: reduce") ? reduce : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
+
 describe("AchievementUnlockOverlay", () => {
   beforeEach(() => {
+    stubPrefersReducedMotion(false)
     mockUpdateEq.mockResolvedValue({ error: null })
     mockMaybeSingle.mockResolvedValue({
       data: { active_title_tier_id: null },
@@ -346,5 +360,65 @@ describe("AchievementUnlockOverlay", () => {
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it("reveals the hero with a rank glow when motion is allowed", () => {
+    renderCeremony([makeUnlock()])
+
+    const dialog = screen.getByRole("dialog")
+    expect(dialog.querySelector(".achievement-badge-reveal")).not.toBeNull()
+    expect(dialog.querySelector(".achievement-glow-gold")).not.toBeNull()
+    expect(dialog.querySelector(".achievement-particle-burst")).not.toBeNull()
+  })
+
+  it("keeps medals, copy, and Equip without burst or rain when motion is reduced", () => {
+    stubPrefersReducedMotion(true)
+    const { store } = renderCeremony([
+      makeUnlock({
+        tier_id: "diamond",
+        rank: "diamond",
+        title_en: "The Spider",
+        group_slug: "spidey",
+        threshold_value: 27,
+      }),
+      makeUnlock({
+        tier_id: "gold",
+        rank: "gold",
+        title_en: "Volume King",
+      }),
+    ])
+    setAuthed(store)
+
+    expect(
+      screen.getByRole("heading", { name: "The Spider" }),
+    ).toBeInTheDocument()
+    expect(screen.getByText("2 unlocked")).toBeInTheDocument()
+    expect(screen.getByLabelText("Volume King")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /equip title/i }),
+    ).toBeInTheDocument()
+
+    const dialog = screen.getByRole("dialog")
+    expect(dialog.querySelector(".achievement-badge-reveal")).toBeNull()
+    expect(dialog.querySelector(".achievement-particle-burst")).toBeNull()
+    expect(dialog.querySelector(".achievement-diamond-particles")).toBeNull()
+  })
+
+  it("keeps the Diamond particle burst aria-hidden so the title stays the accessible name", () => {
+    renderCeremony([
+      makeUnlock({
+        tier_id: "diamond",
+        rank: "diamond",
+        title_en: "The Spider",
+        group_slug: "spidey",
+        threshold_value: 27,
+      }),
+    ])
+
+    const particles = document.querySelector(".achievement-diamond-particles")
+    expect(particles).toHaveAttribute("aria-hidden", "true")
+    expect(
+      screen.getByRole("heading", { name: "The Spider" }),
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/achievements/AchievementUnlockOverlay.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.tsx
@@ -5,8 +5,10 @@ import {
   useState,
   type CSSProperties,
 } from "react"
+import { Link } from "react-router-dom"
 import { useAtom, useSetAtom } from "jotai"
 import { useTranslation } from "react-i18next"
+import { ChevronRight } from "lucide-react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import {
   Dialog,
@@ -73,12 +75,26 @@ function CeremonyGrantMeta({
   locale: string
   t: (key: string, options?: { target?: string; date?: string }) => string
 }) {
-  const thresholdTarget = Number.isFinite(item.threshold_value)
-    ? formatCompactNumber(item.threshold_value, locale)
+  const threshold = Number(item.threshold_value)
+  const thresholdTarget = Number.isFinite(threshold)
+    ? formatCompactNumber(threshold, locale)
     : null
   return (
     <div className="flex flex-col items-center">
-      <div className="mt-3 flex items-center gap-2">
+      {thresholdTarget !== null && (
+        <p
+          className="mt-3 text-center text-base font-semibold"
+          style={{ color: rankChipHex[item.rank] }}
+        >
+          {t(`thresholdHint.${item.group_slug}`, { target: thresholdTarget })}
+        </p>
+      )}
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          thresholdTarget !== null ? "mt-2" : "mt-3",
+        )}
+      >
         <Badge
           variant="outline"
           className="rounded-md border-transparent bg-white/5 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
@@ -90,17 +106,41 @@ function CeremonyGrantMeta({
           {t(`groups.${item.group_slug}`)}
         </span>
       </div>
-      {thresholdTarget !== null && (
-        <p className="mt-2 text-center text-sm text-white/55">
-          {t(`thresholdHint.${item.group_slug}`, { target: thresholdTarget })}
-        </p>
-      )}
-      <p className="mt-1 text-center text-xs text-white/40">
+      <p className="mt-1.5 text-center text-xs text-white/40">
         {t("unlockedOn", {
           date: unlockDateLabel(item.granted_at, locale),
         })}
       </p>
     </div>
+  )
+}
+
+function CeremonySeeAllLink({
+  onNavigate,
+  compact = false,
+}: {
+  onNavigate: () => void
+  compact?: boolean
+}) {
+  const { t } = useTranslation("achievements")
+  return (
+    <Link
+      to="/achievements"
+      onClick={(event) => {
+        event.stopPropagation()
+        onNavigate()
+      }}
+      className={cn(
+        "inline-flex items-center font-medium text-white/70 underline-offset-4 hover:text-white hover:underline",
+        compact ? "mt-1 gap-0.5 text-[10px]" : "mt-3 gap-0.5 text-xs",
+      )}
+    >
+      {t("showcaseSeeAll")}
+      <ChevronRight
+        aria-hidden
+        className={compact ? "size-3" : "size-3.5"}
+      />
+    </Link>
   )
 }
 
@@ -301,6 +341,7 @@ export function AchievementUnlockOverlay() {
               {title}
             </DialogTitle>
             <CeremonyGrantMeta item={hero} locale={i18n.language} t={t} />
+            <CeremonySeeAllLink onNavigate={dismiss} />
 
             {overlapping && (
               <div
@@ -317,6 +358,7 @@ export function AchievementUnlockOverlay() {
                   locale={i18n.language}
                   t={t}
                 />
+                <CeremonySeeAllLink onNavigate={dismiss} />
               </div>
             )}
 
@@ -356,6 +398,7 @@ export function AchievementUnlockOverlay() {
                           date: unlockDateLabel(item.granted_at, i18n.language),
                         })}
                       </p>
+                      <CeremonySeeAllLink compact onNavigate={dismiss} />
                     </li>
                   )
                 })}

--- a/src/components/achievements/AchievementUnlockOverlay.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react"
 import { useAtom, useSetAtom } from "jotai"
 import { useTranslation } from "react-i18next"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
@@ -21,6 +27,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { useEquipTitle } from "@/hooks/useEquipTitle"
 import { useUserProfile } from "@/hooks/useUserProfile"
+import { useMediaQuery } from "@/hooks/useMediaQuery"
 import type { AchievementRank, UnlockedAchievement } from "@/types/achievements"
 
 let audioCtx: AudioContext | null = null
@@ -80,6 +87,52 @@ function localizedTitle(
   return language === "fr" ? item.title_fr : item.title_en
 }
 
+const DIAMOND_PARTICLE_COLORS = ["#a855f7", "#67e8f9"] as const
+const DIAMOND_PARTICLE_COUNT = 18
+
+type DiamondParticleStyle = CSSProperties & {
+  "--dx": string
+  "--dy": string
+}
+
+function diamondParticleStyle(index: number): DiamondParticleStyle {
+  const angle = (index / DIAMOND_PARTICLE_COUNT) * Math.PI * 2
+  const radius = 48 + (index % 5) * 18
+  const size = 4 + (index % 3) * 2
+  return {
+    "--dx": `${Math.cos(angle) * radius}px`,
+    "--dy": `${Math.sin(angle) * radius}px`,
+    width: size,
+    height: size,
+    backgroundColor: DIAMOND_PARTICLE_COLORS[index % 2],
+    animationDelay: `${(index % 6) * 40}ms`,
+    left: "50%",
+    top: "38%",
+  }
+}
+
+const DIAMOND_PARTICLES = Array.from(
+  { length: DIAMOND_PARTICLE_COUNT },
+  (_, index) => diamondParticleStyle(index),
+)
+
+function DiamondParticleBurst() {
+  return (
+    <div
+      className="achievement-diamond-particles pointer-events-none absolute inset-0 z-0"
+      aria-hidden="true"
+    >
+      {DIAMOND_PARTICLES.map((style, index) => (
+        <span
+          key={index}
+          className="achievement-diamond-particle"
+          style={style}
+        />
+      ))}
+    </div>
+  )
+}
+
 export function AchievementUnlockOverlay() {
   const { t, i18n } = useTranslation("achievements")
   const [queue, setQueue] = useAtom(achievementUnlockQueueAtom)
@@ -88,6 +141,8 @@ export function AchievementUnlockOverlay() {
   const hasPlayedRef = useRef(false)
   const equipTitle = useEquipTitle()
   const { data: profile } = useUserProfile()
+  const reduceMotion = useMediaQuery("(prefers-reduced-motion: reduce)")
+  const allowMotion = !reduceMotion
 
   if (batch === null && queue.length > 0) {
     setBatch(queue)
@@ -149,21 +204,32 @@ export function AchievementUnlockOverlay() {
           onClick={dismiss}
           aria-label={title}
         >
-          <div className="relative">
+          {rank === "diamond" && allowMotion && <DiamondParticleBurst />}
+          <div className="relative z-10">
             <div
               className={cn(
-                "absolute -inset-10 opacity-0 achievement-rank-glow",
+                "absolute -inset-10",
                 rankGlowClass[rank],
+                allowMotion
+                  ? "opacity-0 achievement-rank-glow"
+                  : "opacity-35",
               )}
             />
 
-            <div className="relative achievement-badge-reveal">
-              <div
-                className={cn(
-                  "absolute inset-0 achievement-particle-burst",
-                  rankGlowClass[rank],
-                )}
-              />
+            <div
+              className={cn(
+                "relative",
+                allowMotion && "achievement-badge-reveal",
+              )}
+            >
+              {allowMotion && (
+                <div
+                  className={cn(
+                    "absolute inset-0 achievement-particle-burst",
+                    rankGlowClass[rank],
+                  )}
+                />
+              )}
               <BadgeIcon
                 rank={rank}
                 iconUrl={hero.icon_asset_url}
@@ -174,7 +240,10 @@ export function AchievementUnlockOverlay() {
               />
               {overlapping && (
                 <div
-                  className="absolute -bottom-1 -right-3"
+                  className={cn(
+                    "absolute -bottom-1 -right-3",
+                    allowMotion && "achievement-supporting-entrance",
+                  )}
                   aria-label={localizedTitle(overlapping, i18n.language)}
                 >
                   <BadgeIcon
@@ -190,7 +259,12 @@ export function AchievementUnlockOverlay() {
           </div>
 
           {showSupportingRow && (
-            <ul className="flex items-end justify-center gap-3">
+            <ul
+              className={cn(
+                "relative z-10 flex items-end justify-center gap-3",
+                allowMotion && "achievement-supporting-entrance",
+              )}
+            >
               {visible.map((item) => {
                 const caption = `${t(`ranks.${item.rank}`)} ${localizedTitle(item, i18n.language)}`
                 return (
@@ -223,7 +297,12 @@ export function AchievementUnlockOverlay() {
             </ul>
           )}
 
-          <div className="flex flex-col items-center gap-2 achievement-text-entrance">
+          <div
+            className={cn(
+              "relative z-10 flex flex-col items-center gap-2",
+              allowMotion && "achievement-text-entrance",
+            )}
+          >
             <p className="text-sm font-medium tracking-wide text-muted-foreground">
               {eyebrow}
             </p>

--- a/src/components/achievements/AchievementUnlockOverlay.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.tsx
@@ -18,6 +18,9 @@ import { formatCompactNumber } from "@/lib/formatters"
 import { pickHero, supportingMedals, supportingOverflow } from "@/lib/achievementUtils"
 import { BadgeIcon } from "@/components/achievements/BadgeIcon"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { useEquipTitle } from "@/hooks/useEquipTitle"
+import { useUserProfile } from "@/hooks/useUserProfile"
 import type { AchievementRank, UnlockedAchievement } from "@/types/achievements"
 
 let audioCtx: AudioContext | null = null
@@ -83,6 +86,8 @@ export function AchievementUnlockOverlay() {
   const setShownIds = useSetAtom(achievementShownIdsAtom)
   const [batch, setBatch] = useState<UnlockedAchievement[] | null>(null)
   const hasPlayedRef = useRef(false)
+  const equipTitle = useEquipTitle()
+  const { data: profile } = useUserProfile()
 
   if (batch === null && queue.length > 0) {
     setBatch(queue)
@@ -125,6 +130,7 @@ export function AchievementUnlockOverlay() {
   const { visible, overflowCount } = supportingOverflow(supporting)
   const overflowLabel = t("ceremonyOverflow", { count: overflowCount })
   const showSupportingRow = supporting.length >= 2
+  const heroAlreadyEquipped = profile?.active_title_tier_id === hero.tier_id
 
   return (
     <Dialog
@@ -242,6 +248,20 @@ export function AchievementUnlockOverlay() {
                   target: thresholdTarget,
                 })}
               </p>
+            )}
+            {!heroAlreadyEquipped && (
+              <Button
+                variant="default"
+                size="lg"
+                className="w-full max-w-xs"
+                disabled={equipTitle.isPending}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  equipTitle.mutate(hero.tier_id)
+                }}
+              >
+                {t("equipTitle")}
+              </Button>
             )}
             <p className="text-sm text-muted-foreground">
               {t("ceremonyTapToContinue")}

--- a/src/components/achievements/AchievementUnlockOverlay.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.tsx
@@ -1,16 +1,24 @@
-import { useEffect, useRef, useCallback } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useAtom, useSetAtom } from "jotai"
 import { useTranslation } from "react-i18next"
-import * as Dialog from "@radix-ui/react-dialog"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import {
+  Dialog,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import {
   achievementUnlockQueueAtom,
   achievementShownIdsAtom,
 } from "@/store/atoms"
 import { cn } from "@/lib/utils"
+import { formatCompactNumber } from "@/lib/formatters"
+import { pickHero, supportingMedals, supportingOverflow } from "@/lib/achievementUtils"
 import { BadgeIcon } from "@/components/achievements/BadgeIcon"
-import type { AchievementRank } from "@/types/achievements"
-
-const AUTO_DISMISS_MS = 4_000
+import { Badge } from "@/components/ui/badge"
+import type { AchievementRank, UnlockedAchievement } from "@/types/achievements"
 
 let audioCtx: AudioContext | null = null
 function getAudioCtx(): AudioContext {
@@ -46,14 +54,6 @@ function playAchievementChime() {
   }
 }
 
-const rankColorClass: Record<AchievementRank, string> = {
-  bronze: "text-amber-600",
-  silver: "text-slate-300",
-  gold: "text-yellow-400",
-  platinum: "text-blue-300",
-  diamond: "text-purple-400",
-}
-
 const rankGlowClass: Record<AchievementRank, string> = {
   bronze: "achievement-glow-bronze",
   silver: "achievement-glow-silver",
@@ -62,121 +62,197 @@ const rankGlowClass: Record<AchievementRank, string> = {
   diamond: "achievement-glow-diamond",
 }
 
+const rankChipHex: Record<AchievementRank, string> = {
+  bronze: "#C26A16",
+  silver: "#c8c8dc",
+  gold: "#F0C014",
+  platinum: "#93c5fd",
+  diamond: "#a855f7",
+}
+
+function localizedTitle(
+  item: UnlockedAchievement,
+  language: string,
+): string {
+  return language === "fr" ? item.title_fr : item.title_en
+}
+
 export function AchievementUnlockOverlay() {
   const { t, i18n } = useTranslation("achievements")
   const [queue, setQueue] = useAtom(achievementUnlockQueueAtom)
   const setShownIds = useSetAtom(achievementShownIdsAtom)
-  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [batch, setBatch] = useState<UnlockedAchievement[] | null>(null)
   const hasPlayedRef = useRef(false)
 
-  const current = queue[0] ?? null
-  const isOpen = current !== null
+  if (batch === null && queue.length > 0) {
+    setBatch(queue)
+  }
 
   const dismiss = useCallback(() => {
-    if (dismissTimerRef.current) {
-      clearTimeout(dismissTimerRef.current)
-      dismissTimerRef.current = null
-    }
-    hasPlayedRef.current = false
-
-    setQueue((prev) => {
-      const dismissed = prev[0]
-      if (dismissed) {
-        setShownIds((ids: Set<string>) => new Set([...ids, dismissed.tier_id]))
-      }
-      return prev.slice(1)
-    })
-  }, [setQueue, setShownIds])
+    if (!batch) return
+    const batchIds = new Set(batch.map((item) => item.tier_id))
+    setShownIds((ids) => new Set([...ids, ...batchIds]))
+    setQueue((prev) => prev.filter((item) => !batchIds.has(item.tier_id)))
+    setBatch(null)
+  }, [batch, setQueue, setShownIds])
 
   useEffect(() => {
-    if (!current) return
+    if (!batch) {
+      hasPlayedRef.current = false
+      return
+    }
     if (hasPlayedRef.current) return
     hasPlayedRef.current = true
-
     if (navigator.vibrate) navigator.vibrate([100, 50, 200])
     playAchievementChime()
+  }, [batch])
 
-    dismissTimerRef.current = setTimeout(dismiss, AUTO_DISMISS_MS)
-    return () => {
-      if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current)
-    }
-  }, [current, dismiss])
+  if (!batch) return null
 
-  if (!current) return null
-
-  const title =
-    i18n.language === "fr" ? current.title_fr : current.title_en
-  const rank = current.rank
+  const hero = pickHero(batch)
+  const supporting = supportingMedals(batch, hero)
+  const title = localizedTitle(hero, i18n.language)
+  const rank = hero.rank
+  const chipHex = rankChipHex[rank]
+  const thresholdTarget = Number.isFinite(hero.threshold_value)
+    ? formatCompactNumber(hero.threshold_value, i18n.language)
+    : null
+  const eyebrow =
+    batch.length === 1
+      ? t("ceremonyEyebrow")
+      : t("ceremonyEyebrowCount", { count: batch.length })
+  const overlapping = supporting.length === 1 ? supporting[0] : null
+  const { visible, overflowCount } = supportingOverflow(supporting)
+  const overflowLabel = t("ceremonyOverflow", { count: overflowCount })
+  const showSupportingRow = supporting.length >= 2
 
   return (
-    <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open) dismiss() }}>
-      <Dialog.Portal>
-        <Dialog.Overlay
-          className="fixed inset-0 z-50 bg-black/70 animate-in fade-in duration-300"
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) dismiss()
+      }}
+    >
+      <DialogPortal>
+        <DialogOverlay
+          className="bg-[#0f0f13]/70 backdrop-blur-sm"
           onClick={dismiss}
         />
-        <Dialog.Content
+        <DialogPrimitive.Content
           className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 outline-hidden"
           onClick={dismiss}
           aria-label={title}
-          onEscapeKeyDown={dismiss}
         >
-          {/* Rank glow */}
-          <div
-            className={cn(
-              "absolute inset-0 opacity-0 achievement-rank-glow",
-              rankGlowClass[rank],
-            )}
-          />
-
-          {/* Badge reveal */}
-          <div className="relative achievement-badge-reveal">
-            {/* Particle burst */}
-            <div className={cn("absolute inset-0 achievement-particle-burst", rankGlowClass[rank])} />
-
+          <div className="relative">
             <div
               className={cn(
-                "flex h-28 w-28 items-center justify-center rounded-full border-2 bg-card/80 backdrop-blur-sm",
-                rank === "bronze" && "border-amber-600",
-                rank === "silver" && "border-slate-300",
-                rank === "gold" && "border-yellow-400",
-                rank === "platinum" && "border-blue-300",
-                rank === "diamond" && "border-purple-400",
+                "absolute -inset-10 opacity-0 achievement-rank-glow",
+                rankGlowClass[rank],
               )}
-            >
+            />
+
+            <div className="relative achievement-badge-reveal">
+              <div
+                className={cn(
+                  "absolute inset-0 achievement-particle-burst",
+                  rankGlowClass[rank],
+                )}
+              />
               <BadgeIcon
                 rank={rank}
-                iconUrl={current.icon_asset_url}
+                iconUrl={hero.icon_asset_url}
                 size="lg"
+                className={overlapping ? "h-[120px] w-[120px]" : undefined}
                 alt={title}
                 eager
               />
+              {overlapping && (
+                <div
+                  className="absolute -bottom-1 -right-3"
+                  aria-label={localizedTitle(overlapping, i18n.language)}
+                >
+                  <BadgeIcon
+                    rank={overlapping.rank}
+                    iconUrl={overlapping.icon_asset_url}
+                    className="h-[72px] w-[72px]"
+                    alt={localizedTitle(overlapping, i18n.language)}
+                    eager
+                  />
+                </div>
+              )}
             </div>
           </div>
 
-          {/* Text entrance */}
-          <div className="flex flex-col items-center gap-2 achievement-text-entrance">
-            <h2 className="text-2xl font-bold text-foreground">{title}</h2>
-            <span
-              className={cn(
-                "rounded-full px-3 py-0.5 text-sm font-semibold capitalize",
-                rankColorClass[rank],
-                "bg-card/60",
+          {showSupportingRow && (
+            <ul className="flex items-end justify-center gap-3">
+              {visible.map((item) => {
+                const caption = `${t(`ranks.${item.rank}`)} ${localizedTitle(item, i18n.language)}`
+                return (
+                  <li
+                    key={item.tier_id}
+                    aria-label={caption}
+                    className="flex max-w-20 flex-col items-center gap-1"
+                  >
+                    <BadgeIcon
+                      rank={item.rank}
+                      iconUrl={item.icon_asset_url}
+                      className="h-14 w-14"
+                      alt=""
+                      eager
+                    />
+                    <p className="text-center text-xs text-muted-foreground">
+                      {caption}
+                    </p>
+                  </li>
+                )
+              })}
+              {overflowCount > 0 && (
+                <li
+                  aria-label={overflowLabel}
+                  className="flex h-14 w-14 items-center justify-center rounded-full border border-dashed border-muted-foreground/40 text-sm font-semibold text-muted-foreground"
+                >
+                  {overflowLabel}
+                </li>
               )}
-            >
-              {rank}
-            </span>
+            </ul>
+          )}
+
+          <div className="flex flex-col items-center gap-2 achievement-text-entrance">
+            <p className="text-sm font-medium tracking-wide text-muted-foreground">
+              {eyebrow}
+            </p>
+            <DialogTitle className="text-2xl font-bold tracking-tight text-foreground">
+              {title}
+            </DialogTitle>
+            <div className="flex items-center gap-2">
+              <Badge
+                variant="outline"
+                className="bg-card/60"
+                style={{ color: chipHex, borderColor: chipHex }}
+              >
+                {t(`ranks.${rank}`)}
+              </Badge>
+              <Badge variant="outline" className="text-muted-foreground">
+                {t(`groups.${hero.group_slug}`)}
+              </Badge>
+            </div>
+            {thresholdTarget !== null && (
+              <p className="text-sm text-muted-foreground">
+                {t(`thresholdHint.${hero.group_slug}`, {
+                  target: thresholdTarget,
+                })}
+              </p>
+            )}
             <p className="text-sm text-muted-foreground">
-              {t(`groupDescriptions.${current.group_slug}`)}
+              {t("ceremonyTapToContinue")}
             </p>
           </div>
 
-          <Dialog.Title className="sr-only">{title}</Dialog.Title>
-          <Dialog.Description className="sr-only">
-            {rank} achievement unlocked
-          </Dialog.Description>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+          <DialogDescription className="sr-only">
+            {t(`ranks.${rank}`)} {title}
+          </DialogDescription>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    </Dialog>
   )
 }

--- a/src/components/achievements/AchievementUnlockOverlay.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.tsx
@@ -20,49 +20,16 @@ import {
   achievementShownIdsAtom,
 } from "@/store/atoms"
 import { cn } from "@/lib/utils"
-import { formatCompactNumber } from "@/lib/formatters"
+import { formatCompactNumber, formatDate } from "@/lib/formatters"
 import { pickHero, supportingMedals, supportingOverflow } from "@/lib/achievementUtils"
-import { BadgeIcon } from "@/components/achievements/BadgeIcon"
+import { CeremonyMedal } from "@/components/achievements/CeremonyMedal"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { useEquipTitle } from "@/hooks/useEquipTitle"
 import { useUserProfile } from "@/hooks/useUserProfile"
 import { useMediaQuery } from "@/hooks/useMediaQuery"
+import { playAchievementFanfare } from "@/lib/audio"
 import type { AchievementRank, UnlockedAchievement } from "@/types/achievements"
-
-let audioCtx: AudioContext | null = null
-function getAudioCtx(): AudioContext {
-  if (!audioCtx) audioCtx = new AudioContext()
-  return audioCtx
-}
-
-function playAchievementChime() {
-  try {
-    const ctx = getAudioCtx()
-    if (ctx.state === "suspended") ctx.resume()
-
-    const play = (freq: number, delay: number, dur: number) => {
-      const osc = ctx.createOscillator()
-      const gain = ctx.createGain()
-      osc.connect(gain)
-      gain.connect(ctx.destination)
-      osc.frequency.value = freq
-      osc.type = "sine"
-      gain.gain.setValueAtTime(0.35, ctx.currentTime + delay)
-      gain.gain.exponentialRampToValueAtTime(
-        0.001,
-        ctx.currentTime + delay + dur,
-      )
-      osc.start(ctx.currentTime + delay)
-      osc.stop(ctx.currentTime + delay + dur)
-    }
-
-    play(523, 0, 0.25)
-    play(784, 0.15, 0.35)
-  } catch {
-    // Web Audio unavailable — silent fallback
-  }
-}
 
 const rankGlowClass: Record<AchievementRank, string> = {
   bronze: "achievement-glow-bronze",
@@ -87,47 +54,112 @@ function localizedTitle(
   return language === "fr" ? item.title_fr : item.title_en
 }
 
-const DIAMOND_PARTICLE_COLORS = ["#a855f7", "#67e8f9"] as const
-const DIAMOND_PARTICLE_COUNT = 18
+const UNLOCK_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+}
 
-type DiamondParticleStyle = CSSProperties & {
+function unlockDateLabel(grantedAt: string | undefined, locale: string): string {
+  return formatDate(grantedAt ?? new Date(), locale, UNLOCK_DATE_OPTIONS)
+}
+
+function CeremonyGrantMeta({
+  item,
+  locale,
+  t,
+}: {
+  item: UnlockedAchievement
+  locale: string
+  t: (key: string, options?: { target?: string; date?: string }) => string
+}) {
+  const thresholdTarget = Number.isFinite(item.threshold_value)
+    ? formatCompactNumber(item.threshold_value, locale)
+    : null
+  return (
+    <div className="flex flex-col items-center">
+      <div className="mt-3 flex items-center gap-2">
+        <Badge
+          variant="outline"
+          className="rounded-md border-transparent bg-white/5 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
+          style={{ color: rankChipHex[item.rank] }}
+        >
+          {t(`ranks.${item.rank}`)}
+        </Badge>
+        <span className="text-sm text-white/70">
+          {t(`groups.${item.group_slug}`)}
+        </span>
+      </div>
+      {thresholdTarget !== null && (
+        <p className="mt-2 text-center text-sm text-white/55">
+          {t(`thresholdHint.${item.group_slug}`, { target: thresholdTarget })}
+        </p>
+      )}
+      <p className="mt-1 text-center text-xs text-white/40">
+        {t("unlockedOn", {
+          date: unlockDateLabel(item.granted_at, locale),
+        })}
+      </p>
+    </div>
+  )
+}
+
+const SPARKLE_COLORS: Record<AchievementRank, readonly [string, string]> = {
+  bronze: ["#C26A16", "#E8A04A"],
+  silver: ["#c8c8dc", "#e8e8f4"],
+  gold: ["#F0C014", "#FFE27A"],
+  platinum: ["#93c5fd", "#dbeafe"],
+  diamond: ["#a855f7", "#67e8f9"],
+}
+
+const SPARKLE_COUNT: Record<AchievementRank, number> = {
+  bronze: 16,
+  silver: 20,
+  gold: 22,
+  platinum: 22,
+  diamond: 28,
+}
+
+type SparkleStyle = CSSProperties & {
   "--dx": string
   "--dy": string
 }
 
-function diamondParticleStyle(index: number): DiamondParticleStyle {
-  const angle = (index / DIAMOND_PARTICLE_COUNT) * Math.PI * 2
-  const radius = 48 + (index % 5) * 18
-  const size = 4 + (index % 3) * 2
+function sparkleStyle(
+  rank: AchievementRank,
+  index: number,
+  count: number,
+): SparkleStyle {
+  const colors = SPARKLE_COLORS[rank]
+  const color = colors[index % 2]
+  const angle = (index / count) * Math.PI * 2
+  const radius = 52 + (index % 5) * 18
+  const size = 4 + (index % 3)
   return {
     "--dx": `${Math.cos(angle) * radius}px`,
     "--dy": `${Math.sin(angle) * radius}px`,
     width: size,
     height: size,
-    backgroundColor: DIAMOND_PARTICLE_COLORS[index % 2],
+    backgroundColor: color,
+    color,
     animationDelay: `${(index % 6) * 40}ms`,
     left: "50%",
-    top: "38%",
+    top: "42%",
   }
 }
 
-const DIAMOND_PARTICLES = Array.from(
-  { length: DIAMOND_PARTICLE_COUNT },
-  (_, index) => diamondParticleStyle(index),
-)
-
-function DiamondParticleBurst() {
+function RankSparkles({ rank }: { rank: AchievementRank }) {
+  const count = SPARKLE_COUNT[rank]
+  const particles = Array.from({ length: count }, (_, index) =>
+    sparkleStyle(rank, index, count),
+  )
   return (
     <div
-      className="achievement-diamond-particles pointer-events-none absolute inset-0 z-0"
+      className="achievement-rank-sparkles pointer-events-none absolute inset-0 z-0"
       aria-hidden="true"
     >
-      {DIAMOND_PARTICLES.map((style, index) => (
-        <span
-          key={index}
-          className="achievement-diamond-particle"
-          style={style}
-        />
+      {particles.map((style, index) => (
+        <span key={index} className="achievement-sparkle" style={style} />
       ))}
     </div>
   )
@@ -163,8 +195,8 @@ export function AchievementUnlockOverlay() {
     }
     if (hasPlayedRef.current) return
     hasPlayedRef.current = true
-    if (navigator.vibrate) navigator.vibrate([100, 50, 200])
-    playAchievementChime()
+    if (navigator.vibrate) navigator.vibrate([40, 30, 40, 30, 140])
+    playAchievementFanfare(pickHero(batch).rank)
   }, [batch])
 
   if (!batch) return null
@@ -173,10 +205,6 @@ export function AchievementUnlockOverlay() {
   const supporting = supportingMedals(batch, hero)
   const title = localizedTitle(hero, i18n.language)
   const rank = hero.rank
-  const chipHex = rankChipHex[rank]
-  const thresholdTarget = Number.isFinite(hero.threshold_value)
-    ? formatCompactNumber(hero.threshold_value, i18n.language)
-    : null
   const eyebrow =
     batch.length === 1
       ? t("ceremonyEyebrow")
@@ -186,6 +214,12 @@ export function AchievementUnlockOverlay() {
   const overflowLabel = t("ceremonyOverflow", { count: overflowCount })
   const showSupportingRow = supporting.length >= 2
   const heroAlreadyEquipped = profile?.active_title_tier_id === hero.tier_id
+  const heroSize = overlapping ? 120 : 112
+  const eyebrowNode = (
+    <p className="text-[11px] font-medium uppercase tracking-[0.22em] text-white/55">
+      {eyebrow}
+    </p>
+  )
 
   return (
     <Dialog
@@ -196,143 +230,151 @@ export function AchievementUnlockOverlay() {
     >
       <DialogPortal>
         <DialogOverlay
-          className="bg-[#0f0f13]/70 backdrop-blur-sm"
+          className="bg-[#0f0f13]/90 backdrop-blur-[2px]"
           onClick={dismiss}
         />
         <DialogPrimitive.Content
-          className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 outline-hidden"
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center outline-hidden"
           onClick={dismiss}
           aria-label={title}
         >
-          {rank === "diamond" && allowMotion && <DiamondParticleBurst />}
-          <div className="relative z-10">
-            <div
-              className={cn(
-                "absolute -inset-10",
-                rankGlowClass[rank],
-                allowMotion
-                  ? "opacity-0 achievement-rank-glow"
-                  : "opacity-35",
-              )}
-            />
-
-            <div
-              className={cn(
-                "relative",
-                allowMotion && "achievement-badge-reveal",
-              )}
-            >
-              {allowMotion && (
-                <div
-                  className={cn(
-                    "absolute inset-0 achievement-particle-burst",
-                    rankGlowClass[rank],
-                  )}
-                />
-              )}
-              <BadgeIcon
-                rank={rank}
-                iconUrl={hero.icon_asset_url}
-                size="lg"
-                className={overlapping ? "h-[120px] w-[120px]" : undefined}
-                alt={title}
-                eager
-              />
-              {overlapping && (
-                <div
-                  className={cn(
-                    "absolute -bottom-1 -right-3",
-                    allowMotion && "achievement-supporting-entrance",
-                  )}
-                  aria-label={localizedTitle(overlapping, i18n.language)}
-                >
-                  <BadgeIcon
-                    rank={overlapping.rank}
-                    iconUrl={overlapping.icon_asset_url}
-                    className="h-[72px] w-[72px]"
-                    alt={localizedTitle(overlapping, i18n.language)}
-                    eager
-                  />
-                </div>
-              )}
-            </div>
-          </div>
-
-          {showSupportingRow && (
-            <ul
-              className={cn(
-                "relative z-10 flex items-end justify-center gap-3",
-                allowMotion && "achievement-supporting-entrance",
-              )}
-            >
-              {visible.map((item) => {
-                const caption = `${t(`ranks.${item.rank}`)} ${localizedTitle(item, i18n.language)}`
-                return (
-                  <li
-                    key={item.tier_id}
-                    aria-label={caption}
-                    className="flex max-w-20 flex-col items-center gap-1"
-                  >
-                    <BadgeIcon
-                      rank={item.rank}
-                      iconUrl={item.icon_asset_url}
-                      className="h-14 w-14"
-                      alt=""
-                      eager
-                    />
-                    <p className="text-center text-xs text-muted-foreground">
-                      {caption}
-                    </p>
-                  </li>
-                )
-              })}
-              {overflowCount > 0 && (
-                <li
-                  aria-label={overflowLabel}
-                  className="flex h-14 w-14 items-center justify-center rounded-full border border-dashed border-muted-foreground/40 text-sm font-semibold text-muted-foreground"
-                >
-                  {overflowLabel}
-                </li>
-              )}
-            </ul>
-          )}
-
           <div
             className={cn(
-              "relative z-10 flex flex-col items-center gap-2",
+              "relative z-10 flex w-full max-w-[320px] flex-col items-center px-6",
               allowMotion && "achievement-text-entrance",
             )}
           >
-            <p className="text-sm font-medium tracking-wide text-muted-foreground">
-              {eyebrow}
-            </p>
-            <DialogTitle className="text-2xl font-bold tracking-tight text-foreground">
+            {batch.length > 1 && <div className="mb-5">{eyebrowNode}</div>}
+
+            <div className="relative">
+              <div
+                className={cn(
+                  "absolute -inset-12",
+                  rankGlowClass[rank],
+                  allowMotion
+                    ? "opacity-0 achievement-rank-glow"
+                    : "opacity-35",
+                )}
+              />
+              <div
+                className={cn(
+                  "relative",
+                  allowMotion && "achievement-badge-reveal",
+                )}
+              >
+                {allowMotion && <RankSparkles rank={rank} />}
+                {allowMotion && (
+                  <div
+                    className={cn(
+                      "absolute inset-0 achievement-particle-burst",
+                      rankGlowClass[rank],
+                    )}
+                  />
+                )}
+                <CeremonyMedal
+                  rank={rank}
+                  iconUrl={hero.icon_asset_url}
+                  alt={title}
+                  size={heroSize}
+                />
+                {overlapping && (
+                  <div
+                    className={cn(
+                      "absolute -bottom-1 -right-3",
+                      allowMotion && "achievement-supporting-entrance",
+                    )}
+                  >
+                    <CeremonyMedal
+                      rank={overlapping.rank}
+                      iconUrl={overlapping.icon_asset_url}
+                      alt={localizedTitle(overlapping, i18n.language)}
+                      size={72}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {batch.length === 1 && <div className="mt-5">{eyebrowNode}</div>}
+
+            <DialogTitle className="mt-3 text-center text-[28px] font-semibold leading-tight tracking-tight text-white">
               {title}
             </DialogTitle>
-            <div className="flex items-center gap-2">
-              <Badge
-                variant="outline"
-                className="bg-card/60"
-                style={{ color: chipHex, borderColor: chipHex }}
+            <CeremonyGrantMeta item={hero} locale={i18n.language} t={t} />
+
+            {overlapping && (
+              <div
+                className={cn(
+                  "mt-6 flex flex-col items-center",
+                  allowMotion && "achievement-supporting-entrance",
+                )}
               >
-                {t(`ranks.${rank}`)}
-              </Badge>
-              <Badge variant="outline" className="text-muted-foreground">
-                {t(`groups.${hero.group_slug}`)}
-              </Badge>
-            </div>
-            {thresholdTarget !== null && (
-              <p className="text-sm text-muted-foreground">
-                {t(`thresholdHint.${hero.group_slug}`, {
-                  target: thresholdTarget,
-                })}
-              </p>
+                <p className="text-center text-lg font-semibold text-white">
+                  {localizedTitle(overlapping, i18n.language)}
+                </p>
+                <CeremonyGrantMeta
+                  item={overlapping}
+                  locale={i18n.language}
+                  t={t}
+                />
+              </div>
             )}
+
+            {showSupportingRow && (
+              <ul
+                className={cn(
+                  "mt-8 flex items-start justify-center gap-5",
+                  allowMotion && "achievement-supporting-entrance",
+                )}
+              >
+                {visible.map((item) => {
+                  const itemTitle = localizedTitle(item, i18n.language)
+                  const caption = `${t(`ranks.${item.rank}`)} ${itemTitle}`
+                  return (
+                    <li
+                      key={item.tier_id}
+                      aria-label={caption}
+                      className="flex w-[72px] flex-col items-center gap-1.5"
+                    >
+                      <CeremonyMedal
+                        rank={item.rank}
+                        iconUrl={item.icon_asset_url}
+                        alt=""
+                        size={56}
+                      />
+                      <p
+                        className="text-[10px] font-semibold uppercase tracking-wide"
+                        style={{ color: rankChipHex[item.rank] }}
+                      >
+                        {t(`ranks.${item.rank}`)}
+                      </p>
+                      <p className="text-center text-[11px] leading-tight text-white/50">
+                        {itemTitle}
+                      </p>
+                      <p className="text-center text-[10px] text-white/35">
+                        {t("unlockedOn", {
+                          date: unlockDateLabel(item.granted_at, i18n.language),
+                        })}
+                      </p>
+                    </li>
+                  )
+                })}
+                {overflowCount > 0 && (
+                  <li
+                    aria-label={overflowLabel}
+                    className="flex h-14 w-14 items-center justify-center rounded-full border border-dashed border-white/25 text-sm font-semibold text-white/50"
+                  >
+                    {overflowLabel}
+                  </li>
+                )}
+              </ul>
+            )}
+
             {!heroAlreadyEquipped && (
               <Button
                 variant="default"
                 size="lg"
-                className="w-full max-w-xs"
+                className="mt-10 h-12 w-full rounded-lg text-base font-semibold"
                 disabled={equipTitle.isPending}
                 onClick={(event) => {
                   event.stopPropagation()
@@ -342,7 +384,12 @@ export function AchievementUnlockOverlay() {
                 {t("equipTitle")}
               </Button>
             )}
-            <p className="text-sm text-muted-foreground">
+            <p
+              className={cn(
+                "mt-4 text-sm font-medium uppercase tracking-[0.18em] text-white/50",
+                allowMotion && "achievement-tap-continue-pulse",
+              )}
+            >
               {t("ceremonyTapToContinue")}
             </p>
           </div>

--- a/src/components/achievements/AchievementUnlockOverlay.tsx
+++ b/src/components/achievements/AchievementUnlockOverlay.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/store/atoms"
 import { cn } from "@/lib/utils"
 import { formatCompactNumber, formatDate } from "@/lib/formatters"
-import { pickHero, supportingMedals, supportingOverflow } from "@/lib/achievementUtils"
+import { coerceNumeric, pickHero, supportingMedals, supportingOverflow } from "@/lib/achievementUtils"
 import { CeremonyMedal } from "@/components/achievements/CeremonyMedal"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -75,7 +75,7 @@ function CeremonyGrantMeta({
   locale: string
   t: (key: string, options?: { target?: string; date?: string }) => string
 }) {
-  const threshold = Number(item.threshold_value)
+  const threshold = coerceNumeric(item.threshold_value)
   const thresholdTarget = Number.isFinite(threshold)
     ? formatCompactNumber(threshold, locale)
     : null

--- a/src/components/achievements/BadgeDetailDrawer.tsx
+++ b/src/components/achievements/BadgeDetailDrawer.tsx
@@ -1,7 +1,4 @@
-import { useAtomValue } from "jotai"
 import { useTranslation } from "react-i18next"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { toast } from "sonner"
 import {
   Drawer,
   DrawerContent,
@@ -11,8 +8,7 @@ import {
 } from "@/components/ui/drawer"
 import { Button } from "@/components/ui/button"
 import { BadgeIcon } from "./BadgeIcon"
-import { supabase } from "@/lib/supabase"
-import { authAtom } from "@/store/atoms"
+import { useEquipTitle } from "@/hooks/useEquipTitle"
 import { useUserProfile } from "@/hooks/useUserProfile"
 import { cn } from "@/lib/utils"
 import { rankColorText } from "@/lib/achievementUtils"
@@ -26,31 +22,10 @@ interface BadgeDetailDrawerProps {
 
 export function BadgeDetailDrawer({ badge, onClose }: BadgeDetailDrawerProps) {
   const { t, i18n } = useTranslation("achievements")
-  const user = useAtomValue(authAtom)
-  const queryClient = useQueryClient()
   const { data: profile } = useUserProfile()
+  const equipTitle = useEquipTitle()
 
   const isActive = profile?.active_title_tier_id === badge?.tier_id
-
-  const equipTitle = useMutation({
-    mutationFn: async (tierId: string | null) => {
-      if (!user) throw new Error("Not authenticated")
-      const { error } = await supabase
-        .from("user_profiles")
-        .update({ active_title_tier_id: tierId })
-        .eq("user_id", user.id)
-      if (error) throw error
-    },
-    onSuccess: (_, tierId) => {
-      if (user) {
-        queryClient.invalidateQueries({ queryKey: ["user-profile", user.id] })
-      }
-      toast.success(tierId ? t("titleEquipped") : t("titleRemoved"))
-    },
-    onError: () => {
-      toast.error(t("titleError"))
-    },
-  })
 
   if (!badge) return null
 

--- a/src/components/achievements/CeremonyMedal.test.tsx
+++ b/src/components/achievements/CeremonyMedal.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { CeremonyMedal } from "./CeremonyMedal"
+
+describe("CeremonyMedal", () => {
+  it("renders a metallic coin with the GymLogic ring, not a trophy emoji", () => {
+    const { container } = render(
+      <CeremonyMedal rank="gold" iconUrl={null} alt="Plateau Titan" size={112} />,
+    )
+
+    expect(screen.getByRole("img", { name: "Plateau Titan" })).toBeInTheDocument()
+    expect(container.textContent).toContain("GYMLOGIC")
+    expect(container.textContent).not.toContain("🏆")
+  })
+
+  it("clips the real icon into the coin when a url is provided", () => {
+    const { container } = render(
+      <CeremonyMedal
+        rank="gold"
+        iconUrl="https://example.com/badge.png"
+        alt="Plateau Titan"
+        size={112}
+      />,
+    )
+
+    expect(container.querySelector("image")).toHaveAttribute(
+      "href",
+      "https://example.com/badge.png",
+    )
+  })
+})

--- a/src/components/achievements/CeremonyMedal.tsx
+++ b/src/components/achievements/CeremonyMedal.tsx
@@ -1,0 +1,153 @@
+import { useId } from "react"
+import { cn } from "@/lib/utils"
+import type { AchievementRank } from "@/types/achievements"
+
+const RING = "GYMLOGIC  ·  FITNESS APP  ·  "
+
+const metal: Record<
+  AchievementRank,
+  { ring: string; mid: string; inner: string; accent: string }
+> = {
+  bronze: {
+    ring: "#C26A16",
+    mid: "#8B4E14",
+    inner: "#140c06",
+    accent: "#E8A04A",
+  },
+  silver: {
+    ring: "#c8c8dc",
+    mid: "#8a8aa0",
+    inner: "#121216",
+    accent: "#e8e8f4",
+  },
+  gold: {
+    ring: "#F0C014",
+    mid: "#C4920A",
+    inner: "#161004",
+    accent: "#FFE27A",
+  },
+  platinum: {
+    ring: "#93c5fd",
+    mid: "#5b8fc7",
+    inner: "#0c141c",
+    accent: "#dbeafe",
+  },
+  diamond: {
+    ring: "#a855f7",
+    mid: "#67e8f9",
+    inner: "#120818",
+    accent: "#e9d5ff",
+  },
+}
+
+function LifterSilhouette({ fill }: { fill: string }) {
+  return (
+    <g fill={fill} stroke={fill} strokeWidth="1.6" strokeLinecap="round">
+      <circle cx="60" cy="44" r="5.5" stroke="none" />
+      <path d="M60 50 v20" fill="none" />
+      <path d="M36 52 h48" fill="none" strokeWidth="2.2" />
+      <path d="M40 48 v8M80 48 v8" fill="none" />
+      <path d="M52 70 L44 90M68 70 L76 90" fill="none" />
+      <path d="M48 58 L42 68M72 58 L78 68" fill="none" />
+    </g>
+  )
+}
+
+interface CeremonyMedalProps {
+  rank: AchievementRank
+  iconUrl: string | null
+  alt: string
+  size: number
+  className?: string
+}
+
+export function CeremonyMedal({
+  rank,
+  iconUrl,
+  alt,
+  size,
+  className,
+}: CeremonyMedalProps) {
+  const uid = useId()
+  const ringPathId = `${uid}-ring`
+  const clipId = `${uid}-clip`
+  const discId = `${uid}-disc`
+  const shineId = `${uid}-shine`
+  const palette = metal[rank]
+  const dualRing = rank === "diamond"
+
+  return (
+    <div
+      role={alt ? "img" : undefined}
+      aria-label={alt || undefined}
+      aria-hidden={alt ? undefined : true}
+      className={cn("relative shrink-0", className)}
+      style={{ width: size, height: size }}
+    >
+      <svg viewBox="0 0 120 120" className="h-full w-full" aria-hidden>
+        <defs>
+          <radialGradient id={discId} cx="38%" cy="32%" r="70%">
+            <stop offset="0%" stopColor={palette.accent} />
+            <stop offset="42%" stopColor={palette.ring} />
+            <stop offset="100%" stopColor={palette.mid} />
+          </radialGradient>
+          <radialGradient id={shineId} cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor={palette.inner} stopOpacity="0.2" />
+            <stop offset="70%" stopColor={palette.inner} />
+            <stop offset="100%" stopColor="#000" />
+          </radialGradient>
+          <path
+            id={ringPathId}
+            d="M60,60 m-40,0 a40,40 0 1,1 80,0 a40,40 0 1,1 -80,0"
+          />
+          <clipPath id={clipId}>
+            <circle cx="60" cy="60" r="28" />
+          </clipPath>
+        </defs>
+
+        <circle
+          cx="60"
+          cy="60"
+          r="56"
+          fill={palette.ring}
+          opacity="0.18"
+        />
+        <circle cx="60" cy="60" r="50" fill={`url(#${discId})`} />
+        {dualRing && (
+          <circle
+            cx="60"
+            cy="60"
+            r="46"
+            fill="none"
+            stroke={palette.mid}
+            strokeWidth="2.4"
+          />
+        )}
+        <circle cx="60" cy="60" r="36" fill={`url(#${shineId})`} />
+        <text
+          fill={rank === "diamond" ? palette.mid : palette.inner}
+          fontSize="6.4"
+          fontWeight="700"
+          letterSpacing="1.8"
+        >
+          <textPath href={`#${ringPathId}`} startOffset="0">
+            {RING}
+          </textPath>
+        </text>
+        {iconUrl ? (
+          <image
+            href={iconUrl}
+            x="32"
+            y="32"
+            width="56"
+            height="56"
+            clipPath={`url(#${clipId})`}
+            preserveAspectRatio="xMidYMid slice"
+          />
+        ) : (
+          <LifterSilhouette fill={palette.accent} />
+        )}
+      </svg>
+    </div>
+  )
+}

--- a/src/hooks/useEquipTitle.test.ts
+++ b/src/hooks/useEquipTitle.test.ts
@@ -8,7 +8,7 @@ import { useEquipTitle } from "./useEquipTitle"
 
 const mockEq = vi.fn()
 const mockUpdate = vi.fn(() => ({ eq: mockEq }))
-const mockFrom = vi.fn((_table: string) => ({ update: mockUpdate }))
+const mockFrom = vi.fn(() => ({ update: mockUpdate }))
 
 vi.mock("@/lib/supabase", () => ({
   supabase: {

--- a/src/hooks/useEquipTitle.test.ts
+++ b/src/hooks/useEquipTitle.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { act } from "@testing-library/react"
+import { toast } from "sonner"
+import { createStore } from "jotai"
+import { renderHookWithProviders } from "@/test/utils"
+import { authAtom } from "@/store/atoms"
+import { useEquipTitle } from "./useEquipTitle"
+
+const mockEq = vi.fn()
+const mockUpdate = vi.fn(() => ({ eq: mockEq }))
+const mockFrom = vi.fn((_table: string) => ({ update: mockUpdate }))
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: (table: string) => mockFrom(table),
+  },
+}))
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const USER_ID = "user-1"
+
+function setAuthed(store: ReturnType<typeof createStore>) {
+  act(() => {
+    store.set(authAtom, { id: USER_ID } as never)
+  })
+}
+
+describe("useEquipTitle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEq.mockResolvedValue({ error: null })
+  })
+
+  it("equips a title, invalidates the profile query, and toasts success", async () => {
+    const { result, store, queryClient } = renderHookWithProviders(() =>
+      useEquipTitle(),
+    )
+    setAuthed(store)
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+
+    await act(async () => {
+      await result.current.mutateAsync("tier-gold")
+    })
+
+    expect(mockFrom).toHaveBeenCalledWith("user_profiles")
+    expect(mockUpdate).toHaveBeenCalledWith({
+      active_title_tier_id: "tier-gold",
+    })
+    expect(mockEq).toHaveBeenCalledWith("user_id", USER_ID)
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ["user-profile", USER_ID],
+    })
+    expect(toast.success).toHaveBeenCalledWith("Title equipped!")
+  })
+
+  it("clears the title, invalidates the profile query, and toasts removal", async () => {
+    const { result, store, queryClient } = renderHookWithProviders(() =>
+      useEquipTitle(),
+    )
+    setAuthed(store)
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+
+    await act(async () => {
+      await result.current.mutateAsync(null)
+    })
+
+    expect(mockUpdate).toHaveBeenCalledWith({ active_title_tier_id: null })
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ["user-profile", USER_ID],
+    })
+    expect(toast.success).toHaveBeenCalledWith("Title removed.")
+  })
+
+  it("toasts an error when the update fails", async () => {
+    mockEq.mockResolvedValue({ error: { message: "RLS denied" } })
+    const { result, store } = renderHookWithProviders(() => useEquipTitle())
+    setAuthed(store)
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync("tier-gold")
+      }),
+    ).rejects.toBeTruthy()
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Could not update title. Try again.",
+    )
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useEquipTitle.test.ts
+++ b/src/hooks/useEquipTitle.test.ts
@@ -8,7 +8,9 @@ import { useEquipTitle } from "./useEquipTitle"
 
 const mockEq = vi.fn()
 const mockUpdate = vi.fn(() => ({ eq: mockEq }))
-const mockFrom = vi.fn(() => ({ update: mockUpdate }))
+const mockFrom = vi.fn<(table: string) => { update: typeof mockUpdate }>(() => ({
+  update: mockUpdate,
+}))
 
 vi.mock("@/lib/supabase", () => ({
   supabase: {

--- a/src/hooks/useEquipTitle.ts
+++ b/src/hooks/useEquipTitle.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useAtomValue } from "jotai"
+import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
+import { supabase } from "@/lib/supabase"
+import { authAtom } from "@/store/atoms"
+
+export function useEquipTitle() {
+  const user = useAtomValue(authAtom)
+  const queryClient = useQueryClient()
+  const { t } = useTranslation("achievements")
+
+  return useMutation({
+    mutationFn: async (tierId: string | null) => {
+      if (!user) throw new Error("Not authenticated")
+      const { error } = await supabase
+        .from("user_profiles")
+        .update({ active_title_tier_id: tierId })
+        .eq("user_id", user.id)
+      if (error) throw error
+    },
+    onSuccess: (_, tierId) => {
+      if (user) {
+        queryClient.invalidateQueries({ queryKey: ["user-profile", user.id] })
+      }
+      toast.success(tierId ? t("titleEquipped") : t("titleRemoved"))
+    },
+    onError: () => {
+      toast.error(t("titleError"))
+    },
+  })
+}

--- a/src/lib/achievementUtils.test.ts
+++ b/src/lib/achievementUtils.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+import { pickHero, supportingMedals, supportingOverflow } from "./achievementUtils"
+import type { UnlockedAchievement } from "@/types/achievements"
+
+function makeUnlock(
+  overrides: Partial<UnlockedAchievement> = {},
+): UnlockedAchievement {
+  return {
+    tier_id: "tier-1",
+    group_slug: "volume_king",
+    rank: "gold",
+    title_en: "Volume King",
+    title_fr: "Roi du Volume",
+    icon_asset_url: null,
+    threshold_value: 5000,
+    ...overrides,
+  }
+}
+
+describe("pickHero", () => {
+  it("picks the highest rank in the batch (diamond over lower metals)", () => {
+    const gold = makeUnlock({ tier_id: "gold", rank: "gold" })
+    const diamond = makeUnlock({ tier_id: "diamond", rank: "diamond" })
+    const bronze = makeUnlock({ tier_id: "bronze", rank: "bronze" })
+
+    expect(pickHero([gold, diamond, bronze])).toBe(diamond)
+  })
+
+  it("keeps the first item when ranks tie", () => {
+    const firstGold = makeUnlock({
+      tier_id: "gold-first",
+      rank: "gold",
+      title_en: "First Gold",
+    })
+    const secondGold = makeUnlock({
+      tier_id: "gold-second",
+      rank: "gold",
+      title_en: "Second Gold",
+    })
+    const silver = makeUnlock({ tier_id: "silver", rank: "silver" })
+
+    expect(pickHero([firstGold, silver, secondGold])).toBe(firstGold)
+  })
+})
+
+describe("supportingMedals", () => {
+  it("returns non-hero items in original order", () => {
+    const bronze = makeUnlock({
+      tier_id: "bronze",
+      rank: "bronze",
+      title_en: "First Steps",
+    })
+    const gold = makeUnlock({
+      tier_id: "gold",
+      rank: "gold",
+      title_en: "Volume King",
+    })
+    const silver = makeUnlock({
+      tier_id: "silver",
+      rank: "silver",
+      title_en: "Quiet Strength",
+    })
+    const batch = [bronze, gold, silver]
+
+    expect(supportingMedals(batch, gold)).toEqual([bronze, silver])
+  })
+})
+
+describe("supportingOverflow", () => {
+  it("keeps the first 3 visible and reports overflow beyond that", () => {
+    const supporting = [
+      makeUnlock({ tier_id: "s1", rank: "bronze" }),
+      makeUnlock({ tier_id: "s2", rank: "silver" }),
+      makeUnlock({ tier_id: "s3", rank: "gold" }),
+      makeUnlock({ tier_id: "s4", rank: "platinum" }),
+      makeUnlock({ tier_id: "s5", rank: "bronze", title_en: "Extra" }),
+    ]
+
+    expect(supportingOverflow(supporting)).toEqual({
+      visible: supporting.slice(0, 3),
+      overflowCount: 2,
+    })
+  })
+
+  it("reports no overflow when three or fewer supporting medals", () => {
+    const supporting = [
+      makeUnlock({ tier_id: "s1", rank: "bronze" }),
+      makeUnlock({ tier_id: "s2", rank: "silver" }),
+    ]
+
+    expect(supportingOverflow(supporting)).toEqual({
+      visible: supporting,
+      overflowCount: 0,
+    })
+  })
+})

--- a/src/lib/achievementUtils.test.ts
+++ b/src/lib/achievementUtils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { pickHero, supportingMedals, supportingOverflow } from "./achievementUtils"
+import {
+  coerceNumeric,
+  pickHero,
+  supportingMedals,
+  supportingOverflow,
+} from "./achievementUtils"
 import type { UnlockedAchievement } from "@/types/achievements"
 
 function makeUnlock(
@@ -92,5 +97,24 @@ describe("supportingOverflow", () => {
       visible: supporting,
       overflowCount: 0,
     })
+  })
+})
+
+describe("coerceNumeric", () => {
+  it("keeps finite numbers", () => {
+    expect(coerceNumeric(3)).toBe(3)
+    expect(coerceNumeric(5000.5)).toBe(5000.5)
+  })
+
+  it("parses PostgREST NUMERIC strings", () => {
+    expect(coerceNumeric("3")).toBe(3)
+    expect(coerceNumeric("5000.5")).toBe(5000.5)
+  })
+
+  it("returns NaN for junk so callers can hide the threshold line", () => {
+    expect(Number.isFinite(coerceNumeric("nope"))).toBe(false)
+    expect(Number.isFinite(coerceNumeric(null))).toBe(false)
+    expect(Number.isFinite(coerceNumeric(undefined))).toBe(false)
+    expect(Number.isFinite(coerceNumeric({}))).toBe(false)
   })
 })

--- a/src/lib/achievementUtils.ts
+++ b/src/lib/achievementUtils.ts
@@ -1,4 +1,8 @@
-import type { AchievementRank, BadgeStatusRow } from "@/types/achievements"
+import type {
+  AchievementRank,
+  BadgeStatusRow,
+  UnlockedAchievement,
+} from "@/types/achievements"
 import type { UserProfile } from "@/types/onboarding"
 
 export const rankColorText: Record<AchievementRank, string> = {
@@ -7,6 +11,36 @@ export const rankColorText: Record<AchievementRank, string> = {
   gold: "text-yellow-400",
   platinum: "text-blue-300",
   diamond: "text-purple-400",
+}
+
+const RANK_ORDER: Record<AchievementRank, number> = {
+  bronze: 0,
+  silver: 1,
+  gold: 2,
+  platinum: 3,
+  diamond: 4,
+}
+
+export function pickHero(batch: UnlockedAchievement[]): UnlockedAchievement {
+  return batch.reduce((hero, item) =>
+    RANK_ORDER[item.rank] > RANK_ORDER[hero.rank] ? item : hero,
+  )
+}
+
+export function supportingMedals(
+  batch: UnlockedAchievement[],
+  hero: UnlockedAchievement,
+): UnlockedAchievement[] {
+  return batch.filter((item) => item.tier_id !== hero.tier_id)
+}
+
+export function supportingOverflow(supporting: UnlockedAchievement[]): {
+  visible: UnlockedAchievement[]
+  overflowCount: number
+} {
+  const visible = supporting.slice(0, 3)
+  const overflowCount = Math.max(0, supporting.length - 3)
+  return { visible, overflowCount }
 }
 
 export function resolveActiveTitle(

--- a/src/lib/achievementUtils.ts
+++ b/src/lib/achievementUtils.ts
@@ -43,6 +43,14 @@ export function supportingOverflow(supporting: UnlockedAchievement[]): {
   return { visible, overflowCount }
 }
 
+/** PostgREST NUMERIC often arrives as a string. Domain values stay `number`. */
+export function coerceNumeric(value: unknown): number {
+  if (typeof value === "number" || typeof value === "string") {
+    return Number(value)
+  }
+  return Number.NaN
+}
+
 export function resolveActiveTitle(
   profile: UserProfile | null | undefined,
   rows: BadgeStatusRow[],

--- a/src/lib/audio.test.ts
+++ b/src/lib/audio.test.ts
@@ -107,11 +107,13 @@ describe("audio.ts", () => {
       }),
     )
 
-    const { primeAudio, playBeep, playFinishBeeps } = await importAudio()
+    const { primeAudio, playBeep, playFinishBeeps, playAchievementFanfare } =
+      await importAudio()
 
     expect(() => primeAudio()).not.toThrow()
     expect(() => playBeep(440, 100)).not.toThrow()
     expect(() => playFinishBeeps()).not.toThrow()
+    expect(() => playAchievementFanfare()).not.toThrow()
   })
 
   it("plays the finish chime as two oscillators at 880 Hz and 1100 Hz, 250 ms apart", async () => {
@@ -131,5 +133,33 @@ describe("audio.ts", () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it("plays a rising fanfare, not a two-beep chime", async () => {
+    const { playAchievementFanfare } = await importAudio()
+
+    playAchievementFanfare("gold")
+
+    expect(currentCtx.oscillators.length).toBeGreaterThan(4)
+    expect(currentCtx.oscillators[0]?.frequency.value).toBeCloseTo(261.63)
+    expect(currentCtx.oscillators.some((osc) => osc.frequency.value === 1046.5)).toBe(
+      true,
+    )
+    expect(
+      currentCtx.oscillators.some((osc) => osc.type === "triangle"),
+    ).toBe(true)
+  })
+
+  it("adds a higher sparkle for Diamond", async () => {
+    const { playAchievementFanfare } = await importAudio()
+
+    playAchievementFanfare("gold")
+    const goldCount = currentCtx.oscillators.length
+
+    playAchievementFanfare("diamond")
+    expect(currentCtx.oscillators.length).toBeGreaterThan(goldCount)
+    expect(currentCtx.oscillators.some((osc) => osc.frequency.value === 2093)).toBe(
+      true,
+    )
   })
 })

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -1,3 +1,5 @@
+import type { AchievementRank } from "@/types/achievements"
+
 let audioCtx: AudioContext | null = null
 
 function getAudioCtx(): AudioContext {
@@ -49,4 +51,64 @@ export function playWarningBeep(): void {
 export function playFinishBeeps(): void {
   playBeep(880, 200, 0.5)
   setTimeout(() => playBeep(1100, 300, 0.5), 250)
+}
+
+type FanfareVoice = {
+  freq: number
+  delay: number
+  dur: number
+  volume: number
+  type: OscillatorType
+}
+
+/** C major lift: arpeggio → octave resolve → sparkle. Game unlock, not a rest beep. */
+const FANFARE_VOICES: FanfareVoice[] = [
+  { freq: 261.63, delay: 0, dur: 0.72, volume: 0.1, type: "sine" },
+  { freq: 523.25, delay: 0, dur: 0.16, volume: 0.22, type: "triangle" },
+  { freq: 659.25, delay: 0.11, dur: 0.16, volume: 0.24, type: "triangle" },
+  { freq: 783.99, delay: 0.22, dur: 0.2, volume: 0.26, type: "triangle" },
+  { freq: 1046.5, delay: 0.34, dur: 0.58, volume: 0.28, type: "triangle" },
+  { freq: 783.99, delay: 0.34, dur: 0.52, volume: 0.14, type: "triangle" },
+  { freq: 1318.51, delay: 0.44, dur: 0.38, volume: 0.11, type: "sine" },
+]
+
+const DIAMOND_VOICES: FanfareVoice[] = [
+  { freq: 1567.98, delay: 0.52, dur: 0.4, volume: 0.09, type: "sine" },
+  { freq: 2093.0, delay: 0.6, dur: 0.28, volume: 0.07, type: "triangle" },
+]
+
+const FANFARE_GAIN: Record<AchievementRank, number> = {
+  bronze: 0.78,
+  silver: 0.86,
+  gold: 0.94,
+  platinum: 1,
+  diamond: 1.06,
+}
+
+function playVoice(ctx: AudioContext, voice: FanfareVoice, gainScale: number): void {
+  const osc = ctx.createOscillator()
+  const gain = ctx.createGain()
+  osc.connect(gain)
+  gain.connect(ctx.destination)
+  osc.type = voice.type
+  osc.frequency.value = voice.freq
+  const start = ctx.currentTime + voice.delay
+  const peak = Math.max(voice.volume * gainScale, 0.001)
+  gain.gain.setValueAtTime(0.001, start)
+  gain.gain.exponentialRampToValueAtTime(peak, start + 0.02)
+  gain.gain.exponentialRampToValueAtTime(0.001, start + voice.dur)
+  osc.start(start)
+  osc.stop(start + voice.dur)
+}
+
+export function playAchievementFanfare(rank: AchievementRank = "gold"): void {
+  try {
+    const ctx = getAudioCtx()
+    const scale = FANFARE_GAIN[rank] ?? FANFARE_GAIN.gold
+    const voices =
+      rank === "diamond" ? [...FANFARE_VOICES, ...DIAMOND_VOICES] : FANFARE_VOICES
+    voices.forEach((voice) => playVoice(ctx, voice, scale))
+  } catch {
+    // Web Audio not available — silent fallback
+  }
 }

--- a/src/lib/syncService.test.ts
+++ b/src/lib/syncService.test.ts
@@ -1,4 +1,5 @@
 import { vi, describe, it, expect, beforeEach } from "vitest"
+import type { UnlockedAchievement } from "@/types/achievements"
 
 // ---------------------------------------------------------------------------
 // Atom markers — unique objects used as identity keys for store.get/set
@@ -49,7 +50,11 @@ let blockRunsChain = createChain()
 
 const mockFrom = vi.fn()
 
-const mockRpc = vi.fn().mockResolvedValue({ data: [], error: null })
+function rpcCall(result: Promise<{ data: unknown; error: unknown }>) {
+  return Object.assign(result, { returns: () => result })
+}
+
+const mockRpc = vi.fn(() => rpcCall(Promise.resolve({ data: [], error: null })))
 const mockSupabase = { from: mockFrom, rpc: mockRpc }
 
 const mockQueryClient = {
@@ -221,6 +226,10 @@ describe("SyncService", () => {
       if (table === "block_runs") return blockRunsChain
       return createChain()
     })
+
+    mockRpc.mockImplementation(() =>
+      rpcCall(Promise.resolve({ data: [], error: null })),
+    )
 
     const mod = await import("./syncService")
     enqueueSetLog = mod.enqueueSetLog
@@ -853,7 +862,9 @@ describe("SyncService", () => {
     })
 
     it("returns true even when achievement RPC fails", async () => {
-      mockRpc.mockRejectedValueOnce(new Error("RPC failed"))
+      mockRpc.mockImplementationOnce(() =>
+        rpcCall(Promise.reject(new Error("RPC failed"))),
+      )
       vi.spyOn(console, "error").mockImplementation(() => {})
       vi.spyOn(console, "warn").mockImplementation(() => {})
 
@@ -875,10 +886,14 @@ describe("SyncService", () => {
     })
 
     it("treats achievement RPC error response as non-critical", async () => {
-      mockRpc.mockResolvedValueOnce({
-        data: null,
-        error: { message: "RPC failed" },
-      })
+      mockRpc.mockImplementationOnce(() =>
+        rpcCall(
+          Promise.resolve({
+            data: null,
+            error: { message: "RPC failed" },
+          }),
+        ),
+      )
       vi.spyOn(console, "warn").mockImplementation(() => {})
 
       enqueueSessionFinish(makeSessionFinishPayload())
@@ -894,7 +909,7 @@ describe("SyncService", () => {
     })
 
     it("pushes RPC response into achievement queue and lastSessionBadgesAtom", async () => {
-      const mockBadges = [
+      const mockBadges: UnlockedAchievement[] = [
         {
           tier_id: "tier-1",
           group_slug: "consistency_streak",
@@ -902,9 +917,12 @@ describe("SyncService", () => {
           title_en: "The Sore Apprentice",
           title_fr: "Apprenti Courbaturé",
           icon_asset_url: null,
+          threshold_value: 3,
         },
       ]
-      mockRpc.mockResolvedValueOnce({ data: mockBadges, error: null })
+      mockRpc.mockImplementationOnce(() =>
+        rpcCall(Promise.resolve({ data: mockBadges, error: null })),
+      )
 
       enqueueSessionFinish(makeSessionFinishPayload())
 

--- a/src/lib/syncService.test.ts
+++ b/src/lib/syncService.test.ts
@@ -948,6 +948,43 @@ describe("SyncService", () => {
       expect(badgesSetCall?.[1]).toEqual(queued)
     })
 
+    it("coerces PostgREST NUMERIC strings on grant RPC rows", async () => {
+      mockRpc.mockImplementationOnce(() =>
+        rpcCall(
+          Promise.resolve({
+            data: [
+              {
+                tier_id: "tier-1",
+                group_slug: "consistency_streak",
+                rank: "bronze",
+                title_en: "The Sore Apprentice",
+                title_fr: "Apprenti Courbaturé",
+                icon_asset_url: null,
+                threshold_value: "3",
+              },
+            ],
+            error: null,
+          }),
+        ),
+      )
+
+      enqueueSessionFinish(makeSessionFinishPayload())
+
+      await drainQueue(USER_ID)
+
+      const queueSetCall = mockStore.set.mock.calls.find(
+        ([atom]) => atom === ACHIEVEMENT_UNLOCK_QUEUE_ATOM,
+      )
+      const queued = queueSetCall?.[1]
+      expect(Array.isArray(queued)).toBe(true)
+      if (!Array.isArray(queued)) return
+      expect(queued[0]).toEqual(
+        expect.objectContaining({
+          threshold_value: 3,
+        }),
+      )
+    })
+
     it("does not call RPC when session upsert fails", async () => {
       sessionsChain.then.mockImplementation(
         (resolve: (v: unknown) => void) =>

--- a/src/lib/syncService.test.ts
+++ b/src/lib/syncService.test.ts
@@ -931,12 +931,21 @@ describe("SyncService", () => {
       const queueSetCall = mockStore.set.mock.calls.find(
         ([atom]) => atom === ACHIEVEMENT_UNLOCK_QUEUE_ATOM,
       )
-      expect(queueSetCall?.[1]).toEqual(mockBadges)
+      const queued = queueSetCall?.[1]
+      expect(Array.isArray(queued)).toBe(true)
+      if (!Array.isArray(queued)) return
+      expect(queued).toHaveLength(1)
+      expect(queued[0]).toEqual(
+        expect.objectContaining({
+          ...mockBadges[0],
+          granted_at: expect.any(String),
+        }),
+      )
 
       const badgesSetCall = mockStore.set.mock.calls.find(
         ([atom]) => atom === LAST_SESSION_BADGES_ATOM,
       )
-      expect(badgesSetCall?.[1]).toEqual(mockBadges)
+      expect(badgesSetCall?.[1]).toEqual(queued)
     })
 
     it("does not call RPC when session upsert fails", async () => {

--- a/src/lib/syncService.ts
+++ b/src/lib/syncService.ts
@@ -964,11 +964,13 @@ async function processSessionFinish(
     }
 
     try {
-      const { data, error } = await supabase.rpc("check_and_grant_achievements", {
-        p_user_id: userId,
-      })
+      const { data, error } = await supabase
+        .rpc("check_and_grant_achievements", {
+          p_user_id: userId,
+        })
+        .returns<UnlockedAchievement[]>()
       if (error) throw error
-      const unlocked = (data ?? []) as UnlockedAchievement[]
+      const unlocked = Array.isArray(data) ? data : []
       if (unlocked.length > 0) {
         pushAchievementsToQueue(unlocked)
         store.set(lastSessionBadgesAtom, unlocked)

--- a/src/lib/syncService.ts
+++ b/src/lib/syncService.ts
@@ -12,6 +12,7 @@ import {
   achievementShownIdsAtom,
   lastSessionBadgesAtom,
 } from "@/store/atoms"
+import { coerceNumeric } from "@/lib/achievementUtils"
 import type { UnlockedAchievement } from "@/types/achievements"
 import type { WorkoutDay } from "@/types/database"
 
@@ -973,6 +974,7 @@ async function processSessionFinish(
       const grantedAt = new Date().toISOString()
       const unlocked = (Array.isArray(data) ? data : []).map((row) => ({
         ...row,
+        threshold_value: coerceNumeric(row.threshold_value),
         granted_at: row.granted_at ?? grantedAt,
       }))
       if (unlocked.length > 0) {

--- a/src/lib/syncService.ts
+++ b/src/lib/syncService.ts
@@ -970,7 +970,11 @@ async function processSessionFinish(
         })
         .returns<UnlockedAchievement[]>()
       if (error) throw error
-      const unlocked = Array.isArray(data) ? data : []
+      const grantedAt = new Date().toISOString()
+      const unlocked = (Array.isArray(data) ? data : []).map((row) => ({
+        ...row,
+        granted_at: row.granted_at ?? grantedAt,
+      }))
       if (unlocked.length > 0) {
         pushAchievementsToQueue(unlocked)
         store.set(lastSessionBadgesAtom, unlocked)

--- a/src/locales/en/achievements.json
+++ b/src/locales/en/achievements.json
@@ -67,6 +67,10 @@
     "heroes": "Min. runs across Heracles / Theseus / Atlas / Achilles",
     "pantheoniste": "Min. runs across the eight Greek seeds"
   },
+  "ceremonyEyebrow": "Unlocked",
+  "ceremonyEyebrowCount": "{{count}} unlocked",
+  "ceremonyOverflow": "+{{count}}",
+  "ceremonyTapToContinue": "Tap to continue",
   "thresholdHint": {
     "consistency_streak": "Complete {{target}} sessions",
     "volume_king": "Lift {{target}} kg total",

--- a/src/locales/fr/achievements.json
+++ b/src/locales/fr/achievements.json
@@ -67,6 +67,10 @@
     "heroes": "Min. de runs Héraclès / Thésée / Atlas / Achille",
     "pantheoniste": "Min. de runs sur les huit grecs"
   },
+  "ceremonyEyebrow": "Débloqué",
+  "ceremonyEyebrowCount": "{{count}} débloqués",
+  "ceremonyOverflow": "+{{count}}",
+  "ceremonyTapToContinue": "Toucher pour continuer",
   "thresholdHint": {
     "consistency_streak": "Terminer {{target}} séances",
     "volume_king": "Soulever {{target}} kg au total",

--- a/src/pages/UnlockOverlayPlaygroundPage.test.tsx
+++ b/src/pages/UnlockOverlayPlaygroundPage.test.tsx
@@ -18,6 +18,7 @@ const BUTTON_NAMES = [
   "Platinum",
   "Diamond",
   "2 overlap",
+  "Burst 3",
   "Burst 4",
   "Overflow 5+",
 ] as const
@@ -29,7 +30,7 @@ describe("UnlockOverlayPlaygroundPage", () => {
     store.set(achievementShownIdsAtom, new Set())
   })
 
-  it("renders the eight fixture buttons", () => {
+  it("renders the nine fixture buttons", () => {
     renderWithProviders(<UnlockOverlayPlaygroundPage />)
 
     for (const name of BUTTON_NAMES) {

--- a/src/pages/UnlockOverlayPlaygroundPage.test.tsx
+++ b/src/pages/UnlockOverlayPlaygroundPage.test.tsx
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { getDefaultStore } from "jotai"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { renderWithProviders } from "@/test/utils"
+import {
+  achievementShownIdsAtom,
+  achievementUnlockQueueAtom,
+} from "@/store/atoms"
+import { UnlockOverlayPlaygroundPage } from "./UnlockOverlayPlaygroundPage"
+
+vi.mock("@/lib/supabase", () => ({ supabase: { from: vi.fn() } }))
+
+const BUTTON_NAMES = [
+  "Bronze",
+  "Silver",
+  "Gold",
+  "Platinum",
+  "Diamond",
+  "2 overlap",
+  "Burst 4",
+  "Overflow 5+",
+] as const
+
+describe("UnlockOverlayPlaygroundPage", () => {
+  afterEach(() => {
+    const store = getDefaultStore()
+    store.set(achievementUnlockQueueAtom, [])
+    store.set(achievementShownIdsAtom, new Set())
+  })
+
+  it("renders the eight fixture buttons", () => {
+    renderWithProviders(<UnlockOverlayPlaygroundPage />)
+
+    for (const name of BUTTON_NAMES) {
+      expect(screen.getByRole("button", { name })).toBeInTheDocument()
+    }
+  })
+
+  it("puts a gold grant on the queue when Gold is clicked", async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<UnlockOverlayPlaygroundPage />)
+
+    await user.click(screen.getByRole("button", { name: "Gold" }))
+
+    const queue = getDefaultStore().get(achievementUnlockQueueAtom)
+    expect(queue).toHaveLength(1)
+    expect(queue[0]?.rank).toBe("gold")
+  })
+})

--- a/src/pages/UnlockOverlayPlaygroundPage.tsx
+++ b/src/pages/UnlockOverlayPlaygroundPage.tsx
@@ -9,6 +9,7 @@ const FIXTURE_BUTTONS = [
   "Platinum",
   "Diamond",
   "2 overlap",
+  "Burst 3",
   "Burst 4",
   "Overflow 5+",
 ] as const
@@ -30,6 +31,7 @@ function grant(
     title_fr,
     icon_asset_url: null,
     threshold_value,
+    granted_at: new Date().toISOString(),
   }
 }
 
@@ -82,6 +84,11 @@ const FIXTURES: Record<FixtureName, () => UnlockedAchievement[]> = {
       "Apprenti Courbaturé",
       5,
     ),
+  ],
+  "Burst 3": () => [
+    grant("gold", "volume_king", "Plateau Titan", "Titan du plateau", 50_000),
+    grant("silver", "consistency_streak", "Iron Routine", "Routine de Fer", 25),
+    grant("bronze", "record_hunter", "Ceiling Breaker", "Briseur de plafonds", 1),
   ],
   "Burst 4": () => [
     grant(

--- a/src/pages/UnlockOverlayPlaygroundPage.tsx
+++ b/src/pages/UnlockOverlayPlaygroundPage.tsx
@@ -1,0 +1,142 @@
+import { Button } from "@/components/ui/button"
+import { pushAchievementsToQueue } from "@/lib/syncService"
+import type { AchievementRank, UnlockedAchievement } from "@/types/achievements"
+
+const FIXTURE_BUTTONS = [
+  "Bronze",
+  "Silver",
+  "Gold",
+  "Platinum",
+  "Diamond",
+  "2 overlap",
+  "Burst 4",
+  "Overflow 5+",
+] as const
+
+type FixtureName = (typeof FIXTURE_BUTTONS)[number]
+
+function grant(
+  rank: AchievementRank,
+  group_slug: string,
+  title_en: string,
+  title_fr: string,
+  threshold_value: number,
+): UnlockedAchievement {
+  return {
+    tier_id: crypto.randomUUID(),
+    group_slug,
+    rank,
+    title_en,
+    title_fr,
+    icon_asset_url: null,
+    threshold_value,
+  }
+}
+
+const FIXTURES: Record<FixtureName, () => UnlockedAchievement[]> = {
+  Bronze: () => [
+    grant(
+      "bronze",
+      "volume_king",
+      "Is That All You Got?",
+      "Sérieux, c'est tout ?",
+      15_000,
+    ),
+  ],
+  Silver: () => [
+    grant("silver", "consistency_streak", "Iron Routine", "Routine de Fer", 25),
+  ],
+  Gold: () => [
+    grant("gold", "volume_king", "Plateau Titan", "Titan du plateau", 50_000),
+  ],
+  Platinum: () => [
+    grant(
+      "platinum",
+      "volume_king",
+      "Steel Forger",
+      "Forgeron d'Acier",
+      500_000,
+    ),
+  ],
+  Diamond: () => [
+    grant(
+      "diamond",
+      "volume_king",
+      "God of Steel",
+      "Dieu de l'Acier",
+      2_000_000,
+    ),
+  ],
+  "2 overlap": () => [
+    grant(
+      "silver",
+      "volume_king",
+      "Sunday Mover",
+      "Déménageur du dimanche",
+      25_000,
+    ),
+    grant(
+      "bronze",
+      "consistency_streak",
+      "The Sore Apprentice",
+      "Apprenti Courbaturé",
+      5,
+    ),
+  ],
+  "Burst 4": () => [
+    grant(
+      "diamond",
+      "volume_king",
+      "God of Steel",
+      "Dieu de l'Acier",
+      2_000_000,
+    ),
+    grant("gold", "consistency_streak", "Gym Demon", "Démon des Salles", 100),
+    grant("silver", "rhythm_master", "Human Pendulum", "Pendule humaine", 8),
+    grant("bronze", "record_hunter", "Ceiling Breaker", "Briseur de plafonds", 1),
+  ],
+  "Overflow 5+": () => [
+    grant(
+      "diamond",
+      "volume_king",
+      "God of Steel",
+      "Dieu de l'Acier",
+      2_000_000,
+    ),
+    grant("gold", "consistency_streak", "Gym Demon", "Démon des Salles", 100),
+    grant(
+      "platinum",
+      "exercise_variety",
+      "Fiber Master",
+      "Maître des Fibres",
+      35,
+    ),
+    grant("silver", "rhythm_master", "Human Pendulum", "Pendule humaine", 8),
+    grant("bronze", "record_hunter", "Ceiling Breaker", "Briseur de plafonds", 1),
+  ],
+}
+
+export function UnlockOverlayPlaygroundPage() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4">
+      <div>
+        <h1 className="text-2xl font-bold">Unlock overlay playground</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Not in nav — fixtures only.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {FIXTURE_BUTTONS.map((name) => (
+          <Button
+            key={name}
+            type="button"
+            variant="outline"
+            onClick={() => pushAchievementsToQueue(FIXTURES[name]())}
+          >
+            {name}
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -104,6 +104,11 @@ const AchievementsPage = lazyWithRecover(() =>
     default: m.AchievementsPage,
   })),
 )
+const UnlockOverlayPlaygroundPage = lazyWithRecover(() =>
+  import("@/pages/UnlockOverlayPlaygroundPage").then((m) => ({
+    default: m.UnlockOverlayPlaygroundPage,
+  })),
+)
 const PrivacyPage = lazyWithRecover(() =>
   import("@/pages/PrivacyPage").then((m) => ({ default: m.PrivacyPage })),
 )
@@ -209,6 +214,10 @@ export const router = createBrowserRouter([
               {
                 path: "/achievements",
                 element: <AchievementsPage />,
+              },
+              {
+                path: "/_unlock-overlay",
+                element: <UnlockOverlayPlaygroundPage />,
               },
               {
                 path: "/cycle-summary/:cycleId",

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -268,6 +268,11 @@
   100% { transform: translateY(0); opacity: 1; }
 }
 
+@keyframes supporting-slide-in {
+  0% { transform: translateY(10px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+
 .achievement-badge-reveal {
   animation: badge-reveal 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 }
@@ -285,6 +290,36 @@
 
 .achievement-text-entrance {
   animation: text-slide-up 0.4s 0.35s ease-out both;
+}
+
+.achievement-supporting-entrance {
+  animation: supporting-slide-in 0.3s 0.12s ease-out both;
+}
+
+@keyframes diamond-particle-burst {
+  0% {
+    transform: translate(-50%, -50%) translate(0, 0) rotate(0deg) scale(0.3);
+    opacity: 0;
+  }
+  25% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) translate(var(--dx), var(--dy)) rotate(45deg) scale(1);
+    opacity: 0.18;
+  }
+}
+
+.achievement-diamond-particles {
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.achievement-diamond-particle {
+  position: absolute;
+  border-radius: 1px;
+  pointer-events: none;
+  animation: diamond-particle-burst 0.85s ease-out forwards;
 }
 
 /* ===== Badge Frame Classes ===== */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -296,30 +296,43 @@
   animation: supporting-slide-in 0.3s 0.12s ease-out both;
 }
 
-@keyframes diamond-particle-burst {
+@keyframes sparkle-burst {
   0% {
-    transform: translate(-50%, -50%) translate(0, 0) rotate(0deg) scale(0.3);
+    transform: translate(-50%, -50%) translate(0, 0) rotate(0deg) scale(0.4);
     opacity: 0;
   }
-  25% {
+  18% {
+    opacity: 1;
+  }
+  48% {
     opacity: 1;
   }
   100% {
-    transform: translate(-50%, -50%) translate(var(--dx), var(--dy)) rotate(45deg) scale(1);
-    opacity: 0.18;
+    transform: translate(-50%, -50%) translate(var(--dx), var(--dy)) rotate(45deg) scale(1.2);
+    opacity: 0;
   }
 }
 
-.achievement-diamond-particles {
+.achievement-rank-sparkles {
   pointer-events: none;
-  overflow: hidden;
+  overflow: visible;
 }
 
-.achievement-diamond-particle {
+.achievement-sparkle {
   position: absolute;
   border-radius: 1px;
   pointer-events: none;
-  animation: diamond-particle-burst 0.85s ease-out forwards;
+  box-shadow: 0 0 5px 1px currentColor;
+  animation: sparkle-burst 0.9s ease-out forwards;
+}
+
+@keyframes tap-continue-pulse {
+  0%, 100% { opacity: 0.35; }
+  50% { opacity: 0.85; }
+}
+
+.achievement-tap-continue-pulse {
+  animation: tap-continue-pulse 1.8s ease-in-out infinite;
 }
 
 /* ===== Badge Frame Classes ===== */

--- a/src/test/circuitAchievementTracks.arch.test.ts
+++ b/src/test/circuitAchievementTracks.arch.test.ts
@@ -147,6 +147,18 @@ describe("grant RPC threshold_value (#491 / T213)", () => {
     "check_and_grant_achievements",
   )
 
+  it("drops the existing (uuid) signature before changing RETURNS TABLE", () => {
+    // CREATE OR REPLACE cannot change RETURNS TABLE (42P13). Pin to this
+    // file — a later body-only replace must not be forced to DROP.
+    const thresholdSql =
+      Object.entries(migrationSources).find(([path]) =>
+        path.includes("grant_achievements_threshold_value"),
+      )?.[1] ?? ""
+    expect(thresholdSql).toMatch(
+      /DROP\s+FUNCTION\s+IF\s+EXISTS\s+check_and_grant_achievements\s*\(\s*uuid\s*\)/i,
+    )
+  })
+
   it("latest RETURNS TABLE includes threshold_value numeric", () => {
     expect(grantHeader).toMatch(/threshold_value\s+numeric/i)
   })

--- a/src/test/circuitAchievementTracks.arch.test.ts
+++ b/src/test/circuitAchievementTracks.arch.test.ts
@@ -119,6 +119,44 @@ describe("circuit achievement tracks migration (#482 / T209)", () => {
   })
 })
 
+/**
+ * #491 / T213: overlay threshold copy reads the hero's requirement off the
+ * grant row. Last-wins across migrations — a later CREATE OR REPLACE is the
+ * live function, same rule as securityDefiner.arch.test.ts.
+ */
+describe("grant RPC threshold_value (#491 / T213)", () => {
+  const latestGrantSql =
+    Object.entries(migrationSources)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .filter(([, sql]) =>
+        /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+check_and_grant_achievements/i.test(
+          sql,
+        ),
+      )
+      .at(-1)?.[1] ?? ""
+
+  const grantStart = latestGrantSql.search(
+    /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+check_and_grant_achievements/i,
+  )
+  const grantHeader = latestGrantSql.slice(
+    grantStart,
+    latestGrantSql.indexOf("$$", grantStart),
+  )
+  const grantBody = extractFunctionBody(
+    latestGrantSql,
+    "check_and_grant_achievements",
+  )
+
+  it("latest RETURNS TABLE includes threshold_value numeric", () => {
+    expect(grantHeader).toMatch(/threshold_value\s+numeric/i)
+  })
+
+  it("eligible and output SELECT project threshold_value", () => {
+    expect(grantBody).toMatch(/at\.icon_asset_url,\s*at\.threshold_value/)
+    expect(grantBody).toMatch(/e\.icon_asset_url,\s*e\.threshold_value/)
+  })
+})
+
 describe("circuit achievement i18n (#482 / T209)", () => {
   it("exposes groups, groupDescriptions, and thresholdHint for all five slugs", () => {
     const missing = CIRCUIT_METRICS.flatMap((slug) =>

--- a/src/types/achievements.ts
+++ b/src/types/achievements.ts
@@ -57,4 +57,5 @@ export interface UnlockedAchievement {
   title_fr: string
   icon_asset_url: string | null
   threshold_value: number
+  granted_at?: string
 }

--- a/src/types/achievements.ts
+++ b/src/types/achievements.ts
@@ -56,4 +56,5 @@ export interface UnlockedAchievement {
   title_en: string
   title_fr: string
   icon_asset_url: string | null
+  threshold_value: number
 }

--- a/supabase/migrations/20260819174900_grant_achievements_threshold_value.sql
+++ b/supabase/migrations/20260819174900_grant_achievements_threshold_value.sql
@@ -1,6 +1,12 @@
 -- Overlay threshold copy interpolates the hero's requirement. Grant RPC
 -- returned rank/title/icon but not threshold_value; get_badge_status already
 -- does. Additive column only — metrics / qualifying_runs unchanged.
+--
+-- CREATE OR REPLACE cannot change RETURNS TABLE (SQLSTATE 42P13). Drop the
+-- existing (uuid) signature first, then recreate with threshold_value. DROP
+-- clears EXECUTE grants — re-apply the 20260802170000 definer grants below.
+
+DROP FUNCTION IF EXISTS check_and_grant_achievements(uuid);
 
 CREATE OR REPLACE FUNCTION check_and_grant_achievements(p_user_id uuid)
 RETURNS TABLE (
@@ -230,3 +236,6 @@ BEGIN
   JOIN granted g ON g.tier_id = e.id;
 END;
 $$;
+
+REVOKE ALL ON FUNCTION check_and_grant_achievements(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION check_and_grant_achievements(uuid) TO authenticated, service_role;

--- a/supabase/migrations/20260819174900_grant_achievements_threshold_value.sql
+++ b/supabase/migrations/20260819174900_grant_achievements_threshold_value.sql
@@ -1,0 +1,232 @@
+-- Overlay threshold copy interpolates the hero's requirement. Grant RPC
+-- returned rank/title/icon but not threshold_value; get_badge_status already
+-- does. Additive column only — metrics / qualifying_runs unchanged.
+
+CREATE OR REPLACE FUNCTION check_and_grant_achievements(p_user_id uuid)
+RETURNS TABLE (
+  tier_id uuid, group_slug text, rank text,
+  title_en text, title_fr text, icon_asset_url text,
+  threshold_value numeric
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+BEGIN
+  IF NOT (
+    COALESCE(auth.uid() = p_user_id, false)
+    OR is_trusted_backend_caller()
+  ) THEN
+    RAISE EXCEPTION 'access denied: cannot grant achievements for another user'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_sessions AS (
+    SELECT s.id, s.workout_day_id, s.finished_at
+    FROM sessions s
+    WHERE s.user_id = p_user_id AND s.finished_at IS NOT NULL
+  ),
+  -- Circuit Achievement Run: GO snapshot FK → seed (owner_id IS NULL),
+  -- finished_at set, full_rounds = MAX(set_number)-1 >= 1 (amrapScore oracle).
+  qualifying_runs AS (
+    SELECT br.id, br.session_id, bc.slug,
+           (MAX(sl.set_number) - 1) AS full_rounds
+    FROM block_runs br
+    JOIN sessions s ON s.id = br.session_id AND s.user_id = p_user_id
+    JOIN benchmark_circuits bc ON bc.id = br.benchmark_circuit_id
+      AND bc.owner_id IS NULL
+    JOIN block_exercises be ON be.block_id = br.block_id
+    JOIN set_logs sl ON sl.session_id = br.session_id
+      AND sl.block_exercise_id = be.id
+    WHERE br.finished_at IS NOT NULL
+    GROUP BY br.id, br.session_id, bc.slug
+    HAVING (MAX(sl.set_number) - 1) >= 1
+  ),
+  olympian_slugs AS (
+    SELECT unnest(ARRAY['zeus','ares','athena','hades']) AS slug
+  ),
+  hero_slugs AS (
+    SELECT unnest(ARRAY['heracles','theseus','atlas','achilles']) AS slug
+  ),
+  pantheon_slugs AS (
+    SELECT slug FROM olympian_slugs
+    UNION ALL
+    SELECT slug FROM hero_slugs
+  ),
+  metrics AS (
+    SELECT 'session_count' AS metric_type, COUNT(*)::numeric AS value
+      FROM user_sessions
+
+    UNION ALL
+    SELECT 'total_volume_kg',
+           COALESCE(SUM(sl.weight_logged * sl.reps_logged::int), 0)
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.reps_logged IS NOT NULL
+        AND sl.reps_logged ~ '^\d+$'
+
+    UNION ALL
+    SELECT 'pr_count', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      WHERE sl.was_pr = true
+
+    UNION ALL
+    SELECT 'unique_exercises', COUNT(DISTINCT sl.exercise_id)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+
+    UNION ALL
+    SELECT 'active_weeks', COUNT(*)::numeric
+      FROM (
+        SELECT date_trunc('week', us.finished_at) AS wk
+        FROM user_sessions us
+        GROUP BY date_trunc('week', us.finished_at)
+        HAVING COUNT(*) >= 3
+      ) AS weeks_with_3plus
+
+    UNION ALL
+    SELECT 'quick_sessions', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN workout_days wd ON wd.id = us.workout_day_id
+      LEFT JOIN programs p ON p.id = wd.program_id
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) AS day_count
+        FROM workout_days wd2
+        WHERE wd2.program_id = p.id
+      ) dc ON true
+      WHERE us.workout_day_id IS NOT NULL
+        AND (
+          wd.program_id IS NULL
+          OR (p.template_id IS NULL AND dc.day_count = 1)
+        )
+
+    UNION ALL
+    SELECT 'leg_day', COUNT(*)::numeric
+      FROM set_logs sl
+      JOIN user_sessions us ON us.id = sl.session_id
+      JOIN exercises e ON e.id = sl.exercise_id
+      WHERE e.muscle_group IN ('Quadriceps', 'Ischios', 'Fessiers', 'Adducteurs', 'Mollets')
+
+    UNION ALL
+    SELECT 'streak_king', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT wk,
+                 wk - (ROW_NUMBER() OVER (ORDER BY wk))::bigint AS grp
+          FROM (
+            SELECT DISTINCT
+              (EXTRACT(EPOCH FROM date_trunc('week', us.finished_at))::bigint / 604800) AS wk
+            FROM user_sessions us
+          ) distinct_weeks
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'marathoner', COUNT(*)::numeric
+      FROM (
+        SELECT us.id
+        FROM set_logs sl
+        JOIN user_sessions us ON us.id = sl.session_id
+        WHERE sl.reps_logged IS NOT NULL
+          AND sl.reps_logged ~ '^\d+$'
+        GROUP BY us.id
+        HAVING SUM(sl.weight_logged * sl.reps_logged::int) >= 5000
+      ) heavy_sessions
+
+    UNION ALL
+    SELECT 'pr_streak', COALESCE(MAX(streak_len), 0)::numeric
+      FROM (
+        SELECT COUNT(*) AS streak_len
+        FROM (
+          SELECT session_ord,
+                 session_ord - ROW_NUMBER() OVER (ORDER BY session_ord) AS grp
+          FROM (
+            SELECT us.id,
+                   ROW_NUMBER() OVER (ORDER BY us.finished_at, us.id) AS session_ord,
+                   (prs.session_id IS NOT NULL) AS has_pr
+            FROM user_sessions us
+            LEFT JOIN (
+              SELECT DISTINCT sl.session_id
+              FROM set_logs sl
+              WHERE sl.was_pr = true
+            ) prs ON prs.session_id = us.id
+          ) all_sessions
+          WHERE has_pr
+        ) grouped
+        GROUP BY grp
+      ) streaks
+
+    UNION ALL
+    SELECT 'early_bird', COUNT(*)::numeric
+      FROM user_sessions us
+      LEFT JOIN user_profiles up ON up.user_id = p_user_id
+      WHERE EXTRACT(HOUR FROM us.finished_at AT TIME ZONE COALESCE(up.timezone, 'UTC')) BETWEEN 5 AND 7
+
+    -- === CIRCUIT TRACKS (#482) ===
+
+    UNION ALL
+    SELECT 'circuit_runner', COUNT(*)::numeric
+      FROM qualifying_runs
+
+    UNION ALL
+    SELECT 'spidey', COALESCE(MAX(full_rounds), 0)::numeric
+      FROM qualifying_runs
+      WHERE slug = 'cindy'
+
+    -- Cast Clearing: LEFT JOIN fixed slug lists so a missing seed (e.g. Hades)
+    -- yields cnt 0; MIN stays 0. Never MIN over observed-only rows.
+    UNION ALL
+    SELECT 'olympians', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM olympian_slugs o
+        LEFT JOIN qualifying_runs q ON q.slug = o.slug
+        GROUP BY o.slug
+      ) c
+
+    UNION ALL
+    SELECT 'heroes', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM hero_slugs h
+        LEFT JOIN qualifying_runs q ON q.slug = h.slug
+        GROUP BY h.slug
+      ) c
+
+    UNION ALL
+    SELECT 'pantheoniste', COALESCE(MIN(c.cnt), 0)::numeric
+      FROM (
+        SELECT COALESCE(COUNT(q.id), 0) AS cnt
+        FROM pantheon_slugs p
+        LEFT JOIN qualifying_runs q ON q.slug = p.slug
+        GROUP BY p.slug
+      ) c
+  ),
+  eligible AS (
+    SELECT at.id, ag.slug, at.rank AS r,
+           at.title_en, at.title_fr, at.icon_asset_url, at.threshold_value
+    FROM metrics m
+    JOIN achievement_groups ag ON ag.metric_type = m.metric_type
+    JOIN achievement_tiers at ON at.group_id = ag.id
+    WHERE at.threshold_value <= m.value
+      AND NOT EXISTS (
+        SELECT 1 FROM user_achievements ua
+        WHERE ua.user_id = p_user_id AND ua.tier_id = at.id
+      )
+  ),
+  granted AS (
+    INSERT INTO user_achievements (user_id, tier_id)
+    SELECT p_user_id, e.id FROM eligible e
+    ON CONFLICT (user_id, tier_id) DO NOTHING
+    RETURNING user_achievements.tier_id
+  )
+  SELECT e.id, e.slug, e.r, e.title_en, e.title_fr, e.icon_asset_url, e.threshold_value
+  FROM eligible e
+  JOIN granted g ON g.tier_id = e.id;
+END;
+$$;


### PR DESCRIPTION
## What

- Grant overlay is one ceremony per batch — a hero medal plus supporting medals — not a serial 4s slot-machine.
- Hidden `/_unlock-overlay` playground so HITL can fire fixture batches without waiting on a lucky finish.
- Grant RPC now returns `threshold_value` so the overlay can interpolate the hero's requirement.

## Why

The Stitch v2 ceremony is a freeze, not a queue: one moment per finish, hero chrome only, late Realtime extras wait. Pixel-perfect against that layout; T218's human visual closeout is still a pass, not claimed done here.

## How

- Snapshot the unlock queue into a Grant Batch as the overlay opens; `pickHero` is `diamond > platinum > gold > silver > bronze` (ties keep queue order).
- Equip uses `useEquipTitle` — the same write as the drawer.
- Tap or Escape dismisses the whole batch; fanfare + rank sparkles run when motion is allowed; reduced-motion keeps medals, copy, and Equip still.

Closes #491