### PR TITLE
docs: add Q4 milestone brief Voir · Éditer · Envoyer

### DIFF
--- a/docs/Milestone_Brief_—_Voir_Éditer_Envoyer.md
+++ b/docs/Milestone_Brief_—_Voir_Éditer_Envoyer.md
@@ -1,0 +1,73 @@
+# Milestone Brief — Voir · Éditer · Envoyer
+
+Next quarter. Not an Epic Brief. Not four epics glued with a bow.
+
+---
+
+## The bet
+
+GymLogic already *has* a **Program**, a **Builder**, a History, and an **Embedded Agent** at creation. None of them look at each other.
+
+This quarter they do.
+
+**See the week as written. See the past as trained. Edit without leaving. Fork before a patch. Send the result.**
+
+Coach is the caption. Clone/share are how the caption leaves the diary. Marketplace is the encore — not invited.
+
+---
+
+## Why these four Gos, not twelve
+
+**Coach** without clone/share is a diary. **Saison** without a Builder that isn’t a CMS is a gauge on a spreadsheet. **Logger** without saison is Hevy’s chart next to a mute program. **Social** as a network is a second company.
+
+So we take the *first step* of each, on **one object**: the **Program**.
+
+| Go | First step this quarter | Not this quarter |
+| --- | --- | --- |
+| Coach | Insight on the **Builder** ([#503](https://github.com/PierreTsia/workout-app/issues/503)) | In-set chat. Replaying May. |
+| Saison | Live goal-tracks from **Template Prescription** ([#504](https://github.com/PierreTsia/workout-app/issues/504)) | **Mesocycle** object. [#149](https://github.com/PierreTsia/workout-app/issues/149) as a deload pictogram. |
+| Logger | One glance-at-progress surface ([#502](https://github.com/PierreTsia/workout-app/issues/502)) | Watch. Health. Dashboard dump. |
+| Social | Clone + share a **Program** ([#230](https://github.com/PierreTsia/workout-app/issues/230) phase 1) | Gallery, publish, ranked board. |
+
+[#505](https://github.com/PierreTsia/workout-app/issues/505) (agent *between* sessions) is the last brick, not the first. It ships if the numbers and the verbs exist for the agent to point at. It does not open the quarter.
+
+---
+
+## Sequence (this is one stack)
+
+1. **Canvas** — [#503](https://github.com/PierreTsia/workout-app/issues/503). Hevy floor on the **DayEditor**: live muscle read, add that doesn’t feel like 2014, insight *touch*. Slot-level prescription. No Hevy set-table.
+2. **Intent** — [#504](https://github.com/PierreTsia/workout-app/issues/504) on that same canvas. Hypertrophy / strength / … as published rules, or no number. Updates while you edit.
+3. **Evidence** — [#502](https://github.com/PierreTsia/workout-app/issues/502). Twin of #504: `set_logs` vs the week as written. One surface. Type-aware. No fake 1RM on a plank.
+4. **Verbs** — [#230](https://github.com/PierreTsia/workout-app/issues/230) phase 1. Clone = fork before a coach patch. Share = one link, one clone, someone else trains *your* **Program**.
+5. **Caption** — [#505](https://github.com/PierreTsia/workout-app/issues/505) only after 1–4. Between sessions. User confirms. Never during the set.
+
+**Vérité** is the filter on every number: publish the rubric or don’t show the score.
+
+---
+
+## Done when
+
+A user already in GymLogic can:
+
+- Open a **Program**, *see* what the week is for (tracks), *see* whether last month agreed (glance).
+- Change 4×8 without a drill-in that feels like an admin panel.
+- Duplicate the **Program** before they break it.
+- Send it. The other person runs it — not a screenshot, not a marketplace card.
+
+If the agent then says “why HOLD, drop a set of pecs” and they can fork, apply, send — the quarter over-delivered. If it can’t say that yet, the quarter still landed: the evidence exists.
+
+---
+
+## Explicitly not the quarter
+
+**Switch** ([#506](https://github.com/PierreTsia/workout-app/issues/506)). **Food** ([#507](https://github.com/PierreTsia/workout-app/issues/507)). **Quotidien**. Watch. In-set LLM. SemVer. MCP copy nits. “Become a network.”
+
+Those are other years, other companies, or chores wearing a milestone hat.
+
+---
+
+## How we work it
+
+Every brick above except [#230](https://github.com/PierreTsia/workout-app/issues/230) is `needs-grilling`. Grill **hero surface** (#503), **one honest track** (#504), **dashboard vs diagnosis** (#502), **clone+share vs gallery** (#230) — then Epic Briefs. Do not drop a body map, four fake gauges, and a Share button as three “quick wins.” That’s how this becomes a restyle ticket.
+
+Source of the stack: `file:docs/Discovery_—_Next_milestone_candidates.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Adds `docs/Milestone_Brief_—_Voir_Éditer_Envoyer.md` — the next-quarter planning brief, written as provided.

## Why

GymLogic’s Q4 bet is one stack on one object (the Program): Canvas → Intent → Evidence → Verbs → Caption. This file is the source of truth for the GitHub milestone and Project of the same name.

## How

Single markdown doc under `docs/`. Filename follows the repo convention (underscores, em dash). No product code changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9093af4f-7e26-4cdb-96cf-50a543ddad7e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9093af4f-7e26-4cdb-96cf-50a543ddad7e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

